### PR TITLE
Setup pass-support and create pass-data-client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: pass-core Continuous Integration
+on: [ pull_request, workflow_dispatch ]
+
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  print-workflow-description:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "This is a CI build of branch ${{ github.ref }} in repository ${{ github.repository }}"
+      - run: echo "This job was triggered by a ${{ github.event_name }} event and is running on a ${{ runner.os }} server"
+
+  run-tests:
+    name: "Run Unit & Integration Tests"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout the repository"
+        uses: actions/checkout@v2
+      - name: "Set up JDK 11"
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: "Cache Maven packages"
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m3-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m3
+      - name: "Run unit & integration tests"
+        run: mvn -U -B -V -ntp verify --file pom.xml

--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# Introduction
+
+The pass-support repository contains components which sit outside pass-core.
+
+
+

--- a/pass-data-client/pom.xml
+++ b/pass-data-client/pom.xml
@@ -1,0 +1,117 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.eclipse.pass</groupId>
+    <artifactId>pass-support</artifactId>
+    <version>0.2.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>pass-data-client</artifactId>
+
+  <!-- Properties for ITs -->
+  <properties>
+    <pass.core.port>8080</pass.core.port>
+    <pass.core.url>http://localhost:8080</pass.core.url>
+  </properties>
+  
+  <dependencies>
+    <dependency>
+      <groupId>com.markomilos.jsonapi</groupId>
+      <artifactId>jsonapi-adapters</artifactId>
+      <version>1.1.0</version>
+    </dependency>
+    
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+      <version>4.10.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.squareup</groupId>
+      <artifactId>javapoet</artifactId>
+      <version>1.13.0</version>
+    </dependency>
+    
+    <!-- Test dependencies -->
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit.jupiter.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit.jupiter.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+	<groupId>io.fabric8</groupId>
+	<artifactId>docker-maven-plugin</artifactId>
+	<executions>
+          <execution>
+            <id>start</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>start</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>stop</id>
+            <phase>post-integration-test</phase>
+            <goals>
+              <goal>stop</goal>
+            </goals>
+          </execution>
+	</executions>
+	<configuration>
+          <images>
+            <image>
+              <name>ghcr.io/eclipse-pass/pass-core-main:%v</name>
+              <run>
+                <wait>
+                  <http>
+                    <url>
+                      ${pass.core.url}/data/grant
+                    </url>
+                  </http>
+                  <time>60000</time>
+                </wait>
+		<ports>
+                  <port>${pass.core.port}:${pass.core.port}</port>
+		</ports>
+              </run>
+            </image>
+          </images>
+	</configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${maven-failsafe-plugin.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+	<configuration>
+          <systemPropertyVariables>
+            <pass.core.url>${pass.core.url}</pass.core.url>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/JsonApiPassClient.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/JsonApiPassClient.java
@@ -1,0 +1,536 @@
+package org.eclipse.pass.support.client;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonAdapter.Factory;
+import com.squareup.moshi.JsonReader;
+import com.squareup.moshi.JsonReader.Token;
+import com.squareup.moshi.Moshi;
+import com.squareup.moshi.Types;
+import jsonapi.Document;
+import jsonapi.Document.IncludedSerialization;
+import jsonapi.JsonApiFactory;
+import okhttp3.HttpUrl;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okio.Buffer;
+import org.eclipse.pass.support.client.adapter.AggregatedDepositStatusAdapter;
+import org.eclipse.pass.support.client.adapter.AwardStatusAdapter;
+import org.eclipse.pass.support.client.adapter.ContributorRoleAdapter;
+import org.eclipse.pass.support.client.adapter.CopyStatusAdapter;
+import org.eclipse.pass.support.client.adapter.DepositStatusAdapter;
+import org.eclipse.pass.support.client.adapter.EventTypeAdapter;
+import org.eclipse.pass.support.client.adapter.FileRoleAdapter;
+import org.eclipse.pass.support.client.adapter.IntegrationTypeAdapter;
+import org.eclipse.pass.support.client.adapter.PerformerRoleAdapter;
+import org.eclipse.pass.support.client.adapter.SourceAdapter;
+import org.eclipse.pass.support.client.adapter.SubmissionStatusAdapter;
+import org.eclipse.pass.support.client.adapter.UriAdapter;
+import org.eclipse.pass.support.client.adapter.UserRoleAdapter;
+import org.eclipse.pass.support.client.adapter.ZonedDateTimeAdapter;
+import org.eclipse.pass.support.client.model.Contributor;
+import org.eclipse.pass.support.client.model.Deposit;
+import org.eclipse.pass.support.client.model.File;
+import org.eclipse.pass.support.client.model.Funder;
+import org.eclipse.pass.support.client.model.Grant;
+import org.eclipse.pass.support.client.model.Journal;
+import org.eclipse.pass.support.client.model.PassEntity;
+import org.eclipse.pass.support.client.model.Policy;
+import org.eclipse.pass.support.client.model.Publication;
+import org.eclipse.pass.support.client.model.Publisher;
+import org.eclipse.pass.support.client.model.Repository;
+import org.eclipse.pass.support.client.model.RepositoryCopy;
+import org.eclipse.pass.support.client.model.Submission;
+import org.eclipse.pass.support.client.model.SubmissionEvent;
+import org.eclipse.pass.support.client.model.User;
+
+/**
+ * PassClient implementation using https://github.com/MarkoMilos/jsonapi.
+ */
+public class JsonApiPassClient implements PassClient {
+    private final static String JSON_API_CONTENT_TYPE = "application/vnd.api+json";
+    private final static MediaType JSON_API_MEDIA_TYPE = MediaType.parse("application/vnd.api+json; charset=utf-8");
+
+    private final Moshi moshi;
+    private final String baseUrl;
+    private final OkHttpClient client;
+
+    /**
+     * Create a JsonApiClient.
+     *
+     * @param baseUrl base url of PASS API
+     */
+    public JsonApiPassClient(String baseUrl) {
+        this(baseUrl, null, null);
+    }
+
+    /**
+     * Create a JsonApiClient which uses HTTP basic auth.
+     *
+     * @param baseUrl  base url of PASS API
+     * @param user user to connect as
+     * @param pass password of user
+     */
+    public JsonApiPassClient(String baseUrl, String user, String pass) {
+        this.baseUrl = (baseUrl.endsWith("/") ? baseUrl : baseUrl + "/") + "data/";
+
+        OkHttpClient.Builder client_builder = new OkHttpClient.Builder();
+
+        if (user != null && pass != null) {
+            client_builder.addInterceptor(new OkHttpBasicAuthInterceptor(user, pass));
+        }
+
+        client = client_builder.build();
+
+        Factory factory = new JsonApiFactory.Builder().addTypes(Contributor.class, Deposit.class, File.class,
+                Funder.class, Grant.class, Journal.class, Policy.class, Publication.class, Publisher.class,
+                Repository.class, RepositoryCopy.class, Submission.class, SubmissionEvent.class, User.class).build();
+
+        this.moshi = new Moshi.Builder().add(factory).add(new AggregatedDepositStatusAdapter())
+                .add(new AwardStatusAdapter()).add(new ContributorRoleAdapter()).add(new CopyStatusAdapter())
+                .add(new DepositStatusAdapter()).add(new EventTypeAdapter()).add(new FileRoleAdapter())
+                .add(new IntegrationTypeAdapter()).add(new PerformerRoleAdapter()).add(new SourceAdapter())
+                .add(new SubmissionStatusAdapter()).add(new ZonedDateTimeAdapter()).add(new UriAdapter())
+                .add(new UserRoleAdapter()).build();
+    }
+
+    private String get_url(PassEntity obj) {
+        return get_url(obj.getClass(), obj.getId());
+    }
+
+    private String get_url(Class<?> type, String id) {
+        String name = get_json_type(type);
+
+        if (id == null) {
+            return baseUrl + name;
+        } else {
+            return baseUrl + name + "/" + id;
+        }
+    }
+
+    private String get_json_type(Class<?> type) {
+        String name = type.getSimpleName();
+
+        char[] chars = name.toCharArray();
+        chars[0] = Character.toLowerCase(chars[0]);
+
+        return new String(chars);
+    }
+
+    private String get_java_type(String json_type) {
+        char[] chars = json_type.toCharArray();
+        chars[0] = Character.toUpperCase(chars[0]);
+
+        return new String(chars);
+    }
+
+    @Override
+    public <T extends PassEntity> void createObject(T obj) throws IOException {
+        JsonAdapter<Document<T>> adapter = moshi.adapter(Types.newParameterizedType(Document.class, obj.getClass()));
+
+        Document<T> doc = Document.with(obj).includedSerialization(IncludedSerialization.NONE).build();
+
+        String json = adapter.toJson(doc);
+
+        String url = get_url(obj);
+        RequestBody body = RequestBody.create(json, JSON_API_MEDIA_TYPE);
+        Request request = new Request.Builder().url(url).header("Accept", JSON_API_CONTENT_TYPE)
+                .addHeader("Content-Type", JSON_API_CONTENT_TYPE).post(body).build();
+
+        Response response = client.newCall(request).execute();
+
+        if (!response.isSuccessful()) {
+            throw new IOException(
+                    "Create failed: " + url + " returned " + response.code() + " " + response.body().string());
+        }
+
+        Document<T> result_doc = adapter.fromJson(response.body().string());
+        obj.setId(result_doc.requireData().getId());
+    }
+
+    @Override
+    public <T extends PassEntity> void updateObject(T obj) throws IOException {
+        JsonAdapter<Document<T>> adapter = moshi.adapter(Types.newParameterizedType(Document.class, obj.getClass()));
+        Document<T> doc = Document.with(obj).includedSerialization(IncludedSerialization.NONE).build();
+
+        String json = adapter.toJson(doc);
+
+        String url = get_url(obj);
+        RequestBody body = RequestBody.create(json, JSON_API_MEDIA_TYPE);
+        Request request = new Request.Builder().url(url).header("Accept", JSON_API_CONTENT_TYPE)
+                .addHeader("Content-Type", JSON_API_CONTENT_TYPE).post(body).build();
+
+        Response response = client.newCall(request).execute();
+
+        if (!response.isSuccessful()) {
+            throw new IOException(
+                    "Update failed: " + url + " returned " + response.code() + " " + response.body().string());
+        }
+    }
+
+    private static class Relationship {
+        String name;
+        List<String> targets;
+        String target_type;
+        boolean to_many;
+
+        Relationship(String name) {
+            this.name = name;
+            this.targets = new ArrayList<>();
+        }
+    }
+
+    // Return map of source object id to object relationships.
+    // Ignore any relationships whose target is included
+    private Map<String, List<Relationship>> get_relationships(String json_api_doc) throws IOException {
+        Map<String, List<Relationship>> result = new HashMap<>();
+
+        // Contains type_id for objects which are included in the document
+        Set<String> included = new HashSet<>();
+
+        try (Buffer buffer = new Buffer(); JsonReader reader = JsonReader.of(buffer.writeUtf8(json_api_doc))) {
+            reader.beginObject();
+
+            while (reader.hasNext()) {
+                String top_name = reader.nextName();
+
+                if (top_name.equals("data")) {
+                    Token next = reader.peek();
+
+                    if (next == Token.BEGIN_ARRAY) {
+                        reader.beginArray();
+                        while (reader.hasNext()) {
+                            gather_relationships_from_data(result, reader, included);
+                        }
+                        reader.endArray();
+                    } else if (next == Token.BEGIN_OBJECT) {
+                        gather_relationships_from_data(result, reader, included);
+                    } else {
+                        reader.skipValue();
+                    }
+                } else if (top_name.equals("included")) {
+                    reader.beginArray();
+
+                    while (reader.hasNext()) {
+                        String id = null;
+                        String type = null;
+
+                        reader.beginObject();
+                        while (reader.hasNext()) {
+                            switch (reader.nextName()) {
+                                case "id":
+                                    id = reader.nextString();
+                                    break;
+
+                                case "type":
+                                    type = reader.nextString();
+                                    break;
+
+                                default:
+                                    reader.skipValue();
+                                    break;
+                            }
+                        }
+                        reader.endObject();
+
+                        if (id != null && type != null) {
+                            included.add(type + "_" + id);
+                        }
+                    }
+
+                    reader.endArray();
+                } else {
+                    reader.skipValue();
+                }
+            }
+
+            reader.endObject();
+        }
+
+        // Prune relationship targets that are included in the document
+        if (included.size() > 0) {
+            result.forEach((id, rels) -> {
+                rels.forEach(rel -> {
+                    rel.targets.removeIf(target_id -> included.contains(rel.target_type + "_" + target_id));
+                });
+            });
+        }
+
+        return result;
+    }
+
+    // Return relationships from a data object
+    private void gather_relationships_from_data(Map<String, List<Relationship>> result, JsonReader reader,
+            Set<String> included) throws IOException {
+        String id = null;
+        List<Relationship> rels = null;
+
+        reader.beginObject();
+        while (reader.hasNext()) {
+            String name = reader.nextName();
+
+            if (name.equals("relationships")) {
+                rels = parse_relationships(reader, included);
+            } else if (name.equals("id")) {
+                id = reader.nextString();
+            } else {
+                reader.skipValue();
+            }
+        }
+        reader.endObject();
+
+        if (id != null && rels != null && rels.size() > 0) {
+            result.put(id, rels);
+        }
+    }
+
+    // Parse the relationships object
+    private List<Relationship> parse_relationships(JsonReader reader, Set<String> included) throws IOException {
+        List<Relationship> result = new ArrayList<>();
+
+        reader.beginObject();
+        while (reader.hasNext()) {
+            Relationship rel = new Relationship(reader.nextName());
+
+            reader.beginObject();
+            while (reader.hasNext()) {
+                if (reader.nextName().equals("data")) {
+                    Token next = reader.peek();
+
+                    if (next == Token.BEGIN_ARRAY) {
+                        reader.beginArray();
+                        rel.to_many = true;
+
+                        while (reader.hasNext()) {
+                            fill_relationship(rel, reader);
+                        }
+
+                        reader.endArray();
+                    } else if (next == Token.BEGIN_OBJECT) {
+                        rel.to_many = false;
+                        fill_relationship(rel, reader);
+                    } else {
+                        reader.skipValue();
+                    }
+
+                    if (rel.targets.size() > 0) {
+                        result.add(rel);
+                    }
+                } else {
+                    reader.skipValue();
+                }
+            }
+            reader.endObject();
+        }
+        reader.endObject();
+
+        return result;
+    }
+
+    // Parse the data of a relationship target into a Relationship
+    private void fill_relationship(Relationship rel, JsonReader reader) throws IOException {
+        reader.beginObject();
+
+        String id = null;
+        String type = null;
+
+        while (reader.hasNext()) {
+            switch (reader.nextName()) {
+                case "id":
+                    id = reader.nextString();
+                    break;
+
+                case "type":
+                    type = reader.nextString();
+                    break;
+
+                default:
+                    reader.skipValue();
+                    break;
+            }
+        }
+
+        if (id != null && type != null) {
+            rel.targets.add(id);
+            rel.target_type = type;
+        }
+
+        reader.endObject();
+    }
+
+    // Create a PassEntity and set the id. It must have an appropriate constructor.
+    private Object create_target(String target_id, String class_name) {
+        try {
+            return Class.forName(class_name).getConstructor(String.class).newInstance(target_id);
+        } catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException
+                | NoSuchMethodException | SecurityException | ClassNotFoundException e) {
+            throw new RuntimeException("Failed to create: " + class_name, e);
+        }
+    }
+
+    // Set a value on an object using a set method.
+    private void set_value(Object obj, String set_method, Object value) {
+        try {
+            Class<?> value_class = value.getClass();
+
+            // Handle the set method taking a List instead of a List implementation
+            if (value instanceof List) {
+                value_class = List.class;
+            }
+
+            obj.getClass().getMethod(set_method, value_class).invoke(obj, value);
+        } catch (NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException
+                | InvocationTargetException e) {
+            throw new RuntimeException("Failed to invoke: " + set_method, e);
+        }
+    }
+
+    // Set a relationship on a matched object
+    private void set_relationship(Object obj, Relationship rel) {
+        // Targets may have been pruned
+        if (rel.targets.size() == 0) {
+            return;
+        }
+
+        String target_class_name = "org.eclipse.pass.support.client.model." + get_java_type(rel.target_type);
+        Object target;
+
+        if (rel.to_many) {
+            List<Object> list = new ArrayList<>();
+            rel.targets.forEach(id -> {
+                list.add(create_target(id, target_class_name));
+            });
+            target = list;
+        } else {
+            target = create_target(rel.targets.get(0), target_class_name);
+        }
+
+        set_value(obj, "set" + get_java_type(rel.name), target);
+    }
+
+    private void set_relationships(Object obj, List<Relationship> rels) {
+        if (rels != null) {
+            rels.forEach(rel -> {
+                set_relationship(obj, rel);
+            });
+        }
+    }
+
+    @Override
+    public <T extends PassEntity> T getObject(Class<T> type, String id, String... include) throws IOException {
+        JsonAdapter<Document<T>> adapter = moshi.adapter(Types.newParameterizedType(Document.class, type));
+
+        HttpUrl.Builder url_builder = HttpUrl.parse(get_url(type, id)).newBuilder();
+        if (include != null && include.length > 0) {
+            url_builder.addQueryParameter("include", String.join(",", include));
+        }
+        HttpUrl url = url_builder.build();
+
+        Request request = new Request.Builder().url(url).header("Accept", JSON_API_CONTENT_TYPE)
+                .addHeader("Content-Type", JSON_API_CONTENT_TYPE).get().build();
+
+        Response response = client.newCall(request).execute();
+
+        if (response.code() == 404) {
+            return null;
+        }
+
+        String body = response.body().string();
+
+        if (!response.isSuccessful()) {
+            throw new IOException("Get failed: " + url + " returned " + response.code() + " " + body);
+        }
+
+        Document<T> doc = adapter.fromJson(body);
+        T result = doc.requireData();
+
+        set_relationships(result, get_relationships(body).get(id));
+
+        return result;
+    }
+
+    @Override
+    public <T extends PassEntity> void deleteObject(Class<T> type, String id) throws IOException {
+        String url = get_url(type, id);
+
+        Request request = new Request.Builder().url(url).delete().build();
+        Response response = client.newCall(request).execute();
+
+        if (!response.isSuccessful()) {
+            throw new IOException(
+                    "Delete failed: " + url + " returned " + response.code() + " " + response.body().string());
+        }
+    }
+
+    @Override
+    public <T extends PassEntity> PassClientResult<T> selectObjects(PassClientSelector<T> selector) throws IOException {
+        JsonAdapter<Document<List<T>>> adapter = moshi.adapter(
+                Types.newParameterizedType(Document.class, Types.newParameterizedType(List.class, selector.getType())));
+        HttpUrl.Builder url_builder = HttpUrl.parse(get_url(selector.getType(), null)).newBuilder();
+
+        String[] include = selector.getInclude();
+        if (include != null && include.length > 0) {
+            url_builder.addQueryParameter("include", String.join(",", include));
+        }
+
+        if (selector.getFilter() != null) {
+            url_builder.addQueryParameter("filter", selector.getFilter());
+        }
+
+        if (selector.getSorting() != null) {
+            url_builder.addQueryParameter("sort", selector.getSorting());
+        }
+
+        url_builder.addQueryParameter("page[offset]", "" + selector.getOffset());
+        url_builder.addQueryParameter("page[limit]", "" + selector.getLimit());
+        url_builder.addQueryParameter("page[totals]", null);
+
+        HttpUrl url = url_builder.build();
+
+        Request request = new Request.Builder().url(url).header("Accept", JSON_API_CONTENT_TYPE)
+                .addHeader("Content-Type", JSON_API_CONTENT_TYPE).get().build();
+
+        Response response = client.newCall(request).execute();
+
+        if (response.code() == 404) {
+            return null;
+        }
+
+        String body = response.body().string();
+
+        if (!response.isSuccessful()) {
+            throw new IOException("Select failed: " + url + " returned " + response.code() + " " + body);
+        }
+
+        Document<List<T>> doc = adapter.fromJson(body);
+        List<T> matches = doc.requireData();
+        long total = -1;
+
+        if (doc.getMeta().has("page")) {
+            Map<?, ?> page = (Map<?, ?>) doc.getMeta().get("page");
+
+            if (page.containsKey("totalRecords")) {
+                total = ((Double) page.get("totalRecords")).longValue();
+            }
+        }
+
+        Map<String, List<Relationship>> rels = get_relationships(body);
+
+        matches.forEach(o -> {
+            set_relationships(o, rels.get(o.getId()));
+        });
+
+        return new PassClientResult<>(matches, total);
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/OkHttpBasicAuthInterceptor.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/OkHttpBasicAuthInterceptor.java
@@ -1,0 +1,32 @@
+package org.eclipse.pass.support.client;
+
+import java.io.IOException;
+
+import okhttp3.Credentials;
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+
+/**
+ * Add an Authorization header for basic auth to all requests.
+ */
+public class OkHttpBasicAuthInterceptor implements Interceptor {
+    private final String credentials;
+
+    /**
+     * Create new Interceptor which will add the given credentials.
+     *
+     * @param user for basic auth
+     * @param password for basic auth
+     */
+    public OkHttpBasicAuthInterceptor(String user, String password) {
+        this.credentials = Credentials.basic(user, password);
+    }
+
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+        Request request = chain.request();
+        Request authenticatedRequest = request.newBuilder().header("Authorization", credentials).build();
+        return chain.proceed(authenticatedRequest);
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/PassClient.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/PassClient.java
@@ -29,6 +29,24 @@ import org.eclipse.pass.support.client.model.PassEntity;
  */
 public interface PassClient {
     /**
+     * Create a new PassClient configured by using system properties:
+     * pass.core.url, pass.core.user, and pass.core.password.
+     *
+     * @return new PassClient
+     */
+    public static PassClient newInstance() {
+        String url = System.getProperty("pass.core.url");
+        String user = System.getProperty("pass.core.user");
+        String pass = System.getProperty("pass.core.password");
+
+        if (url == null) {
+            throw new RuntimeException("Missing required system property: pass.core.url");
+        }
+
+        return new JsonApiPassClient(url, user, pass);
+    }
+
+    /**
      * Create a new PassClient.
      *
      * @param baseUrl base url of PASS API

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/PassClient.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/PassClient.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2022 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client;
+
+import java.io.IOException;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import org.eclipse.pass.support.client.model.PassEntity;
+
+/**
+ * PassClient provides CRUD operations on objects in a running PASS system.
+ * A Java representation of the PASS data model is provided.
+ */
+public interface PassClient {
+    /**
+     * Create a new PassClient.
+     *
+     * @param baseUrl base url of PASS API
+     * @return new PassClient
+     */
+    public static PassClient newInstance(String baseUrl) {
+        return new JsonApiPassClient(baseUrl);
+    }
+
+    /**
+     * Create a PassClient which uses HTTP basic auth.
+     *
+     * @param baseUrl  base url of PASS API
+     * @param user user to connect as
+     * @param pass password of user
+     * @return new PassClient
+     */
+    public static PassClient newInstance(String baseUrl, String user, String pass) {
+        return new JsonApiPassClient(baseUrl, user, pass);
+    }
+
+    /**
+     * Create a new object.
+     * The id of the object must be null and will be set by the method.
+     *
+     * @param <T> type of the object
+     * @param obj object to persist
+     * @throws IOException if operation fails
+     */
+    <T extends PassEntity> void createObject(T obj) throws IOException;
+
+    /**
+     * Update an existing object.
+     *
+     * @param <T> type of the object
+     * @param obj object to update
+     * @throws IOException if operation fails
+     */
+    <T extends PassEntity> void updateObject(T obj) throws IOException;
+
+    /**
+     * Retrieve object with the given type and id from the repository. Targets of
+     * relationships may optionally be included in the response. If they are not included,
+     * the target object will have its identifier set, but nothing else.
+     *
+     * @param <T> type of the object
+     * @param type Class of the object
+     * @param id identifier of the object
+     * @param include Array of relationship names whose targets will be included in response
+     * @return persisted object or null if it does not exist
+     * @throws IOException if operation fails
+     */
+    <T extends PassEntity> T getObject(Class<T> type, String id, String... include) throws IOException;
+
+    /**
+     * Retrieve object with the type of and id of the argument object.
+     * This can be useful when only the type and id are known.
+     *
+     * @param <T> type of the object
+     * @param obj type and id of object to retrieve
+     * @param include relationships who
+     * @return persisted object or null if it does not exist
+     * @throws IOException if operation fails
+     */
+    @SuppressWarnings("unchecked")
+    default <T extends PassEntity> T getObject(T obj, String... include) throws IOException {
+        return (T) getObject(obj.getClass(), obj.getId(), include);
+    }
+
+    /**
+     * Delete object with the given type and id.
+     *
+     * @param <T> type of the object
+     * @param type type of the object
+     * @param id identifier of the object
+     * @throws IOException if operation fails
+     */
+    <T extends PassEntity> void deleteObject(Class<T> type, String id) throws IOException;
+
+    /**
+     * Delete an object.
+     *
+     * @param <T> type of the object
+     * @param obj object to delete
+     * @throws IOException if operation fails
+     */
+    default <T extends PassEntity> void deleteObject(T obj) throws IOException {
+        deleteObject(obj.getClass(), obj.getId());
+    }
+
+    /**
+     * Select objects from the repository matching the selector.
+     *
+     * @param <T> type of the object
+     * @param selector which objects to retrieve
+     * @return matching objects
+     * @throws IOException if operation fails
+     */
+    <T extends PassEntity> PassClientResult<T> selectObjects(PassClientSelector<T> selector) throws IOException;
+
+    /**
+     * Stream all objects in the repository matching the selector starting from the selector offset.
+     *
+     * @param <T> type of the object
+     * @param selector which objects to retrieve
+     * @return Stream matching objects
+     * @throws IOException if operation fails
+     */
+    default <T extends PassEntity> Stream<T> streamObjects(PassClientSelector<T> selector) throws IOException {
+        Spliterator<T> iter = new Spliterator<T>() {
+            PassClientResult<T> result = selectObjects(selector);
+            int next = 0;
+
+            @Override
+            public int characteristics() {
+                return NONNULL | CONCURRENT;
+            }
+
+            @Override
+            public long estimateSize() {
+                return result.getTotal();
+            }
+
+            @Override
+            public boolean tryAdvance(Consumer<? super T> consumer) {
+                if (next == result.getObjects().size()) {
+                    try {
+                        selector.setOffset(selector.getOffset() + selector.getLimit());
+                        result = selectObjects(selector);
+                        next = 0;
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+
+                    if (result.getObjects().size() == 0) {
+                        return false;
+                    }
+                }
+
+                consumer.accept(result.getObjects().get(next++));
+                return true;
+            }
+
+            @Override
+            public Spliterator<T> trySplit() {
+                return null;
+            }
+        };
+
+        return StreamSupport.stream(iter, false);
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/PassClientResult.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/PassClientResult.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client;
+
+import java.util.List;
+
+import org.eclipse.pass.support.client.model.PassEntity;
+
+/**
+ * PassClientResult represents a sublist in the list of total objects which match a selector.
+ */
+public class PassClientResult<T extends PassEntity> {
+    private final List<T> entities;
+    private final long total;
+
+    /**
+     * @param entities matching objects
+     * @param total number of total matches
+     */
+    public PassClientResult(List<T> entities, long total) {
+        this.entities = entities;
+        this.total = total;
+    }
+
+    /**
+     * @return The total number of matching objects or -1 if not known.
+     */
+    public long getTotal() {
+        return total;
+    }
+
+    /**
+     * @return Matching objects.
+     */
+    public List<T> getObjects() {
+        return entities;
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/PassClientSelector.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/PassClientSelector.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2022 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client;
+
+import org.eclipse.pass.support.client.model.PassEntity;
+
+/**
+ * PassClientSelector is used to select objects in the repository.
+ * See https://elide.io/pages/guide/v6/10-jsonapi.html for information on the
+ * sort, filter, and include syntax.
+ * A given number of matches in the total result list starting at the given offset are returned.
+ */
+public class PassClientSelector<T extends PassEntity> {
+    private static final int DEFAULT_LIMIT = 500;
+
+    private int offset;
+    private int limit;
+    private Class<T> type;
+    private String sorting;
+    private String filter;
+    private String[] include;
+
+    /**
+     * Match all objects of the given type.
+     *
+     * @param type of object to match
+     */
+    public PassClientSelector(Class<T> type) {
+        this(type, 0, DEFAULT_LIMIT, null, null);
+    }
+
+    /**
+     * Match objects in the repository.
+     *
+     * @param type Match objects of this type
+     * @param offset Return objects starting at this location in the list of total results
+     * @param limit Return at most this many matching objects
+     * @param filter Return objects which match this RSQL filter or null for no filter
+     * @param sorting Sort objects in this fashion or null for no sorting
+     * @param include Also retrieve targets of these relationships
+     */
+    public PassClientSelector(Class<T> type, int offset, int limit, String filter, String sorting, String... include) {
+        this.offset = offset;
+        this.limit = limit;
+        this.type = type;
+        this.filter = filter;
+        this.sorting = sorting;
+        this.include = include;
+    }
+
+    /**
+     * @return offset into list of total matches
+     */
+    public int getOffset() {
+        return offset;
+    }
+
+    /**
+     * @param offset to set
+     */
+    public void setOffset(int offset) {
+        this.offset = offset;
+    }
+
+    /**
+     * @return max number of matches to return
+     */
+    public int getLimit() {
+        return limit;
+    }
+
+    /**
+     * @param limit to set
+     */
+    public void setLimit(int limit) {
+        this.limit = limit;
+    }
+
+    /**
+     * @return type of objects to match
+     */
+    public Class<? extends PassEntity> getType() {
+        return type;
+    }
+
+    /**
+     * @param type to set
+     */
+    public void setType(Class<T> type) {
+        this.type = type;
+    }
+
+    /**
+     * @return how results are sorted
+     */
+    public String getSorting() {
+        return sorting;
+    }
+
+    /**
+     * @param sorting to set
+     */
+    public void setSorting(String sorting) {
+        this.sorting = sorting;
+    }
+
+    /**
+     * @return RSQL expression to filter matches
+     */
+    public String getFilter() {
+        return filter;
+    }
+
+    /**
+     * @param filter to set
+     */
+    public void setFilter(String filter) {
+        this.filter = filter;
+    }
+
+    /**
+     * @return relationship of matches whose target should be returned
+     */
+    public String[] getInclude() {
+        return include;
+    }
+
+    /**
+     * @param include to set
+     */
+    public void setInclude(String... include) {
+        this.include = include;
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/RSQL.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/RSQL.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2022 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client;
+
+/**
+ * This is a utility class to help construct RSQL expressions to use as a filter.
+ */
+public class RSQL {
+    private RSQL() {}
+
+    // '"' | "'" | "(" | ")" | ";" | "," | "=" | "!" | "~" | "<" | ">";
+
+    /**
+     * @param expressions RSQL expressions
+     * @return logical conjunction of arguments as RSQL expression
+     */
+    public static String and(String... expressions) {
+        return group_expressions(";", expressions);
+    }
+
+    /**
+     * @param expressions RSQL expressions
+     * @return logical disjunction of arguments as RSQL expression
+     */
+    public static String or(String... expressions) {
+        return group_expressions(",", expressions);
+    }
+
+    /**
+     * @param name Name of field
+     * @param value Value of field
+     * @return RSQL expression testing that object has a field with a value
+     */
+    public static String equals(String name, String value) {
+        return comparison(name, "==", value);
+    }
+
+    /**
+     * @param name Name of field
+     * @param value Value of field
+     * @return RSQL expression testing that object does not have a field with a value
+     */
+    public static String notEquals(String name, String value) {
+        return comparison(name, "!=", value);
+    }
+
+    /**
+     * @param name Name of field
+     * @param values Values of field
+     * @return RSQL expression testing that object has a field with at least one of the values
+     */
+    public static String in(String name, String... values) {
+        return comparison_group(name, "=in=", values);
+    }
+
+    /**
+     * @param name Name of field
+     * @param values Values of field
+     * @return RSQL expression testing that object has a field without any of the values
+     */
+    public static String out(String name, String... values) {
+        return comparison_group(name, "=out=", values);
+    }
+
+    private static String group_expressions(String op, String...expressions) {
+        StringBuilder result = new StringBuilder();
+
+        result.append('(');
+        result.append(expressions[0]);
+        for (int i = 1; i < expressions.length; i++) {
+            result.append(op);
+            result.append(expressions[i]);
+        }
+        result.append(')');
+
+        return result.toString();
+    }
+
+    private static String group_values(String...values) {
+        StringBuilder result = new StringBuilder();
+
+        result.append("(\'");
+        result.append(escape(values[0]));
+        for (int i = 1; i < values.length; i++) {
+            result.append("\',\'");
+            result.append(escape(values[i]));
+        }
+        result.append("')");
+
+        return result.toString();
+    }
+
+    private static String comparison(String name, String op, String value) {
+        return name + op + "'" + escape(value) + "'";
+    }
+
+    private static String comparison_group(String name, String op, String... values) {
+        return name + op + group_values(values) ;
+    }
+
+    private static CharSequence escape(String s) {
+        StringBuilder result = new StringBuilder();
+
+        for (int i = 0; i < s.length(); i++) {
+            Character c = s.charAt(i);
+
+            if (c == '\\' || c == '\"' || c == '\'') {
+                result.append('\\');
+            }
+
+            result.append(c);
+        }
+
+        return result;
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/RSQL.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/RSQL.java
@@ -21,8 +21,6 @@ package org.eclipse.pass.support.client;
 public class RSQL {
     private RSQL() {}
 
-    // '"' | "'" | "(" | ")" | ";" | "," | "=" | "!" | "~" | "<" | ">";
-
     /**
      * @param expressions RSQL expressions
      * @return logical conjunction of arguments as RSQL expression

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/Util.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/Util.java
@@ -1,0 +1,21 @@
+package org.eclipse.pass.support.client;
+
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Utilities for working with the model.
+ */
+public class Util {
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
+
+    private Util() {}
+
+    /**
+     * The ZonedDateTime fields in the model must use this formatter.
+     *
+     * @return formatter
+     */
+    public static DateTimeFormatter dateTimeFormatter() {
+        return FORMATTER;
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/adapter/AggregatedDepositStatusAdapter.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/adapter/AggregatedDepositStatusAdapter.java
@@ -1,0 +1,28 @@
+package org.eclipse.pass.support.client.adapter;
+
+import com.squareup.moshi.FromJson;
+import com.squareup.moshi.ToJson;
+import org.eclipse.pass.support.client.model.AggregatedDepositStatus;
+
+/**
+ * Map type to JSON.
+ */
+public class AggregatedDepositStatusAdapter {
+    /**
+     * @param value to convert
+     * @return JSON value
+     */
+    @ToJson
+    public String toJson(AggregatedDepositStatus value) {
+        return value.getValue();
+    }
+
+    /**
+     * @param s to parse
+     * @return type value
+     */
+    @FromJson
+    public AggregatedDepositStatus fromJson(String s) {
+        return AggregatedDepositStatus.of(s);
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/adapter/AwardStatusAdapter.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/adapter/AwardStatusAdapter.java
@@ -1,0 +1,28 @@
+package org.eclipse.pass.support.client.adapter;
+
+import com.squareup.moshi.FromJson;
+import com.squareup.moshi.ToJson;
+import org.eclipse.pass.support.client.model.AwardStatus;
+
+/**
+ * Map type to JSON.
+ */
+public class AwardStatusAdapter {
+    /**
+     * @param value to convert
+     * @return JSON value
+     */
+    @ToJson
+    public String toJson(AwardStatus value) {
+        return value.getValue();
+    }
+
+    /**
+     * @param s to parse
+     * @return type value
+     */
+    @FromJson
+    public AwardStatus fromJson(String s) {
+        return AwardStatus.of(s);
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/adapter/ContributorRoleAdapter.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/adapter/ContributorRoleAdapter.java
@@ -1,0 +1,28 @@
+package org.eclipse.pass.support.client.adapter;
+
+import com.squareup.moshi.FromJson;
+import com.squareup.moshi.ToJson;
+import org.eclipse.pass.support.client.model.ContributorRole;
+
+/**
+ * Map type to JSON.
+ */
+public class ContributorRoleAdapter {
+    /**
+     * @param value to convert
+     * @return JSON value
+     */
+    @ToJson
+    public String toJson(ContributorRole value) {
+        return value.getValue();
+    }
+
+    /**
+     * @param s to parse
+     * @return type value
+     */
+    @FromJson
+    public ContributorRole fromJson(String s) {
+        return ContributorRole.of(s);
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/adapter/CopyStatusAdapter.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/adapter/CopyStatusAdapter.java
@@ -1,0 +1,28 @@
+package org.eclipse.pass.support.client.adapter;
+
+import com.squareup.moshi.FromJson;
+import com.squareup.moshi.ToJson;
+import org.eclipse.pass.support.client.model.CopyStatus;
+
+/**
+ * Map type to JSON.
+ */
+public class CopyStatusAdapter {
+    /**
+     * @param value to convert
+     * @return JSON value
+     */
+    @ToJson
+    public String toJson(CopyStatus value) {
+        return value.getValue();
+    }
+
+    /**
+     * @param s to parse
+     * @return type value
+     */
+    @FromJson
+    public CopyStatus fromJson(String s) {
+        return CopyStatus.of(s);
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/adapter/DepositStatusAdapter.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/adapter/DepositStatusAdapter.java
@@ -1,0 +1,28 @@
+package org.eclipse.pass.support.client.adapter;
+
+import com.squareup.moshi.FromJson;
+import com.squareup.moshi.ToJson;
+import org.eclipse.pass.support.client.model.DepositStatus;
+
+/**
+ * Map type to JSON.
+ */
+public class DepositStatusAdapter {
+    /**
+     * @param value to convert
+     * @return JSON value
+     */
+    @ToJson
+    public String toJson(DepositStatus value) {
+        return value.getValue();
+    }
+
+    /**
+     * @param s to parse
+     * @return type value
+     */
+    @FromJson
+    public DepositStatus fromJson(String s) {
+        return DepositStatus.of(s);
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/adapter/EventTypeAdapter.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/adapter/EventTypeAdapter.java
@@ -1,0 +1,28 @@
+package org.eclipse.pass.support.client.adapter;
+
+import com.squareup.moshi.FromJson;
+import com.squareup.moshi.ToJson;
+import org.eclipse.pass.support.client.model.EventType;
+
+/**
+ * Map type to JSON.
+ */
+public class EventTypeAdapter {
+    /**
+     * @param value to convert
+     * @return JSON value
+     */
+    @ToJson
+    public String toJson(EventType value) {
+        return value.getValue();
+    }
+
+    /**
+     * @param s to parse
+     * @return type value
+     */
+    @FromJson
+    public EventType fromJson(String s) {
+        return EventType.of(s);
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/adapter/FileRoleAdapter.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/adapter/FileRoleAdapter.java
@@ -1,0 +1,28 @@
+package org.eclipse.pass.support.client.adapter;
+
+import com.squareup.moshi.FromJson;
+import com.squareup.moshi.ToJson;
+import org.eclipse.pass.support.client.model.FileRole;
+
+/**
+ * Map type to JSON.
+ */
+public class FileRoleAdapter {
+    /**
+     * @param value to convert
+     * @return JSON value
+     */
+    @ToJson
+    public String toJson(FileRole value) {
+        return value.getValue();
+    }
+
+    /**
+     * @param s to parse
+     * @return type value
+     */
+    @FromJson
+    public FileRole fromJson(String s) {
+        return FileRole.of(s);
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/adapter/IntegrationTypeAdapter.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/adapter/IntegrationTypeAdapter.java
@@ -1,0 +1,28 @@
+package org.eclipse.pass.support.client.adapter;
+
+import com.squareup.moshi.FromJson;
+import com.squareup.moshi.ToJson;
+import org.eclipse.pass.support.client.model.IntegrationType;
+
+/**
+ * Map type to JSON.
+ */
+public class IntegrationTypeAdapter {
+    /**
+     * @param value to convert
+     * @return JSON value
+     */
+    @ToJson
+    public String toJson(IntegrationType value) {
+        return value.getValue();
+    }
+
+    /**
+     * @param s to parse
+     * @return type value
+     */
+    @FromJson
+    public IntegrationType fromJson(String s) {
+        return IntegrationType.of(s);
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/adapter/PerformerRoleAdapter.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/adapter/PerformerRoleAdapter.java
@@ -1,0 +1,28 @@
+package org.eclipse.pass.support.client.adapter;
+
+import com.squareup.moshi.FromJson;
+import com.squareup.moshi.ToJson;
+import org.eclipse.pass.support.client.model.PerformerRole;
+
+/**
+ * Map type to JSON.
+ */
+public class PerformerRoleAdapter {
+    /**
+     * @param value to convert
+     * @return JSON value
+     */
+    @ToJson
+    public String toJson(PerformerRole value) {
+        return value.getValue();
+    }
+
+    /**
+     * @param s to parse
+     * @return type value
+     */
+    @FromJson
+    public PerformerRole fromJson(String s) {
+        return PerformerRole.of(s);
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/adapter/SourceAdapter.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/adapter/SourceAdapter.java
@@ -1,0 +1,28 @@
+package org.eclipse.pass.support.client.adapter;
+
+import com.squareup.moshi.FromJson;
+import com.squareup.moshi.ToJson;
+import org.eclipse.pass.support.client.model.Source;
+
+/**
+ * Map type to JSON.
+ */
+public class SourceAdapter {
+    /**
+     * @param value to convert
+     * @return JSON value
+     */
+    @ToJson
+    public String toJson(Source value) {
+        return value.getValue();
+    }
+
+    /**
+     * @param s to parse
+     * @return type value
+     */
+    @FromJson
+    public Source fromJson(String s) {
+        return Source.of(s);
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/adapter/SubmissionStatusAdapter.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/adapter/SubmissionStatusAdapter.java
@@ -1,0 +1,28 @@
+package org.eclipse.pass.support.client.adapter;
+
+import com.squareup.moshi.FromJson;
+import com.squareup.moshi.ToJson;
+import org.eclipse.pass.support.client.model.SubmissionStatus;
+
+/**
+ * Map type to JSON.
+ */
+public class SubmissionStatusAdapter {
+    /**
+     * @param value to convert
+     * @return JSON value
+     */
+    @ToJson
+    public String toJson(SubmissionStatus value) {
+        return value.getValue();
+    }
+
+    /**
+     * @param s to parse
+     * @return type value
+     */
+    @FromJson
+    public SubmissionStatus fromJson(String s) {
+        return SubmissionStatus.of(s);
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/adapter/UriAdapter.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/adapter/UriAdapter.java
@@ -1,0 +1,29 @@
+package org.eclipse.pass.support.client.adapter;
+
+import java.net.URI;
+
+import com.squareup.moshi.FromJson;
+import com.squareup.moshi.ToJson;
+
+/**
+ * Map type to JSON.
+ */
+public class UriAdapter {
+    /**
+     * @param value to convert
+     * @return JSON value
+     */
+    @ToJson
+    public String toJson(URI value) {
+        return value.toString();
+    }
+
+    /**
+     * @param s to parse
+     * @return type value
+     */
+    @FromJson
+    public URI fromJson(String s) {
+        return URI.create(s);
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/adapter/UserRoleAdapter.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/adapter/UserRoleAdapter.java
@@ -1,0 +1,28 @@
+package org.eclipse.pass.support.client.adapter;
+
+import com.squareup.moshi.FromJson;
+import com.squareup.moshi.ToJson;
+import org.eclipse.pass.support.client.model.UserRole;
+
+/**
+ * Map type to JSON.
+ */
+public class UserRoleAdapter {
+    /**
+     * @param value to convert
+     * @return JSON value
+     */
+    @ToJson
+    public String toJson(UserRole value) {
+        return value.getValue();
+    }
+
+    /**
+     * @param s to parse
+     * @return type value
+     */
+    @FromJson
+    public UserRole fromJson(String s) {
+        return UserRole.of(s);
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/adapter/ZonedDateTimeAdapter.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/adapter/ZonedDateTimeAdapter.java
@@ -1,0 +1,30 @@
+package org.eclipse.pass.support.client.adapter;
+
+import java.time.ZonedDateTime;
+
+import com.squareup.moshi.FromJson;
+import com.squareup.moshi.ToJson;
+import org.eclipse.pass.support.client.Util;
+
+/**
+ * Map type to JSON.
+ */
+public class ZonedDateTimeAdapter {
+    /**
+     * @param value to convert
+     * @return JSON value
+     */
+    @ToJson
+    public String toJson(ZonedDateTime value) {
+        return value.format(Util.dateTimeFormatter());
+    }
+
+    /**
+     * @param s to parse
+     * @return type value
+     */
+    @FromJson
+    public ZonedDateTime fromJson(String s) {
+        return ZonedDateTime.parse(s, Util.dateTimeFormatter());
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/AggregatedDepositStatus.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/AggregatedDepositStatus.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Possible aggregatedDepositStatus of a submission, this is dependent on information from the server and
+ * is calculated using the status of associated Deposits
+ */
+public enum AggregatedDepositStatus {
+    /**
+     * No Deposits have been initiated for the Submission
+     */
+    NOT_STARTED("not-started"),
+
+    /**
+     * One or more Deposits for the Submission have been initiated, and at least one
+     * has not reached the status of "accepted"
+     */
+    IN_PROGRESS("in-progress"),
+
+    /**
+     * One or more Deposits for the Submission has a status of "failed"
+     */
+    FAILED("failed"),
+
+    /**
+     * All related Deposits have a status of "accepted"
+     */
+    ACCEPTED("accepted"),
+
+    /**
+     * One or more Deposits for the Submission has a status of "rejected"
+     */
+    REJECTED("rejected");
+
+    private static final Map<String, AggregatedDepositStatus> map = new HashMap<>(values().length, 1);
+
+    static {
+        for (AggregatedDepositStatus s : values()) {
+            map.put(s.value, s);
+        }
+    }
+
+    private String value;
+
+    private AggregatedDepositStatus(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Parse the aggregated deposit status.
+     *
+     * @param status Serialized status
+     * @return parsed deposit status.
+     */
+    public static AggregatedDepositStatus of(String status) {
+        AggregatedDepositStatus result = map.get(status);
+        if (result == null) {
+            throw new IllegalArgumentException("Invalid Aggregated Deposit Status: " + status);
+        }
+        return result;
+    }
+
+    /**
+     * @return public value
+     */
+    public String getValue() {
+        return value;
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/AwardStatus.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/AwardStatus.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Status of award/grant
+ */
+public enum AwardStatus {
+
+    /**
+     * Active award
+     */
+    ACTIVE("active"),
+
+    /**
+     * Pre-award
+     */
+    PRE_AWARD("pre-award"),
+
+    /**
+     * Terminated
+     */
+    TERMINATED("terminated");
+
+    private static final Map<String, AwardStatus> map = new HashMap<>(values().length, 1);
+
+    static {
+        for (AwardStatus a : values()) {
+            map.put(a.value, a);
+        }
+    }
+
+    private String value;
+
+    private AwardStatus(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Parse award status
+     *
+     * @param status Serialized status
+     * @return Parsed status
+     */
+    public static AwardStatus of(String status) {
+        AwardStatus result = map.get(status);
+        if (result == null) {
+            throw new IllegalArgumentException("Invalid Award Status: " + status);
+        }
+        return result;
+    }
+
+    /**
+     * @return public value
+     */
+    public String getValue() {
+        return value;
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/Contributor.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/Contributor.java
@@ -1,0 +1,316 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client.model;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import jsonapi.Id;
+import jsonapi.Resource;
+import jsonapi.ToOne;
+
+/**
+ * A Contributor is a person who contributed to a Publication. The contributor
+ * model captures the person information as well as the roles they played in
+ * creating the publication (e.g. author).
+ *
+ * @author Karen Hanson
+ */
+
+@Resource(type = "contributor")
+public class Contributor implements PassEntity {
+    /**
+     * Unique id for the resource.
+     */
+    @Id
+    private String id;
+
+    /**
+     * First name(s) of person
+     */
+    private String firstName;
+
+    /**
+     * Middle name(s) of person
+     */
+    private String middleName;
+
+    /**
+     * Last name(s) of person
+     */
+    private String lastName;
+
+    /**
+     * Name for display. Separate names may not be available, but a person should
+     * always at least have a display name.
+     */
+    private String displayName;
+
+    /**
+     * Contact email for person
+     */
+    private String email;
+
+    /**
+     * ORCID ID for person
+     */
+    private String orcidId;
+
+    /**
+     * Affiliation string for person. Where Person is embedded in Submission or
+     * Grant, this is the affiliation relevant to that item
+     */
+    private Set<String> affiliation = new HashSet<>();
+
+    /**
+     * One or more roles that this Contributor performed for the associated
+     * Publication
+     */
+    private List<ContributorRole> roles = new ArrayList<ContributorRole>();
+
+    /**
+     * The publication that this contributor is associated with
+     */
+    @ToOne(name = "publication")
+    private Publication publication;
+
+    /**
+     * The user that represents the same person as this Contributor, where
+     * relevant
+     */
+    @ToOne(name = "user")
+    private User user;
+
+    /**
+     * Contributor constructor
+     */
+    public Contributor() {
+    }
+
+    /**
+     * Constructor that sets id.
+     *
+     * @param id identifier
+     */
+    public Contributor(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Copy constructor, this will copy the values of the object provided into the new object
+     *
+     * @param contributor the contributor to copy
+     */
+    public Contributor(Contributor contributor) {
+        this.id = contributor.id;
+        this.firstName = contributor.firstName;
+        this.middleName = contributor.middleName;
+        this.lastName = contributor.lastName;
+        this.displayName = contributor.displayName;
+        this.email = contributor.email;
+        this.orcidId = contributor.orcidId;
+        this.affiliation = contributor.affiliation;
+        this.roles = new ArrayList<ContributorRole>(contributor.roles);
+        this.publication = contributor.publication;
+        this.user = contributor.user;
+    }
+
+    /**
+     * @return the firstName
+     */
+    public String getFirstName() {
+        return firstName;
+    }
+
+    /**
+     * @param firstName the firstName to set
+     */
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    /**
+     * @return the middleName
+     */
+    public String getMiddleName() {
+        return middleName;
+    }
+
+    /**
+     * @param middleName the middleName to set
+     */
+    public void setMiddleName(String middleName) {
+        this.middleName = middleName;
+    }
+
+    /**
+     * @return the lastName
+     */
+    public String getLastName() {
+        return lastName;
+    }
+
+    /**
+     * @param lastName the lastName to set
+     */
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    /**
+     * @return the displayName
+     */
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    /**
+     * @param displayName the displayName to set
+     */
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    /**
+     * @return the email
+     */
+    public String getEmail() {
+        return email;
+    }
+
+    /**
+     * @param email the email to set
+     */
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    /**
+     * @return the affiliation
+     */
+    public Set<String> getAffiliation() {
+        return affiliation;
+    }
+
+    /**
+     * @param affiliation the affiliation to set
+     */
+    public void setAffiliation(Set<String> affiliation) {
+        this.affiliation = affiliation;
+    }
+
+    /**
+     * @return the orcidId
+     */
+    public String getOrcidId() {
+        return orcidId;
+    }
+
+    /**
+     * @param orcidId the orcidId to set
+     */
+    public void setOrcidId(String orcidId) {
+        this.orcidId = orcidId;
+    }
+
+    /**
+     * @return the list of roles
+     */
+    public List<ContributorRole> getRoles() {
+        return roles;
+    }
+
+    /**
+     * @param roles the roles list to set
+     */
+    public void setRoles(List<ContributorRole> roles) {
+        this.roles = roles;
+    }
+
+    /**
+     * @return the publication
+     */
+    public Publication getPublication() {
+        return publication;
+    }
+
+    /**
+     * @param publication the publication to set
+     */
+    public void setPublication(Publication publication) {
+        this.publication = publication;
+    }
+
+    /**
+     * @return the user
+     */
+    public User getUser() {
+        return user;
+    }
+
+    /**
+     * @param user the user to set
+     */
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, email);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        Contributor other = (Contributor) obj;
+        return Objects.equals(affiliation, other.affiliation) && Objects.equals(displayName, other.displayName)
+                && Objects.equals(email, other.email) && Objects.equals(firstName, other.firstName)
+                && Objects.equals(id, other.id) && Objects.equals(lastName, other.lastName)
+                && Objects.equals(middleName, other.middleName) && Objects.equals(orcidId, other.orcidId)
+                && Objects.equals(publication, other.publication) && Objects.equals(roles, other.roles)
+                && Objects.equals(user, other.user);
+    }
+
+    @Override
+    public String toString() {
+        return "Contributor [id=" + id + ", firstName=" + firstName + ", middleName=" + middleName + ", lastName="
+                + lastName + ", displayName=" + displayName + ", email=" + email + ", orcidId=" + orcidId
+                + ", affiliation=" + affiliation + ", roles=" + roles + ", publication=" + publication + ", user="
+                + user + "]";
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/ContributorRole.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/ContributorRole.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * list of possible contributor Roles
+ */
+public enum ContributorRole {
+
+    /**
+     * Author role
+     */
+    AUTHOR("author"),
+
+    /**
+     * First author role
+     */
+    FIRST_AUTHOR("first-author"),
+
+    /**
+     * Last author role
+     */
+    LAST_AUTHOR("last-author"),
+
+    /**
+     * Corresponding author role
+     */
+    CORRESPONDING_AUTHOR("corresponding-author");
+
+    private static final Map<String, ContributorRole> map = new HashMap<>(values().length, 1);
+
+    static {
+        for (ContributorRole r : values()) {
+            map.put(r.value, r);
+        }
+    }
+
+    private String value;
+
+    private ContributorRole(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Parse the role.
+     *
+     * @param role Serialized role string
+     * @return The parsed value.
+     */
+    public static ContributorRole of(String role) {
+        ContributorRole result = map.get(role);
+        if (result == null) {
+            throw new IllegalArgumentException("Invalid Role: " + role);
+        }
+        return result;
+    }
+
+    /**
+     * @return public value
+     */
+    public String getValue() {
+        return value;
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/CopyStatus.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/CopyStatus.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Possible repository copy statuses. Note that some repositories may not go through every status.
+ */
+public enum CopyStatus {
+    /**
+     * The target Repository has rejected the Deposit
+     */
+    ACCEPTED("accepted"),
+    /**
+     * PASS has sent a package to the target Repository and is waiting for an update on the status
+     */
+    IN_PROGRESS("in-progress"),
+    /**
+     * The target [Repository](Repository.md) has detected a problem that has caused the progress to stall.
+     */
+    STALLED("stalled"),
+    /**
+     * The target Repository has rejected the Deposit
+     */
+    COMPLETE("complete"),
+
+    /**
+     * The RepositoryCopy has been rejected by the remote Repository.
+     */
+    REJECTED("rejected");
+
+    private static final Map<String, CopyStatus> map = new HashMap<>(values().length, 1);
+
+    static {
+        for (CopyStatus c : values()) {
+            map.put(c.value, c);
+        }
+    }
+
+    private String value;
+
+    private CopyStatus(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Parse the copy status.
+     *
+     * @param status Serialized status.
+     * @return Parsed status.
+     */
+    public static CopyStatus of(String status) {
+        CopyStatus result = map.get(status);
+        if (result == null) {
+            throw new IllegalArgumentException("Invalid Copy Status: " + status);
+        }
+        return result;
+    }
+
+    /**
+     * @return public value
+     */
+    public String getValue() {
+        return value;
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/Deposit.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/Deposit.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client.model;
+
+import java.util.Objects;
+
+import jsonapi.Id;
+import jsonapi.Resource;
+import jsonapi.ToOne;
+
+/**
+ * A Submission can have multiple Deposits, each to a different Repository. This describes a single deposit to a
+ * Repository and captures
+ * its current status.
+ *
+ * @author Karen Hanson
+ */
+
+@Resource(type = "deposit")
+public class Deposit implements PassEntity {
+    /**
+     * Unique id for the resource.
+     */
+    @Id
+    private String id;
+
+    /**
+     * A URL or some kind of reference that can be dereferenced, entity body parsed, and used to determine the status
+     * of Deposit
+     */
+    private String depositStatusRef;
+
+    /**
+     * Status of deposit
+     */
+    private DepositStatus depositStatus;
+
+    /**
+     * The Submission that this Deposit is a part of
+     */
+    @ToOne(name = "submission")
+    private Submission submission;
+
+    /**
+     * The Repository being deposited to
+     */
+    @ToOne(name = "repository")
+    private Repository repository;
+
+    /**
+     * The Repository Copy representing the copy that is reltaed to this Deposit. The value is null if there
+     * is no copy
+     */
+    @ToOne(name = "repositoryCopy")
+    private RepositoryCopy repositoryCopy;
+
+    /**
+     * Deposit constructor
+     */
+    public Deposit() {
+    }
+
+    /**
+     * Constructor that sets id.
+     *
+     * @param id identifier
+     */
+    public Deposit(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Copy constructor, this will copy the values of the object provided into the new object
+     *
+     * @param deposit the deposit to copy
+     */
+    public Deposit(Deposit deposit) {
+        this.id = deposit.id;
+        this.depositStatusRef = deposit.depositStatusRef;
+        this.depositStatus = deposit.depositStatus;
+        this.submission = deposit.submission;
+        this.repository = deposit.repository;
+        this.repositoryCopy = deposit.repositoryCopy;
+    }
+
+    /**
+     * @return the deposit status
+     */
+    public DepositStatus getDepositStatus() {
+        return depositStatus;
+    }
+
+    /**
+     * @param depositStatus status the deposit status to set
+     */
+    public void setDepositStatus(DepositStatus depositStatus) {
+        this.depositStatus = depositStatus;
+    }
+
+    /**
+     * @return the repository
+     */
+    public Repository getRepository() {
+        return repository;
+    }
+
+    /**
+     * @param repository the repository to set
+     */
+    public void setRepository(Repository repository) {
+        this.repository = repository;
+    }
+
+    /**
+     * @return the depositStatusRef
+     */
+    public String getDepositStatusRef() {
+        return depositStatusRef;
+    }
+
+    /**
+     * @param depositStatusRef the depositStatusRef to set
+     */
+    public void setDepositStatusRef(String depositStatusRef) {
+        this.depositStatusRef = depositStatusRef;
+    }
+
+    /**
+     * @return the submission
+     */
+    public Submission getSubmission() {
+        return submission;
+    }
+
+    /**
+     * @param submission the submission to set
+     */
+    public void setSubmission(Submission submission) {
+        this.submission = submission;
+    }
+
+    /**
+     * @return the repositoryCopy
+     */
+    public RepositoryCopy getRepositoryCopy() {
+        return repositoryCopy;
+    }
+
+    /**
+     * @param repositoryCopy the repositoryCopy to set
+     */
+    public void setRepositoryCopy(RepositoryCopy repositoryCopy) {
+        this.repositoryCopy = repositoryCopy;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        Deposit other = (Deposit) obj;
+        return depositStatus == other.depositStatus && Objects.equals(depositStatusRef, other.depositStatusRef)
+                && Objects.equals(id, other.id) && Objects.equals(repository, other.repository)
+                && Objects.equals(repositoryCopy, other.repositoryCopy) && Objects.equals(submission, other.submission);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, depositStatus, depositStatusRef);
+    }
+
+    @Override
+    public String toString() {
+        return "Deposit [id=" + id + ", depositStatusRef=" + depositStatusRef + ", depositStatus=" + depositStatus
+                + ", submission=" + submission + ", repository=" + repository + ", repositoryCopy=" + repositoryCopy
+                + "]";
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/DepositStatus.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/DepositStatus.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Possible deposit statuses. Note that some repositories may not go through every status.
+ */
+public enum DepositStatus {
+    /**
+     * PASS has sent a package to the target Repository and is waiting for an update on the status
+     */
+    SUBMITTED("submitted"),
+    /**
+     * The target Repository has rejected the Deposit
+     */
+    ACCEPTED("accepted"),
+    /**
+     * The target Repository has accepted the files into the repository. More steps may be performed by the
+     * Repository, but the
+     * requirements of the Deposit have been satisfied
+     */
+    REJECTED("rejected"),
+    /**
+     * A failure occurred performing the deposit; it may be re-tried later.
+     */
+    FAILED("failed");
+
+    private static final Map<String, DepositStatus> map = new HashMap<>(values().length, 1);
+
+    static {
+        for (DepositStatus d : values()) {
+            map.put(d.value, d);
+        }
+    }
+
+    private String value;
+
+    private DepositStatus(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Parse deposit status
+     *
+     * @param status status string
+     * @return parsed status
+     */
+    public static DepositStatus of(String status) {
+        DepositStatus result = map.get(status);
+        if (result == null) {
+            throw new IllegalArgumentException("Invalid Deposit Status: " + status);
+        }
+        return result;
+    }
+
+    /**
+     * @return public value
+     */
+    public String getValue() {
+        return value;
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/EventType.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/EventType.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * The types of events that might be recorded as SubmissionEvents
+ */
+public enum EventType {
+    /**
+     * A Submission was prepared by a preparer on behalf of a person who does not yet have a User
+     * record in PASS. The preparer is requesting that the submitter join PASS and then approve and
+     * submit it or provide feedback.
+     */
+    APPROVAL_REQUESTED_NEWUSER("approval-requested-newuser"),
+
+    /**
+     * A Submission was prepared by a preparer who is now requesting that the submitter approve and
+     * submit it or provide feedback
+     */
+    APPROVAL_REQUESTED("approval-requested"),
+
+    /**
+     * A Submission was prepared by a preparer, but on review by the submitter, a change was requested.
+     * The Submission has been handed back to the preparer for editing.
+     */
+    CHANGES_REQUESTED("changes-requested"),
+
+    /**
+     * A Submission was prepared and then cancelled by the submitter or preparer without being submitted.
+     * No further edits can be made to the Submission.
+     */
+    CANCELLED("cancelled"),
+
+    /**
+     * The submit button has been pressed through the UI.
+     */
+    SUBMITTED("submitted");
+
+    private static final Map<String, EventType> map = new HashMap<>(values().length, 1);
+
+    static {
+        for (EventType s : values()) {
+            map.put(s.value, s);
+        }
+    }
+
+    String value;
+
+    private EventType(String value) {
+        this.value = value;
+    }
+
+    /**
+     * @param eventType event type as string
+     * @return parsed event type
+     */
+    public static EventType of(String eventType) {
+        EventType result = map.get(eventType);
+        if (result == null) {
+            throw new IllegalArgumentException("Invalid Event Type: " + eventType);
+        }
+        return result;
+    }
+
+    /**
+     * @return public value
+     */
+    public String getValue() {
+        return value;
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/File.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/File.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client.model;
+
+import java.net.URI;
+import java.util.Objects;
+
+import jsonapi.Id;
+import jsonapi.Resource;
+import jsonapi.ToOne;
+
+/**
+ * Files are associated with a Submissions to be used to form Deposits into Repositories
+ *
+ * @author Karen Hanson
+ */
+
+@Resource(type = "file")
+public class File implements PassEntity {
+    /**
+     * Unique id for the resource.
+     */
+    @Id
+    private String id;
+
+    /**
+     * Name of file, defaults to filesystem.name
+     */
+    private String name;
+
+    /**
+     * URI to the bytestream that Deposit services will use to retrieve the bytestream for Deposit
+     */
+    private URI uri;
+
+    /**
+     * Description of file provided by User
+     */
+    private String description;
+
+    /**
+     * Role of the file e.g. manuscript, supplemental
+     */
+    private FileRole fileRole;
+
+    /**
+     * Mime-type of file
+     */
+    private String mimeType;
+
+    /**
+     * The Submission the File is a part of
+     */
+    @ToOne(name = "submission")
+    private Submission submission;
+
+    /**
+     * File constructor
+     */
+    public File() {
+    }
+
+    /**
+     * Copy constructor, this will copy the values of the object provided into the new object
+     *
+     * @param file the file to copy
+     */
+    public File(File file) {
+        this.id = file.id;
+        this.name = file.name;
+        this.uri = file.uri;
+        this.description = file.description;
+        this.fileRole = file.fileRole;
+        this.mimeType = file.mimeType;
+        this.submission = file.submission;
+    }
+
+    /**
+     * Constructor that sets id.
+     *
+     * @param id identifier
+     */
+    public File(String id) {
+        this.id = id;
+    }
+
+    /**
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @param name the name to set
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * @return the uri
+     */
+    public URI getUri() {
+        return uri;
+    }
+
+    /**
+     * @param uri the uri to set
+     */
+    public void setUri(URI uri) {
+        this.uri = uri;
+    }
+
+    /**
+     * @return the description
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * @param description the description to set
+     */
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+     * @return the fileRole
+     */
+    public FileRole getFileRole() {
+        return fileRole;
+    }
+
+    /**
+     * @param fileRole the fileRole to set
+     */
+    public void setFileRole(FileRole fileRole) {
+        this.fileRole = fileRole;
+    }
+
+    /**
+     * @return the mimeType
+     */
+    public String getMimeType() {
+        return mimeType;
+    }
+
+    /**
+     * @param mimeType the mimeType to set
+     */
+    public void setMimeType(String mimeType) {
+        this.mimeType = mimeType;
+    }
+
+    /**
+     * @return the submission
+     */
+    public Submission getSubmission() {
+        return submission;
+    }
+
+    /**
+     * @param submission the submission to set
+     */
+    public void setSubmission(Submission submission) {
+        this.submission = submission;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        File other = (File) obj;
+        return Objects.equals(description, other.description) && fileRole == other.fileRole
+                && Objects.equals(id, other.id) && Objects.equals(mimeType, other.mimeType)
+                && Objects.equals(name, other.name) && Objects.equals(submission, other.submission)
+                && Objects.equals(uri, other.uri);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
+    }
+
+    @Override
+    public String toString() {
+        return "File [id=" + id + ", name=" + name + ", uri=" + uri + ", description=" + description + ", fileRole="
+                + fileRole + ", mimeType=" + mimeType + ", submission=" + submission + "]";
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/FileRole.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/FileRole.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * list of possible File Roles
+ */
+public enum FileRole {
+    /**
+     * Author accepted manuscript
+     */
+    MANUSCRIPT("manuscript"),
+
+    /**
+     * Supplemental material for the Publication
+     */
+    SUPPLEMENTAL("supplemental"),
+
+    /**
+     * An image, data plot, map, or schematic
+     */
+    FIGURE("figure"),
+
+    /**
+     * Tabular data
+     */
+    TABLE("table");
+
+    private static final Map<String, FileRole> map = new HashMap<>(values().length, 1);
+
+    static {
+        for (FileRole r : values()) {
+            map.put(r.value, r);
+        }
+    }
+
+    private String value;
+
+    private FileRole(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Parse file role.
+     *
+     * @param role Role string
+     * @return parsed file role.
+     */
+    public static FileRole of(String role) {
+        FileRole result = map.get(role);
+        if (result == null) {
+            throw new IllegalArgumentException("Invalid File Role: " + role);
+        }
+        return result;
+    }
+
+    /**
+     * @return public value
+     */
+    public String getValue() {
+        return value;
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/Funder.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/Funder.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client.model;
+
+import java.net.URI;
+import java.util.Objects;
+
+import jsonapi.Id;
+import jsonapi.Resource;
+import jsonapi.ToOne;
+
+/**
+ * The funder or sponsor of Grant or award.
+ *
+ * @author Karen Hanson
+ */
+
+@Resource(type = "funder")
+public class Funder implements PassEntity {
+    /**
+     * Unique id for the resource.
+     */
+    @Id
+    private String id;
+
+    /**
+     * Funder name
+     */
+    private String name;
+
+    /**
+     * Funder URL
+     */
+    private URI url;
+
+    /**
+     * The Policy associated with funder
+     */
+    @ToOne(name = "policy")
+    private Policy policy;
+
+    /**
+     * Local key assigned to the funder within the researcher's institution to support matching between
+     * PASS and a local system. In the case of JHU this is the key assigned in COEUS
+     */
+    private String localKey;
+
+    /**
+     * Funder constructor
+     */
+    public Funder() {
+    }
+
+    /**
+     * Copy constructor, this will copy the values of the object provided into the new object
+     *
+     * @param funder the funder to copy
+     */
+    public Funder(Funder funder) {
+        this.id = funder.id;
+        this.name = funder.name;
+        this.url = funder.url;
+        this.policy = funder.policy;
+        this.localKey = funder.localKey;
+    }
+
+    /**
+     * Constructor that sets id.
+     *
+     * @param id identifier to set
+     */
+    public Funder(String id) {
+        this.id = id;
+    }
+
+    /**
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @param name the name to set
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * @return the url
+     */
+    public URI getUrl() {
+        return url;
+    }
+
+    /**
+     * @param url the url to set
+     */
+    public void setUrl(URI url) {
+        this.url = url;
+    }
+
+    /**
+     * @return the the policy
+     */
+    public Policy getPolicy() {
+        return policy;
+    }
+
+    /**
+     * @param policy the policy to set
+     */
+    public void setPolicy(Policy policy) {
+        this.policy = policy;
+    }
+
+    /**
+     * @return the localKey
+     */
+    public String getLocalKey() {
+        return localKey;
+    }
+
+    /**
+     * @param localKey the localKey to set
+     */
+    public void setLocalKey(String localKey) {
+        this.localKey = localKey;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public String toString() {
+        return "Funder [id=" + id + ", name=" + name + ", url=" + url + ", policy=" + policy + ", localKey=" + localKey
+                + "]";
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        Funder other = (Funder) obj;
+        return Objects.equals(id, other.id) && Objects.equals(localKey, other.localKey)
+                && Objects.equals(name, other.name) && Objects.equals(policy, other.policy)
+                && Objects.equals(url, other.url);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, localKey);
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/Grant.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/Grant.java
@@ -1,0 +1,341 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client.model;
+
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import jsonapi.Id;
+import jsonapi.Resource;
+import jsonapi.ToMany;
+import jsonapi.ToOne;
+
+/**
+ * Grant model for the PASS system
+ *
+ * @author Karen Hanson
+ */
+
+@Resource(type = "grant")
+public class Grant implements PassEntity {
+    /**
+     * Unique id for the resource.
+     */
+    @Id
+    private String id;
+
+    /**
+     * Award number from funder
+     */
+    private String awardNumber;
+
+    /**
+     * Status of award
+     */
+    private AwardStatus awardStatus;
+
+    /**
+     * A local key assigned to the Grant within the researcher's institution to
+     * support matching between PASS and a local system. In the case of JHU this is
+     * the key assigned by COEUS
+     */
+    private String localKey;
+
+    /**
+     * Title of the research project
+     */
+    private String projectName;
+
+    /**
+     * The funder.id of the sponsor that is the original source of the funds
+     */
+    @ToOne(name = "primaryFunder")
+    private Funder primaryFunder;
+
+    /**
+     * The funder.id of the organization from which funds are directly received
+     */
+    @ToOne(name = "directFunder")
+    private Funder directFunder;
+
+    /**
+     * The User who is the Principal investigator
+     */
+    @ToOne(name = "pi")
+    private User pi;
+
+    /**
+     * List of User who are the co-principal investigators
+     */
+    @ToMany(name = "coPis")
+    private List<User> coPis = new ArrayList<>();
+
+    /**
+     * Date the grant was awarded
+     */
+    private ZonedDateTime awardDate;
+
+    /**
+     * Date the grant started
+     */
+    private ZonedDateTime startDate;
+
+    /**
+     * Date the grant ended
+     */
+    private ZonedDateTime endDate;
+
+    /**
+     * Grant constructor
+     */
+    public Grant() {
+    }
+
+    /**
+     * Constructor that sets id.
+     *
+     * @param id identifier to set
+     */
+    public Grant(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Copy constructor, this will copy the values of the object provided into the
+     * new object
+     *
+     * @param grant the grant to copy
+     */
+    public Grant(Grant grant) {
+        this.id = grant.id;
+        this.awardNumber = grant.awardNumber;
+        this.awardStatus = grant.awardStatus;
+        this.localKey = grant.localKey;
+        this.projectName = grant.projectName;
+        this.primaryFunder = grant.primaryFunder;
+        this.directFunder = grant.directFunder;
+        this.pi = grant.pi;
+        this.coPis = new ArrayList<User>(grant.coPis);
+        this.awardDate = grant.awardDate;
+        this.startDate = grant.startDate;
+        this.endDate = grant.endDate;
+    }
+
+    /**
+     * @return the awardNumber
+     */
+    public String getAwardNumber() {
+        return awardNumber;
+    }
+
+    /**
+     * @param awardNumber the awardNumber to set
+     */
+    public void setAwardNumber(String awardNumber) {
+        this.awardNumber = awardNumber;
+    }
+
+    /**
+     * @return the awardStatus
+     */
+    public AwardStatus getAwardStatus() {
+        return awardStatus;
+    }
+
+    /**
+     * @param awardStatus the awardStatus to set
+     */
+    public void setAwardStatus(AwardStatus awardStatus) {
+        this.awardStatus = awardStatus;
+    }
+
+    /**
+     * @return the localKey
+     */
+    public String getLocalKey() {
+        return localKey;
+    }
+
+    /**
+     * @param localKey the localKey to set
+     */
+    public void setLocalKey(String localKey) {
+        this.localKey = localKey;
+    }
+
+    /**
+     * @return the projectName
+     */
+    public String getProjectName() {
+        return projectName;
+    }
+
+    /**
+     * @param projectName the projectName to set
+     */
+    public void setProjectName(String projectName) {
+        this.projectName = projectName;
+    }
+
+    /**
+     * @return the primaryFunder
+     */
+    public Funder getPrimaryFunder() {
+        return primaryFunder;
+    }
+
+    /**
+     * @param primaryFunder the primaryFunder to set
+     */
+    public void setPrimaryFunder(Funder primaryFunder) {
+        this.primaryFunder = primaryFunder;
+    }
+
+    /**
+     * @return the directFunder
+     */
+    public Funder getDirectFunder() {
+        return directFunder;
+    }
+
+    /**
+     * @param directFunder the directFunder to set
+     */
+    public void setDirectFunder(Funder directFunder) {
+        this.directFunder = directFunder;
+    }
+
+    /**
+     * @return the pi
+     */
+    public User getPi() {
+        return pi;
+    }
+
+    /**
+     * @param pi the pi to set
+     */
+    public void setPi(User pi) {
+        this.pi = pi;
+    }
+
+    /**
+     * @return the coPis
+     */
+    public List<User> getCoPis() {
+        return coPis;
+    }
+
+    /**
+     * @param coPis the coPis to set
+     */
+    public void setCoPis(List<User> coPis) {
+        this.coPis = coPis;
+    }
+
+    /**
+     * @return the awardDate
+     */
+    public ZonedDateTime getAwardDate() {
+        return awardDate;
+    }
+
+    /**
+     * @param awardDate the awardDate to set
+     */
+    public void setAwardDate(ZonedDateTime awardDate) {
+        this.awardDate = awardDate;
+    }
+
+    /**
+     * @return the startDate
+     */
+    public ZonedDateTime getStartDate() {
+        return startDate;
+    }
+
+    /**
+     * @param startDate the startDate to set
+     */
+    public void setStartDate(ZonedDateTime startDate) {
+        this.startDate = startDate;
+    }
+
+    /**
+     * @return the endDate
+     */
+    public ZonedDateTime getEndDate() {
+        return endDate;
+    }
+
+    /**
+     * @param endDate the endDate to set
+     */
+    public void setEndDate(ZonedDateTime endDate) {
+        this.endDate = endDate;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public String toString() {
+        return "Grant [id=" + id + ", awardNumber=" + awardNumber + ", awardStatus=" + awardStatus + ", localKey="
+                + localKey + ", projectName=" + projectName + ", primaryFunder=" + primaryFunder + ", directFunder="
+                + directFunder + ", pi=" + pi + ", coPis=" + coPis + ", awardDate=" + awardDate + ", startDate="
+                + startDate + ", endDate=" + endDate + "]";
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        Grant other = (Grant) obj;
+
+        return Objects.equals(awardDate == null ? null : awardDate.toInstant(),
+                other.awardDate == null ? null : other.awardDate.toInstant())
+                && Objects.equals(awardNumber, other.awardNumber) && awardStatus == other.awardStatus
+                && Objects.equals(coPis, other.coPis) && Objects.equals(directFunder, other.directFunder)
+                && Objects.equals(endDate == null ? null : endDate.toInstant(),
+                        other.endDate == null ? null : other.endDate.toInstant())
+                && Objects.equals(id, other.id) && Objects.equals(localKey, other.localKey)
+                && Objects.equals(pi, other.pi) && Objects.equals(primaryFunder, other.primaryFunder)
+                && Objects.equals(projectName, other.projectName)
+                && Objects.equals(startDate == null ? null : startDate.toInstant(),
+                        other.startDate == null ? null : other.startDate.toInstant());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, awardNumber);
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/IntegrationType.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/IntegrationType.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Possible deposit statuses. Note that some repositories may not go through every status.
+ */
+public enum IntegrationType {
+    /**
+     * PASS can make Deposits to this Repository, and will received updates about its status
+     */
+    FULL("full"),
+    /**
+     * PASS can make Deposits to this Repository but will not automatically receive updates about its status
+     */
+    ONE_WAY("one-way"),
+    /**
+     * A deposit cannot automatically be made to this Repository from PASS, only a web link can be created.
+     */
+    WEB_LINK("web-link");
+
+    private static final Map<String, IntegrationType> map = new HashMap<>(values().length, 1);
+
+    static {
+        for (IntegrationType d : values()) {
+            map.put(d.value, d);
+        }
+    }
+
+    private String value;
+
+    private IntegrationType(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Parse the integration type.
+     *
+     * @param integrationType String serialized integration type
+     * @return parsed integration type.
+     */
+    public static IntegrationType of(String integrationType) {
+        IntegrationType result = map.get(integrationType);
+        if (result == null) {
+            throw new IllegalArgumentException("Invalid Integration Type: " + integrationType);
+        }
+        return result;
+    }
+
+    /**
+     * @return public value
+     */
+    public String getValue() {
+        return value;
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/Journal.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/Journal.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import jsonapi.Id;
+import jsonapi.Resource;
+import jsonapi.ToOne;
+
+/**
+ * Describes a Journal and the path of it's participation in PubMedCentral
+ *
+ * @author Karen Hanson
+ */
+
+@Resource(type = "journal")
+public class Journal implements PassEntity {
+    /**
+     * Unique id for the resource.
+     */
+    @Id
+    private String id;
+
+    /**
+     * Name of journal
+     */
+    private String journalName;
+
+    /**
+     * Array of ISSN(s) for Journal
+     */
+    private List<String> issns = new ArrayList<>();
+
+    /**
+     * The publisher
+     */
+    @ToOne(name = "publisher")
+    private Publisher publisher;
+
+    /**
+     * National Library of Medicine Title Abbreviation
+     */
+    private String nlmta;
+
+    /**
+     * This field indicates whether a journal participates in the NIH Public Access Program by sending final
+     * published article to PMC. If so, whether it requires additional processing fee.
+     */
+    private PmcParticipation pmcParticipation;
+
+    /**
+     * Journal constructor
+     */
+    public Journal() {
+    }
+
+    /**
+     * Constructor that sets id.
+     *
+     * @param id identifier to set
+     */
+    public Journal(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Copy constructor, this will copy the values of the object provided into the new object
+     *
+     * @param journal the journal to copy
+     */
+    public Journal(Journal journal) {
+        this.id = journal.id;
+        this.journalName = journal.journalName;
+        this.issns = new ArrayList<String>(journal.issns);
+        this.publisher = journal.publisher;
+        this.nlmta = journal.nlmta;
+        this.pmcParticipation = journal.pmcParticipation;
+    }
+
+    /**
+     * @return the journalName
+     */
+    public String getJournalName() {
+        return journalName;
+    }
+
+    /**
+     * @param journalName the journalName to set
+     */
+    public void setJournalName(String journalName) {
+        this.journalName = journalName;
+    }
+
+    /**
+     * @return the issns
+     */
+    public List<String> getIssns() {
+        return issns;
+    }
+
+    /**
+     * @param issn the issn list to set
+     */
+    public void setIssns(List<String> issn) {
+        this.issns = issn;
+    }
+
+    /**
+     * @return the publisher ID
+     */
+    public Publisher getPublisher() {
+        return publisher;
+    }
+
+    /**
+     * @param publisher the publisher to set
+     */
+    public void setPublisher(Publisher publisher) {
+        this.publisher = publisher;
+    }
+
+    /**
+     * @return the nlmta
+     */
+    public String getNlmta() {
+        return nlmta;
+    }
+
+    /**
+     * @param nlmta the nlmta to set
+     */
+    public void setNlmta(String nlmta) {
+        this.nlmta = nlmta;
+    }
+
+    /**
+     * @return the pmcParticipation
+     */
+    public PmcParticipation getPmcParticipation() {
+        return pmcParticipation;
+    }
+
+    /**
+     * @param pmcParticipation the pmcParticipation to set
+     */
+    public void setPmcParticipation(PmcParticipation pmcParticipation) {
+        this.pmcParticipation = pmcParticipation;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        Journal other = (Journal) obj;
+        return Objects.equals(id, other.id) && Objects.equals(issns, other.issns)
+                && Objects.equals(journalName, other.journalName) && Objects.equals(nlmta, other.nlmta)
+                && pmcParticipation == other.pmcParticipation && Objects.equals(publisher, other.publisher);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, journalName);
+    }
+
+    @Override
+    public String toString() {
+        return "Journal [id=" + id + ", journalName=" + journalName + ", issns=" + issns + ", publisher=" + publisher
+                + ", nlmta=" + nlmta + ", pmcParticipation=" + pmcParticipation + "]";
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/PassEntity.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/PassEntity.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client.model;
+
+/**
+ * Abstract method that all PASS model entities inherit from. All entities can include
+ * a unique ID, type, and context
+ *
+ * @author Karen Hanson
+ */
+
+public interface PassEntity {
+    /**
+     * Retrieves the unique URI representing the resource.
+     *
+     * @return the id
+     */
+    public String getId();
+
+    /**
+     * Sets the unique ID for an object. Note that when creating a new resource, this should be left
+     * blank as the ID will be auto-generated and populated by the repository. When performing a
+     * update, this ID will be used as the target resource.
+     *
+     * @param id the id to set
+     */
+    public void setId(String id);
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/PerformerRole.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/PerformerRole.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client.model;
+
+/**
+ * Roles of agents who might perform a SubmissionEvent
+ */
+public enum PerformerRole {
+    /**
+     * Prepares a submission.
+     */
+    PREPARER("preparer"),
+
+    /**
+     * Performs a submission
+     */
+    SUBMITTER("submitter");
+
+    private String value;
+
+    private PerformerRole(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Parse performer role
+     *
+     * @param s status string
+     * @return parsed role
+     */
+    public static PerformerRole of(String s) {
+        for (PerformerRole r: PerformerRole.values()) {
+            if (r.value.equals(s)) {
+                return r;
+            }
+        }
+
+        throw new IllegalArgumentException("Invalid performer role: " + s);
+    }
+
+    /**
+     * @return public value
+     */
+    public String getValue() {
+        return value;
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/PmcParticipation.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/PmcParticipation.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client.model;
+
+/**
+ * PMC route options. Full documentation here: https://publicaccess.nih.gov/submit_process.htm
+ *
+ * @author Karen Hanson
+ */
+public enum PmcParticipation {
+    /**
+     * PMC deposit route A. Journals automatically post the paper to PMC
+     */
+    A,
+
+    /**
+     * PMC deposit route B. Authors must make special arrangements for some journals and
+     * publishers to post the paper directly to PMC
+     */
+    B,
+
+    /**
+     * PMC deposit route C. Authors or their designee must submit manuscripts to NIHMS
+     */
+    C,
+
+    /**
+     * PMC deposit route D. Some publishers will submit manuscripts to NIHMS
+     */
+    D
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/Policy.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/Policy.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client.model;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import jsonapi.Id;
+import jsonapi.Resource;
+import jsonapi.ToMany;
+
+/**
+ * Describes a Policy. Policies determine the rules that need to be followed by a Submission.
+ *
+ * @author Karen Hanson
+ */
+
+@Resource(type = "policy")
+public class Policy implements PassEntity {
+    /**
+     * Unique id for the resource.
+     */
+    @Id
+    private String id;
+
+    /**
+     * Title of policy e.g. "NIH Public Access Policy"
+     */
+    private String title;
+
+    /**
+     * Several sentence description of policy
+     */
+    private String description;
+
+    /**
+     * A link to the actual policy on the policy-owner's page
+     */
+    private URI policyUrl;
+
+    /**
+     * List of repositories that can satisfying this policy
+     */
+    @ToMany(name = "repositories")
+    private List<Repository> repositories = new ArrayList<>();
+
+    /**
+     * the Institution whose Policy this is (note: if institution has a value, funder should be null)
+     */
+    private URI institution;
+
+    /**
+     * Policy constructor
+     */
+    public Policy() {
+    }
+
+    /**
+     * Constructor that sets id.
+     *
+     * @param id identifier to set
+     */
+    public Policy(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Copy constructor, this will copy the values of the object provided into the new object
+     *
+     * @param policy the policy to copy
+     */
+    public Policy(Policy policy) {
+        this.id = policy.id;
+        this.title = policy.title;
+        this.description = policy.description;
+        this.policyUrl = policy.policyUrl;
+        this.repositories = new ArrayList<Repository>(policy.repositories);
+        this.institution = policy.institution;
+    }
+
+    /**
+     * @return the title
+     */
+    public String getTitle() {
+        return title;
+    }
+
+    /**
+     * @param title the title to set
+     */
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    /**
+     * @return the description
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * @param description the description to set
+     */
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+     * @return the policy URL
+     */
+    public URI getPolicyUrl() {
+        return policyUrl;
+    }
+
+    /**
+     * @param policyUrl the policyUrl to set
+     */
+    public void setPolicyUrl(URI policyUrl) {
+        this.policyUrl = policyUrl;
+    }
+
+    /**
+     * @return the institution
+     */
+    public URI getInstitution() {
+        return institution;
+    }
+
+    /**
+     * @param institution the institution to set
+     */
+    public void setInstitution(URI institution) {
+        this.institution = institution;
+    }
+
+    /**
+     * @return the list of repositories
+     */
+    public List<Repository> getRepositories() {
+        return repositories;
+    }
+
+    /**
+     * @param repositories list repositories to set
+     */
+    public void setRepositories(List<Repository> repositories) {
+        this.repositories = repositories;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        Policy other = (Policy) obj;
+        return Objects.equals(description, other.description) && Objects.equals(id, other.id)
+                && Objects.equals(institution, other.institution) && Objects.equals(policyUrl, other.policyUrl)
+                && Objects.equals(repositories, other.repositories) && Objects.equals(title, other.title);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, title);
+    }
+
+    @Override
+    public String toString() {
+        return "Policy [id=" + id + ", title=" + title + ", description=" + description + ", policyUrl=" + policyUrl
+                + ", repositories=" + repositories + ", institution=" + institution + "]";
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/Publication.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/Publication.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client.model;
+
+import java.util.Objects;
+
+import jsonapi.Id;
+import jsonapi.Resource;
+import jsonapi.ToOne;
+
+/**
+ * Publication model. Contains details of work being submitted, where it is being deposited to, related Grants etc.
+ *
+ * @author Karen Hanson
+ */
+
+@Resource(type = "publication")
+public class Publication implements PassEntity {
+    /**
+     * Unique id for the resource.
+     */
+    @Id
+    private String id;
+
+    /**
+     * Title of publication
+     */
+    private String title;
+
+    /**
+     * Abstract of the publication
+     */
+    private String publicationAbstract;
+
+    /**
+     * DOI of the publication
+     */
+    private String doi;
+
+    /**
+     * PMID of the publication
+     */
+    private String pmid;
+
+    /**
+     * The journal the publication is part of (if article)
+     */
+    @ToOne(name = "journal")
+    private Journal journal;
+
+    /**
+     * Volume of journal that contains the publication (if article)
+     */
+    private String volume;
+
+    /**
+     * Issue of journal that contains the publication (if article)
+     */
+    private String issue;
+
+    /**
+     * Publication constructor
+     */
+    public Publication() {
+    }
+
+    /**
+     * Constructor that sets id.
+     *
+     * @param id identifier to set
+     */
+    public Publication(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Copy constructor, this will copy the values of the object provided into the new object
+     *
+     * @param publication the publication to copy
+     */
+    public Publication(Publication publication) {
+        this.id = publication.id;
+        this.title = publication.title;
+        this.publicationAbstract = publication.publicationAbstract;
+        this.doi = publication.doi;
+        this.pmid = publication.pmid;
+        this.journal = publication.journal;
+        this.volume = publication.volume;
+        this.issue = publication.issue;
+    }
+
+    /**
+     * @return the title
+     */
+    public String getTitle() {
+        return title;
+    }
+
+    /**
+     * @param title the title to set
+     */
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    /**
+     * @return the publication abstract
+     */
+    public String getPublicationAbstract() {
+        return publicationAbstract;
+    }
+
+    /**
+     * @param publicationAbstract the publicationAbstract to set
+     */
+    public void setPublicationAbstract(String publicationAbstract) {
+        this.publicationAbstract = publicationAbstract;
+    }
+
+    /**
+     * @return the doi
+     */
+    public String getDoi() {
+        return doi;
+    }
+
+    /**
+     * @param doi the doi to set
+     */
+    public void setDoi(String doi) {
+        this.doi = doi;
+    }
+
+    /**
+     * @return the pmid
+     */
+    public String getPmid() {
+        return pmid;
+    }
+
+    /**
+     * @param pmid the pmid to set
+     */
+    public void setPmid(String pmid) {
+        this.pmid = pmid;
+    }
+
+    /**
+     * @return the Journal
+     */
+    public Journal getJournal() {
+        return journal;
+    }
+
+    /**
+     * @param journal the journal to set
+     */
+    public void setJournal(Journal journal) {
+        this.journal = journal;
+    }
+
+    /**
+     * @return the volume
+     */
+    public String getVolume() {
+        return volume;
+    }
+
+    /**
+     * @param volume the volume to set
+     */
+    public void setVolume(String volume) {
+        this.volume = volume;
+    }
+
+    /**
+     * @return the issue
+     */
+    public String getIssue() {
+        return issue;
+    }
+
+    /**
+     * @param issue the issue to set
+     */
+    public void setIssue(String issue) {
+        this.issue = issue;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        Publication other = (Publication) obj;
+        return Objects.equals(doi, other.doi) && Objects.equals(id, other.id) && Objects.equals(issue, other.issue)
+                && Objects.equals(journal, other.journal) && Objects.equals(pmid, other.pmid)
+                && Objects.equals(publicationAbstract, other.publicationAbstract) && Objects.equals(title, other.title)
+                && Objects.equals(volume, other.volume);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, title);
+    }
+
+    @Override
+    public String toString() {
+        return "Publication [id=" + id + ", title=" + title + ", publicationAbstract=" + publicationAbstract + ", doi="
+                + doi + ", pmid=" + pmid + ", journal=" + journal + ", volume=" + volume + ", issue=" + issue + "]";
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/Publisher.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/Publisher.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.pass.support.client.model;
+
+import java.util.Objects;
+
+import jsonapi.Id;
+import jsonapi.Resource;
+
+/**
+ * Describes a Publisher and its related Journals, also the path of it's participation in PubMedCentral
+ *
+ * @author Karen Hanson
+ */
+
+@Resource(type = "publisher")
+public class Publisher implements PassEntity {
+    /**
+     * Unique id for the resource.
+     */
+    @Id
+    private String id;
+
+    /**
+     * Name of publisher
+     */
+    private String name;
+
+    /**
+     * This field indicates whether a journal participates in the NIH Public Access Program by sending final
+     * published article to PMC. If so, whether it requires additional processing fee.
+     */
+    private PmcParticipation pmcParticipation;
+
+    /**
+     * Publisher constructor
+     */
+    public Publisher() {
+    }
+
+    /**
+     * Constructor that sets id.
+     *
+     * @param id identifier to set
+     */
+    public Publisher(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Copy constructor, this will copy the values of the object provided into the new object
+     *
+     * @param publisher the publisher to copy
+     */
+    public Publisher(Publisher publisher) {
+        this.id = publisher.id;
+        this.name = publisher.name;
+        this.pmcParticipation = publisher.pmcParticipation;
+    }
+
+    /**
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @param name the name to set
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * @return the pmcParticipation
+     */
+    public PmcParticipation getPmcParticipation() {
+        return pmcParticipation;
+    }
+
+    /**
+     * @param pmcParticipation the pmcParticipation to set
+     */
+    public void setPmcParticipation(PmcParticipation pmcParticipation) {
+        this.pmcParticipation = pmcParticipation;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        Publisher other = (Publisher) obj;
+        return Objects.equals(id, other.id) && Objects.equals(name, other.name)
+                && pmcParticipation == other.pmcParticipation;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
+    }
+
+    @Override
+    public String toString() {
+        return "Publisher [id=" + id + ", name=" + name + ", pmcParticipation=" + pmcParticipation + "]";
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/Repository.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/Repository.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client.model;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import jsonapi.Id;
+import jsonapi.Resource;
+
+/**
+ * Describes a Repository. A Repository is the target of a Deposit.
+ *
+ * @author Karen Hanson
+ */
+
+@Resource(type = "repository")
+public class Repository implements PassEntity {
+    /**
+     * Unique id for the resource.
+     */
+    @Id
+    private String id;
+
+    /**
+     * Name of repository e.g. "PubMed Central"
+     */
+    private String name;
+
+    /**
+     * Several sentence description of repository
+     */
+    private String description;
+
+    /**
+     * URL to the homepage of the repository so that PASS users can view the platform before deciding whether to
+     * participate in it
+     */
+    private URI url;
+
+    /**
+     * The legal text that a submitter must agree to in order to submit a publication to this repository
+     */
+    private String agreementText;
+
+    /**
+     * Stringified JSON representing a form template to be loaded by the front-end when this Repository is selected
+     */
+    private String formSchema;
+
+    /**
+     * Type of integration PASS has with the Repository
+     */
+    private IntegrationType integrationType;
+
+    /**
+     * Key that is unique to this {@code Repository} instance.  Used to reference the {@code Repository} when its URI
+     * is not available (e.g. prior to the creation of a {@code Repository} resource in Fedora).
+     */
+    private String repositoryKey;
+
+    /**
+     * URLs that link to JSON schema documents describing the repository's metadata requirements
+     */
+    private List<URI> schemas = new ArrayList<>();
+
+    /**
+     * Repository constructor
+     */
+    public Repository() {
+    }
+
+    /**
+     * Constructor that sets id.
+     *
+     * @param id identifier to set
+     */
+    public Repository(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Copy constructor, this will copy the values of the object provided into the new object
+     *
+     * @param repository the repository to copy
+     */
+    public Repository(Repository repository) {
+        this.id = repository.id;
+        this.name = repository.name;
+        this.description = repository.description;
+        this.url = repository.url;
+        this.agreementText = repository.agreementText;
+        this.formSchema = repository.formSchema;
+        this.integrationType = repository.integrationType;
+        this.repositoryKey = repository.repositoryKey;
+        this.schemas = new ArrayList<>(repository.schemas);
+    }
+
+    /**
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @param name the name to set
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * @return the description
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * @param description the description to set
+     */
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+     * @return the url
+     */
+    public URI getUrl() {
+        return url;
+    }
+
+    /**
+     * @param url the url to set
+     */
+    public void setUrl(URI url) {
+        this.url = url;
+    }
+
+    /**
+     * @return the agreement text
+     */
+    public String getAgreementText() {
+        return agreementText;
+    }
+
+    /**
+     * @param agreementText the agreement text to set
+     */
+    public void setAgreementText(String agreementText) {
+        this.agreementText = agreementText;
+    }
+
+    /**
+     * @return the formSchema
+     */
+    public String getFormSchema() {
+        return formSchema;
+    }
+
+    /**
+     * @param formSchema the form schema (typically, a stringified JSON blob)
+     */
+    public void setFormSchema(String formSchema) {
+        this.formSchema = formSchema;
+    }
+
+    /**
+     * @return the integrationType
+     */
+    public IntegrationType getIntegrationType() {
+        return integrationType;
+    }
+
+    /**
+     * @param integrationType the integrationType to set
+     */
+    public void setIntegrationType(IntegrationType integrationType) {
+        this.integrationType = integrationType;
+    }
+
+    /**
+     * Key that is unique to this {@code Repository} instance.  Used to look up the {@code Repository} when its URI
+     * is not available (e.g. prior to the creation of a {@code Repository} resource in Fedora).
+     *
+     * @return a String unique to this {@code Repository} within PASS, may be {@code null}
+     */
+    public String getRepositoryKey() {
+        return repositoryKey;
+    }
+
+    /**
+     * Key that is unique to this {@code Repository} instance.  Used to look up the {@code Repository} when its URI
+     * is not available (e.g. prior to the creation of a {@code Repository} resource in Fedora).
+     *
+     * @param repositoryKey a String unique to this {@code Repository} within PASS
+     */
+    public void setRepositoryKey(String repositoryKey) {
+        this.repositoryKey = repositoryKey;
+    }
+
+    /**
+     * @return URLs that link to JSON schema documents describing the repository's metadata requirements
+     */
+    public List<URI> getSchemas() {
+        return schemas;
+    }
+
+    /**
+     * @param schemas URLs that link to JSON schema documents describing the repository's metadata requirements
+     */
+    public void setSchemas(List<URI> schemas) {
+        this.schemas = schemas;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        Repository other = (Repository) obj;
+        return Objects.equals(agreementText, other.agreementText) && Objects.equals(description, other.description)
+                && Objects.equals(formSchema, other.formSchema) && Objects.equals(id, other.id)
+                && integrationType == other.integrationType && Objects.equals(name, other.name)
+                && Objects.equals(repositoryKey, other.repositoryKey) && Objects.equals(schemas, other.schemas)
+                && Objects.equals(url, other.url);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
+    }
+
+    @Override
+    public String toString() {
+        return "Repository [id=" + id + ", name=" + name + ", description=" + description + ", url=" + url
+                + ", agreementText=" + agreementText + ", formSchema=" + formSchema + ", integrationType="
+                + integrationType + ", repositoryKey=" + repositoryKey + ", schemas=" + schemas + "]";
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/RepositoryCopy.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/RepositoryCopy.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client.model;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import jsonapi.Id;
+import jsonapi.Resource;
+import jsonapi.ToOne;
+
+/**
+ * A Repository Copy represents a copy of a Publication that exists in a target Repository.
+ *
+ * @author Karen Hanson
+ */
+
+@Resource(type = "repositoryCopy")
+public class RepositoryCopy implements PassEntity {
+    /**
+     * Unique id for the resource.
+     */
+    @Id
+    private String id;
+
+    /**
+     * IDs assigned by the repository
+     */
+    private List<String> externalIds = new ArrayList<String>();
+
+    /**
+     * Status of deposit
+     */
+    private CopyStatus copyStatus;
+
+    /**
+     * URL to access the item in the repository
+     */
+    private URI accessUrl;
+
+    /**
+     * the Publication that this Repository Copy is a copy of
+     */
+    @ToOne(name = "publication")
+    private Publication publication;
+
+    /**
+     * the Repository the Copy is in
+     */
+    @ToOne(name = "repository")
+    private Repository repository;
+
+    /**
+     * RepositoryCopy constructor
+     */
+    public RepositoryCopy() {
+    }
+
+    /**
+     * Constructor that sets id.
+     *
+     * @param id identifier to set
+     */
+    public RepositoryCopy(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Copy constructor, this will copy the values of the object provided into the new object
+     *
+     * @param repositoryCopy the repositoryCopy to copy
+     */
+    public RepositoryCopy(RepositoryCopy repositoryCopy) {
+        this.id = repositoryCopy.id;
+        this.externalIds = new ArrayList<String>(repositoryCopy.externalIds);
+        this.copyStatus = repositoryCopy.copyStatus;
+        this.accessUrl = repositoryCopy.accessUrl;
+        this.publication = repositoryCopy.publication;
+        this.repository = repositoryCopy.repository;
+    }
+
+    /**
+     * @return the externalIds
+     */
+    public List<String> getExternalIds() {
+        return externalIds;
+    }
+
+    /**
+     * @param externalIds the externalIds to set
+     */
+    public void setExternalIds(List<String> externalIds) {
+        this.externalIds = externalIds;
+    }
+
+    /**
+     * @return the repository copy status
+     */
+    public CopyStatus getCopyStatus() {
+        return copyStatus;
+    }
+
+    /**
+     * @return the accessUrl
+     */
+    public URI getAccessUrl() {
+        return accessUrl;
+    }
+
+    /**
+     * @param accessUrl the accessUrl to set
+     */
+    public void setAccessUrl(URI accessUrl) {
+        this.accessUrl = accessUrl;
+    }
+
+    /**
+     * @param copyStatus The repository's status to set
+     */
+    public void setCopyStatus(CopyStatus copyStatus) {
+        this.copyStatus = copyStatus;
+    }
+
+    /**
+     * @return the publication
+     */
+    public Publication getPublication() {
+        return publication;
+    }
+
+    /**
+     * @param publication the publication to set
+     */
+    public void setPublication(Publication publication) {
+        this.publication = publication;
+    }
+
+    /**
+     * @return the repository
+     */
+    public Repository getRepository() {
+        return repository;
+    }
+
+    /**
+     * @param repository the repository to set
+     */
+    public void setRepository(Repository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        RepositoryCopy other = (RepositoryCopy) obj;
+        return Objects.equals(accessUrl, other.accessUrl) && copyStatus == other.copyStatus
+                && Objects.equals(externalIds, other.externalIds) && Objects.equals(id, other.id)
+                && Objects.equals(publication, other.publication) && Objects.equals(repository, other.repository);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, accessUrl);
+    }
+
+    @Override
+    public String toString() {
+        return "RepositoryCopy [id=" + id + ", externalIds=" + externalIds + ", copyStatus=" + copyStatus
+                + ", accessUrl=" + accessUrl + ", publication=" + publication + ", repository=" + repository + "]";
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/Source.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/Source.java
@@ -1,0 +1,46 @@
+package org.eclipse.pass.support.client.model;
+
+/**
+ * Source of the Submission, from a PASS user or imported from another source
+ */
+public enum Source {
+
+    /**
+     * PASS source
+     */
+    PASS("pass"),
+
+    /**
+     * Other source
+     */
+    OTHER("other");
+
+    private String value;
+
+    private Source(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Parse performer role
+     *
+     * @param s status string
+     * @return parsed source
+     */
+    public static Source of(String s) {
+        for (Source o: Source.values()) {
+            if (o.value.equals(s)) {
+                return o;
+            }
+        }
+
+        throw new IllegalArgumentException("Invalid performer role: " + s);
+    }
+
+    /**
+     * @return public value
+     */
+    public String getValue() {
+        return value;
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/Submission.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/Submission.java
@@ -1,0 +1,431 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client.model;
+
+import java.net.URI;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import jsonapi.Id;
+import jsonapi.Resource;
+import jsonapi.ToMany;
+import jsonapi.ToOne;
+
+/**
+ * Submission model. Contains details of work being submitted, where it is being
+ * deposited to, related Grants etc.
+ *
+ * @author Karen Hanson
+ */
+
+@Resource(type = "submission")
+public class Submission implements PassEntity {
+    /**
+     * Unique id for the resource.
+     */
+    @Id
+    private String id;
+
+    /**
+     * Stringified JSON representation of metadata captured by the relevant
+     * repository forms
+     */
+    private String metadata;
+
+    /**
+     * Source of Submission record
+     */
+    private Source source;
+
+    /**
+     * When true, this value signals that the Submission will no longer be edited by
+     * the User. It indicates to Deposit services that it can generate Deposits for
+     * any Repositories that need one.
+     */
+    private Boolean submitted;
+
+    /**
+     * Date the record was submitted by the User through PASS
+     */
+    private ZonedDateTime submittedDate;
+
+    /**
+     * Status of Submission. Focused on informing User of current state of
+     * Submission.
+     */
+    private SubmissionStatus submissionStatus;
+
+    /**
+     * Overall status of Submission's Deposits
+     */
+    private AggregatedDepositStatus aggregatedDepositStatus;
+
+    /**
+     * The Publication associated with the Submission
+     */
+    @ToOne(name = "publication")
+    private Publication publication;
+
+    /**
+     * List of repositories that the submission will be deposited to Note that the
+     * order of the list does not carry any particular significance
+     */
+    @ToMany(name = "repositories")
+    private List<Repository> repositories = new ArrayList<>();
+
+    /**
+     * The User responsible for managing and submitting the Submission.
+     */
+    @ToOne(name = "submitter")
+    private User submitter;
+
+    /**
+     * Name of the submitter. Used with submitterEmail as a temporary store for user
+     * information in the absence of a User record
+     */
+    private String submitterName;
+
+    /**
+     * Email of the submitter as URI e.g. "mailto:j.smith@example.com". Used with
+     * submitterName as a temporary store of user information in the absence of a
+     * User record
+     */
+    private URI submitterEmail;
+
+    /**
+     * The User(s) who prepared, or who could contribute to the preparation of, the
+     * Submission. Prepares can edit the content of the Submission (describe the
+     * Publication, add Grants, add Files, select Repositories) but cannot approve
+     * any Repository agreements or submit the Publication. Note that the order of
+     * the list does not carry any particular significance
+     */
+    @ToMany(name = "preparers")
+    private List<User> preparers = new ArrayList<>();
+
+    /**
+     * List of grants associated with the submission Note that the order of the list
+     * does not carry any particular significance
+     */
+    @ToMany(name = "grants")
+    private List<Grant> grants = new ArrayList<>();
+
+    /**
+     * List of the Policy resources being satisfied upon submission
+     */
+    @ToMany(name = "effectivePolicies")
+    private List<Policy> effectivePolicies = new ArrayList<>();
+
+    /**
+     * Submission constructor
+     */
+    public Submission() {
+    }
+
+    /**
+     * Constructor that sets id.
+     *
+     * @param id identifier to set
+     */
+    public Submission(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Copy constructor, this will copy the values of the object provided into the
+     * new object
+     *
+     * @param submission the submission to copy
+     */
+    public Submission(Submission submission) {
+        this.id = submission.id;
+        this.metadata = submission.metadata;
+        this.source = submission.source;
+        this.submitted = submission.submitted;
+        this.submittedDate = submission.submittedDate;
+        this.submissionStatus = submission.submissionStatus;
+        this.aggregatedDepositStatus = submission.aggregatedDepositStatus;
+        this.publication = submission.publication;
+        this.repositories = new ArrayList<Repository>(submission.repositories);
+        this.submitter = submission.submitter;
+        this.submitterName = submission.submitterName;
+        this.submitterEmail = submission.submitterEmail;
+        this.preparers = new ArrayList<User>(submission.preparers);
+        this.grants = new ArrayList<Grant>(submission.grants);
+        this.effectivePolicies = new ArrayList<>(submission.effectivePolicies);
+    }
+
+    /**
+     * @return the metadata
+     */
+    public String getMetadata() {
+        return metadata;
+    }
+
+    /**
+     * @param metadata the metadata to set
+     */
+    public void setMetadata(String metadata) {
+        this.metadata = metadata;
+    }
+
+    /**
+     * @return the source
+     */
+    public Source getSource() {
+        return source;
+    }
+
+    /**
+     * @param source the source to set
+     */
+    public void setSource(Source source) {
+        this.source = source;
+    }
+
+    /**
+     * @return the submitted
+     */
+    public Boolean calculate() {
+        return submitted;
+    }
+
+    /**
+     * @return Boolean indicating submitted
+     */
+    public Boolean getSubmitted() {
+        return submitted;
+    }
+
+    /**
+     * @param submitted the submitted to set
+     */
+    public void setSubmitted(Boolean submitted) {
+        this.submitted = submitted;
+    }
+
+    /**
+     * @return the submittedDate
+     */
+    public ZonedDateTime getSubmittedDate() {
+        return submittedDate;
+    }
+
+    /**
+     * @param submittedDate the submittedDate to set
+     */
+    public void setSubmittedDate(ZonedDateTime submittedDate) {
+        this.submittedDate = submittedDate;
+    }
+
+    /**
+     * @return the submissionStatus
+     */
+    public SubmissionStatus getSubmissionStatus() {
+        return submissionStatus;
+    }
+
+    /**
+     * @return the aggregatedDepositStatus
+     */
+    public AggregatedDepositStatus getAggregatedDepositStatus() {
+        return aggregatedDepositStatus;
+    }
+
+    /**
+     * @param aggregatedDepositStatus the aggregatedDepositStatus to set
+     */
+    public void setAggregatedDepositStatus(AggregatedDepositStatus aggregatedDepositStatus) {
+        this.aggregatedDepositStatus = aggregatedDepositStatus;
+    }
+
+    /**
+     * @param submissionStatus the submissionStatus to set
+     */
+    public void setSubmissionStatus(SubmissionStatus submissionStatus) {
+        this.submissionStatus = submissionStatus;
+    }
+
+    /**
+     * @return the publication
+     */
+    public Publication getPublication() {
+        return publication;
+    }
+
+    /**
+     * @param publication the publication to set
+     */
+    public void setPublication(Publication publication) {
+        this.publication = publication;
+    }
+
+    /**
+     * @return the repositories
+     */
+    public List<Repository> getRepositories() {
+        return repositories;
+    }
+
+    /**
+     * @param repositories the repositories to set
+     */
+    public void setRepositories(List<Repository> repositories) {
+        this.repositories = repositories;
+    }
+
+    /**
+     * @return the submitter
+     */
+    public User getSubmitter() {
+        return submitter;
+    }
+
+    /**
+     * Set the submitter
+     *
+     * @param submitter the submitter to set
+     */
+    public void setSubmitter(User submitter) {
+        this.submitter = submitter;
+    }
+
+    /**
+     * @return the submitter name
+     */
+    public String getSubmitterName() {
+        return submitterName;
+    }
+
+    /**
+     * Set the submitter name
+     *
+     * @param submitterName the submitter name to set
+     */
+    public void setSubmitterName(String submitterName) {
+        this.submitterName = submitterName;
+    }
+
+    /**
+     * @return the submitter email
+     */
+    public URI getSubmitterEmail() {
+        return submitterEmail;
+    }
+
+    /**
+     * Set the submitter email
+     *
+     * @param submitterEmail the submitter email to set
+     */
+    public void setSubmitterEmail(URI submitterEmail) {
+        this.submitterEmail = submitterEmail;
+    }
+
+    /**
+     * Gets the list of preparers
+     *
+     * @return the preparers
+     */
+    public List<User> getPreparers() {
+        return preparers;
+    }
+
+    /**
+     * @param preparers the preparers to set
+     */
+    public void setPreparers(List<User> preparers) {
+        this.preparers = preparers;
+    }
+
+    /**
+     * @return the grants
+     */
+    public List<Grant> getGrants() {
+        return grants;
+    }
+
+    /**
+     * @param grants the grants to set
+     */
+    public void setGrants(List<Grant> grants) {
+        this.grants = grants;
+    }
+
+    /**
+     * @return the policies being satisfied upon submission
+     */
+    public List<Policy> getEffectivePolicies() {
+        return effectivePolicies;
+    }
+
+    /**
+     * @param effectivePolicies the policies being satisfied upon submission
+     */
+    public void setEffectivePolicies(List<Policy> effectivePolicies) {
+        this.effectivePolicies = effectivePolicies;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        Submission other = (Submission) obj;
+        return aggregatedDepositStatus == other.aggregatedDepositStatus
+                && Objects.equals(effectivePolicies, other.effectivePolicies) && Objects.equals(grants, other.grants)
+                && Objects.equals(id, other.id) && Objects.equals(metadata, other.metadata)
+                && Objects.equals(preparers, other.preparers) && Objects.equals(publication, other.publication)
+                && Objects.equals(repositories, other.repositories) && source == other.source
+                && submissionStatus == other.submissionStatus && Objects.equals(submitted, other.submitted)
+                && Objects.equals(submittedDate == null ? null : submittedDate.toInstant(),
+                        other.submittedDate == null ? null : other.submittedDate.toInstant())
+                && Objects.equals(submitter, other.submitter) && Objects.equals(submitterEmail, other.submitterEmail)
+                && Objects.equals(submitterName, other.submitterName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, metadata, submitterName);
+    }
+
+    @Override
+    public String toString() {
+        return "Submission [id=" + id + ", metadata=" + metadata + ", source=" + source + ", submitted=" + submitted
+                + ", submittedDate=" + submittedDate + ", submissionStatus=" + submissionStatus
+                + ", aggregatedDepositStatus=" + aggregatedDepositStatus + ", publication=" + publication
+                + ", repositories=" + repositories + ", submitter=" + submitter + ", submitterName=" + submitterName
+                + ", submitterEmail=" + submitterEmail + ", preparers=" + preparers + ", grants=" + grants
+                + ", effectivePolicies=" + effectivePolicies + "]";
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/SubmissionEvent.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/SubmissionEvent.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client.model;
+
+import java.net.URI;
+import java.time.ZonedDateTime;
+import java.util.Objects;
+
+import jsonapi.Id;
+import jsonapi.Resource;
+import jsonapi.ToOne;
+
+/**
+ * The SubmissionEvent model captures significant events that are performed by
+ * an agent and occur against a Submission.
+ *
+ * @author Karen Hanson
+ */
+
+@Resource(type = "submissionEvent")
+public class SubmissionEvent implements PassEntity {
+    /**
+     * Unique id for the resource.
+     */
+    @Id
+    private String id;
+
+    /**
+     * The type of event
+     */
+    private EventType eventType;
+
+    /**
+     * Date the event was performed by the User
+     */
+
+    private ZonedDateTime performedDate;
+
+    /**
+     * The User responsible for performing the event
+     */
+    @ToOne(name = "performedBy")
+    private User performedBy;
+
+    /**
+     * Role of the person performing the event
+     */
+    private PerformerRole performerRole;
+
+    /**
+     * Associated submission.
+     */
+    @ToOne(name = "submission")
+    private Submission submission;
+
+    /**
+     * A comment relevant to the SubmissionEvent. For example, when a
+     * `changes-requested` event occurs, this might be added by the User through the
+     * UI to communicate what changes should be made
+     */
+    private String comment;
+
+    /**
+     * A resource relevant to the SubmissionEvent. For example, when a
+     * `changes-requested` event occurs, this may contain an Ember application URL
+     * to the affected Submission.
+     */
+    private URI link;
+
+    /**
+     * SubmissionEvent constructor
+     */
+    public SubmissionEvent() {
+    }
+
+    /**
+     * Constructor that sets id.
+     *
+     * @param id identifier to set
+     */
+    public SubmissionEvent(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Copy constructor, this will copy the values of the object provided into the
+     * new object
+     *
+     * @param submissionEvent the submissionEvent to copy
+     */
+    public SubmissionEvent(SubmissionEvent submissionEvent) {
+        this.id = submissionEvent.id;
+        this.eventType = submissionEvent.eventType;
+        this.performedDate = submissionEvent.performedDate;
+        this.performedBy = submissionEvent.performedBy;
+        this.performerRole = submissionEvent.performerRole;
+        this.submission = submissionEvent.submission;
+        this.comment = submissionEvent.comment;
+        this.link = submissionEvent.link;
+    }
+
+    /**
+     * @return the eventType
+     */
+    public EventType getEventType() {
+        return eventType;
+    }
+
+    /**
+     * @param eventType the eventType to set
+     */
+    public void setEventType(EventType eventType) {
+        this.eventType = eventType;
+    }
+
+    /**
+     * @return the performedDate
+     */
+    public ZonedDateTime getPerformedDate() {
+        return performedDate;
+    }
+
+    /**
+     * @param performedDate the performedDate to set
+     */
+    public void setPerformedDate(ZonedDateTime performedDate) {
+        this.performedDate = performedDate;
+    }
+
+    /**
+     * @return the performedBy
+     */
+    public User getPerformedBy() {
+        return performedBy;
+    }
+
+    /**
+     * @param performedBy the performedBy to set
+     */
+    public void setPerformedBy(User performedBy) {
+        this.performedBy = performedBy;
+    }
+
+    /**
+     * @return the performerRole
+     */
+    public PerformerRole getPerformerRole() {
+        return performerRole;
+    }
+
+    /**
+     * @param performerRole the performerRole to set
+     */
+    public void setPerformerRole(PerformerRole performerRole) {
+        this.performerRole = performerRole;
+    }
+
+    /**
+     * @return the submission
+     */
+    public Submission getSubmission() {
+        return submission;
+    }
+
+    /**
+     * @param submission the submission to set
+     */
+    public void setSubmission(Submission submission) {
+        this.submission = submission;
+    }
+
+    /**
+     * @return the comment
+     */
+    public String getComment() {
+        return comment;
+    }
+
+    /**
+     * @param comment the comment to set
+     */
+    public void setComment(String comment) {
+        this.comment = comment;
+    }
+
+    /**
+     * @return the link
+     */
+    public URI getLink() {
+        return link;
+    }
+
+    /**
+     * @param link the link to set
+     */
+    public void setLink(URI link) {
+        this.link = link;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        SubmissionEvent other = (SubmissionEvent) obj;
+        return Objects.equals(comment, other.comment) && eventType == other.eventType && Objects.equals(id, other.id)
+                && Objects.equals(link, other.link) && Objects.equals(performedBy, other.performedBy)
+                && Objects.equals(performedDate == null ? null : performedDate.toInstant(),
+                        other.performedDate == null ? null : other.performedDate.toInstant())
+                && performerRole == other.performerRole && Objects.equals(submission, other.submission);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(comment, eventType, id, link, performedBy, performedDate, performerRole, submission);
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/SubmissionStatus.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/SubmissionStatus.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * The possible values for the Submission.submissionStatus field.
+ * Note that not all Submissions will go through every status.
+ */
+public enum SubmissionStatus {
+    /**
+     * When the PASS system identifies a need for a User to submit a Publication to a particular Repository,
+     * it will create a new Submission record with this status in order to prompt the User to provide the
+     * document and complete the Submission.
+     */
+    MANUSCRIPT_REQUIRED("manuscript-required", false),
+
+    /**
+     * A Submission was prepared by a preparer but now needs the submitter to approve and submit it or provide
+     * feedback.
+     */
+    APPROVAL_REQUESTED("approval-requested", false),
+
+    /**
+     * A Submission was prepared by a preparer, but on review by the submitter, a change was requested.
+     * The Submission has been handed back to the preparer for editing.
+     */
+    CHANGES_REQUESTED("changes-requested", false),
+
+    /**
+     * A Submission was prepared and then cancelled by the submitter or preparer without being submitted.
+     * No further edits can be made to the Submission.
+     */
+    CANCELLED("cancelled", false),
+
+    /**
+     * The submit button has been pressed through the UI. From this status forward, the Submission
+     * becomes read-only to both the submitter and preparers. This status indicates that either
+     * (a) the Submission is still being processed, or (b) PASS has finished the Deposit process,
+     * but there is not yet confirmation from the Repository that indicates the Submission was valid.
+     * Some Submissions may remain in a submitted state indefinitely depending on PASS's capacity to
+     * verify completion of the process in the target Repository.
+     */
+    SUBMITTED("submitted", true),
+
+    /**
+     * Indicates that a User action may be required outside of PASS. The Submission is stalled or
+     * has been rejected by one or more Repository
+     */
+    NEEDS_ATTENTION("needs-attention", true),
+
+    /**
+     * The target repositories have all received a copy of the Submission, and have indicated that
+     * the Submission was successful.
+     */
+    COMPLETE("complete", true),
+
+    /**
+     * Submissions newly created by the UI will have this status.  Submissions with this status have not yet
+     * been submitted.
+     */
+    DRAFT("draft", false);
+
+    private static final Map<String, SubmissionStatus> map = new HashMap<>(values().length, 1);
+
+    static {
+        for (SubmissionStatus s : values()) {
+            map.put(s.value, s);
+        }
+    }
+
+    private String value;
+
+    private boolean submitted;
+
+    private SubmissionStatus(String value, boolean submitted) {
+        this.value = value;
+        this.submitted = submitted;
+    }
+
+    /**
+     * Parse the submission status.
+     *
+     * @param status Serialized submission status string
+     * @return The submission status
+     */
+    public static SubmissionStatus of(String status) {
+        SubmissionStatus result = map.get(status);
+        if (result == null) {
+            throw new IllegalArgumentException("Invalid Submission Status: " + status);
+        }
+        return result;
+    }
+
+    /**
+     * @return public value
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Determine if submitted.
+     *
+     * @return True if submitted.
+     */
+    public boolean isSubmitted() {
+        return submitted;
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/User.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/User.java
@@ -1,0 +1,311 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client.model;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import jsonapi.Id;
+import jsonapi.Resource;
+
+/**
+ * User model for users logging into PASS
+ *
+ * @author Karen Hanson
+ */
+
+@Resource(type = "user")
+public class User implements PassEntity {
+    /**
+     * Unique id for the resource.
+     */
+    @Id
+    private String id;
+
+    /**
+     * Unique login name used by user
+     */
+    private String username;
+
+    /**
+     * First name(s) of User
+     */
+    private String firstName;
+
+    /**
+     * Middle name(s) of User
+     */
+    private String middleName;
+
+    /**
+     * Last name(s) of User
+     */
+    private String lastName;
+
+    /**
+     * Name for display. Separate names may not be available, but a person should always at least
+     * have a display name.
+     */
+    private String displayName;
+
+    /**
+     * Contact email for User
+     */
+    private String email;
+
+    /**
+     * Affiliation string for person. Where Person is embedded in Submission or Grant,
+     * this is the affiliation relevant to that item
+     */
+    private Set<String> affiliation = new HashSet<>();
+
+    /**
+     * A list of ids associated with the user by various system that PASS interacts with.
+     * The value of each entry would be in the form of : {@code domain:type:value}.
+     * For example, @{code ["johnshopkins.edu:hopkinsid:DRA2D", "johnshopkins.edu:employeeid:12345",
+     * "johnshopkins.edu:jhed:bostaur1"]}
+     */
+    private List<String> locatorIds = new ArrayList<String>();
+
+    /**
+     * ORCID ID for User
+     */
+    private String orcidId;
+
+    /**
+     * User's system roles in PASS
+     */
+    private List<UserRole> roles = new ArrayList<UserRole>();
+
+    /**
+     * User constructor
+     */
+    public User() {
+    }
+
+    /**
+     * Copy constructor, this will copy the values of the object provided into the new object
+     *
+     * @param user the user to copy
+     */
+    public User(User user) {
+        this.id = user.id;
+        this.username = user.username;
+        this.firstName = user.firstName;
+        this.middleName = user.middleName;
+        this.lastName = user.lastName;
+        this.displayName = user.displayName;
+        this.email = user.email;
+        this.affiliation = new HashSet<>(user.affiliation);
+        this.locatorIds = new ArrayList<String>(user.locatorIds);
+        this.orcidId = user.orcidId;
+        this.roles = new ArrayList<UserRole>(user.roles);
+    }
+
+    /**
+     * Constructor that sets id.
+     *
+     * @param id identifier to set
+     */
+    public User(String id) {
+        this.id = id;
+    }
+
+    /**
+     * @return the username
+     */
+    public String getUsername() {
+        return username;
+    }
+
+    /**
+     * @param username the username to set
+     */
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    /**
+     * @return the firstName
+     */
+    public String getFirstName() {
+        return firstName;
+    }
+
+    /**
+     * @param firstName the firstName to set
+     */
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    /**
+     * @return the middleName
+     */
+    public String getMiddleName() {
+        return middleName;
+    }
+
+    /**
+     * @param middleName the middleName to set
+     */
+    public void setMiddleName(String middleName) {
+        this.middleName = middleName;
+    }
+
+    /**
+     * @return the lastName
+     */
+    public String getLastName() {
+        return lastName;
+    }
+
+    /**
+     * @param lastName the lastName to set
+     */
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    /**
+     * @return the displayName
+     */
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    /**
+     * @param displayName the displayName to set
+     */
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    /**
+     * @return the email
+     */
+    public String getEmail() {
+        return email;
+    }
+
+    /**
+     * @param email the email to set
+     */
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    /**
+     * @return the affiliation
+     */
+    public Set<String> getAffiliation() {
+        return affiliation;
+    }
+
+    /**
+     * @param affiliation the affiliation to set
+     */
+    public void setAffiliation(Set<String> affiliation) {
+        this.affiliation = affiliation;
+    }
+
+    /**
+     * @return the locatorIds
+     */
+    public List<String> getLocatorIds() {
+        return locatorIds;
+    }
+
+    /**
+     * @param locatorIds List of locator IDs
+     */
+    public void setLocatorIds(List<String> locatorIds) {
+        this.locatorIds = locatorIds;
+    }
+
+    /**
+     * @return the orcidId
+     */
+    public String getOrcidId() {
+        return orcidId;
+    }
+
+    /**
+     * @param orcidId the orcidId to set
+     */
+    public void setOrcidId(String orcidId) {
+        this.orcidId = orcidId;
+    }
+
+    /**
+     * @return the list of roles
+     */
+    public List<UserRole> getRoles() {
+        return roles;
+    }
+
+    /**
+     * @param roles the roles list to set
+     */
+    public void setRoles(List<UserRole> roles) {
+        this.roles = roles;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public String toString() {
+        return "User [id=" + id + ", username=" + username + ", firstName=" + firstName + ", middleName=" + middleName
+                + ", lastName=" + lastName + ", displayName=" + displayName + ", email=" + email + ", affiliation="
+                + affiliation + ", locatorIds=" + locatorIds + ", orcidId=" + orcidId + ", roles=" + roles + "]";
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        User other = (User) obj;
+        return Objects.equals(affiliation, other.affiliation) && Objects.equals(displayName, other.displayName)
+                && Objects.equals(email, other.email) && Objects.equals(firstName, other.firstName)
+                && Objects.equals(id, other.id) && Objects.equals(lastName, other.lastName)
+                && Objects.equals(locatorIds, other.locatorIds) && Objects.equals(middleName, other.middleName)
+                && Objects.equals(orcidId, other.orcidId) && Objects.equals(roles, other.roles)
+                && Objects.equals(username, other.username);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, username, email);
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/UserRole.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/UserRole.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * list of possible user Roles
+ */
+public enum UserRole {
+
+    /**
+     * Grant admin role
+     */
+    ADMIN("admin"),
+
+    /**
+     * Submitter role
+     */
+    SUBMITTER("submitter");
+
+    private static final Map<String, UserRole> map = new HashMap<>(values().length, 1);
+
+    static {
+        for (UserRole r : values()) {
+            map.put(r.value, r);
+        }
+    }
+
+    private String value;
+
+    private UserRole(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Parse the role.
+     *
+     * @param role Serialized role
+     * @return parsed role.
+     */
+    public static UserRole of(String role) {
+        UserRole result = map.get(role);
+        if (result == null) {
+            throw new IllegalArgumentException("Invalid Role: " + role);
+        }
+        return result;
+    }
+
+    /**
+     * @return public value
+     */
+    public String getValue() {
+        return value;
+    }
+}

--- a/pass-data-client/src/test/java/org/eclipse/pass/support/client/JsonApiPassClientIT.java
+++ b/pass-data-client/src/test/java/org/eclipse/pass/support/client/JsonApiPassClientIT.java
@@ -1,0 +1,415 @@
+package org.eclipse.pass.support.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+import java.net.URI;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.eclipse.pass.support.client.model.AggregatedDepositStatus;
+import org.eclipse.pass.support.client.model.AwardStatus;
+import org.eclipse.pass.support.client.model.Contributor;
+import org.eclipse.pass.support.client.model.ContributorRole;
+import org.eclipse.pass.support.client.model.CopyStatus;
+import org.eclipse.pass.support.client.model.Deposit;
+import org.eclipse.pass.support.client.model.DepositStatus;
+import org.eclipse.pass.support.client.model.EventType;
+import org.eclipse.pass.support.client.model.File;
+import org.eclipse.pass.support.client.model.FileRole;
+import org.eclipse.pass.support.client.model.Funder;
+import org.eclipse.pass.support.client.model.Grant;
+import org.eclipse.pass.support.client.model.IntegrationType;
+import org.eclipse.pass.support.client.model.Journal;
+import org.eclipse.pass.support.client.model.PassEntity;
+import org.eclipse.pass.support.client.model.PerformerRole;
+import org.eclipse.pass.support.client.model.PmcParticipation;
+import org.eclipse.pass.support.client.model.Policy;
+import org.eclipse.pass.support.client.model.Publication;
+import org.eclipse.pass.support.client.model.Publisher;
+import org.eclipse.pass.support.client.model.Repository;
+import org.eclipse.pass.support.client.model.RepositoryCopy;
+import org.eclipse.pass.support.client.model.Source;
+import org.eclipse.pass.support.client.model.Submission;
+import org.eclipse.pass.support.client.model.SubmissionEvent;
+import org.eclipse.pass.support.client.model.User;
+import org.eclipse.pass.support.client.model.UserRole;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class JsonApiPassClientIT {
+    private static PassClient client;
+
+    @BeforeAll
+    private static void setup() {
+        String base_url = System.getProperty("pass.core.url", "http://localhost:8080");
+        client = new JsonApiPassClient(base_url);
+    }
+
+    @Test
+    public void testCreateSimpleObject() throws IOException {
+        Publication pub = new Publication();
+        pub.setIssue("issue");
+        pub.setPmid("pmid");
+
+        client.createObject(pub);
+
+        assertNotNull(pub.getId());
+
+        Publication test = client.getObject(pub);
+
+        assertEquals(pub, test);
+    }
+
+    @Test
+    public void testCreateGetObject() throws IOException {
+        User pi = new User();
+        pi.setDisplayName("Bessie Cow");
+        pi.setRoles(Arrays.asList(UserRole.ADMIN));
+
+        client.createObject(pi);
+
+        List<User> copis = new ArrayList<>();
+
+        for (String name : Arrays.asList("Jessie Farmhand", "Cassie Farmhand")) {
+            User user = new User();
+            user.setDisplayName(name);
+            user.setRoles(Arrays.asList(UserRole.SUBMITTER));
+
+            client.createObject(user);
+            copis.add(user);
+        }
+
+        Funder funder = new Funder();
+        funder.setName("Farmer Bob");
+
+        client.createObject(funder);
+
+        Grant grant = new Grant();
+
+        grant.setAwardNumber("award");
+        grant.setLocalKey("localkey");
+        grant.setAwardDate(dt("2014-03-28T00:00:00.000Z"));
+        grant.setStartDate(dt("2016-01-10T02:12:13.040Z"));
+        grant.setDirectFunder(funder);
+        grant.setPi(pi);
+        grant.setCoPis(copis);
+
+        client.createObject(grant);
+
+        // Get the grant with the relationship target objects included
+        Grant test = client.getObject(grant, "directFunder", "pi", "coPis");
+
+        assertEquals(grant, test);
+
+        // Get the grant without the relationship target objects included
+        test = client.getObject(grant);
+
+        // Relationship targets should just have id
+        grant.setDirectFunder(new Funder(funder.getId()));
+        grant.setPi(new User(pi.getId()));
+        grant.setCoPis(copis.stream().map(u -> new User(u.getId())).collect(Collectors.toList()));
+
+        assertEquals(grant, test);
+
+        // Get the grant with one relationship, other relationship targets should just
+        // have id
+        test = client.getObject(grant, "directFunder");
+
+        grant.setDirectFunder(funder);
+
+        assertEquals(grant, test);
+    }
+
+    @Test
+    public void testUpdateObject() throws IOException {
+
+        Publication pub = new Publication();
+        pub.setTitle("Ten puns");
+
+        client.createObject(pub);
+
+        Submission sub = new Submission();
+
+        sub.setAggregatedDepositStatus(AggregatedDepositStatus.NOT_STARTED);
+        sub.setSource(Source.PASS);
+        sub.setPublication(pub);
+        sub.setSubmitterName("Name");
+        sub.setSubmitted(false);
+
+        client.createObject(sub);
+
+        assertEquals(sub, client.getObject(sub, "publication"));
+    }
+
+    @Test
+    public void testSelectObjects() throws IOException {
+        String pmid = "" + UUID.randomUUID();
+
+        Journal journal = new Journal();
+        journal.setJournalName("The ministry of silly walks");
+
+        client.createObject(journal);
+
+        List<Publication> pubs = new ArrayList<>();
+
+        for (int i = 0; i < 10; i++) {
+            Publication pub = new Publication();
+
+            pub.setIssue("Number: " + i);
+            pub.setTitle("Title: " + i);
+            pub.setPmid(pmid);
+            pub.setJournal(journal);
+
+            client.createObject(pub);
+            pubs.add(pub);
+        }
+
+        String filter = RSQL.equals("pmid", pmid);
+        PassClientSelector<Publication> selector = new PassClientSelector<>(Publication.class, 0, 100, filter, "id");
+        selector.setInclude("journal");
+        PassClientResult<Publication> result = client.selectObjects(selector);
+
+        assertEquals(pubs.size(), result.getTotal());
+        assertIterableEquals(pubs, result.getObjects());
+
+        // Test selecting with an offset
+        selector = new PassClientSelector<>(Publication.class, 5, 100, filter, "id");
+        selector.setInclude("journal");
+        result = client.selectObjects(selector);
+
+        assertEquals(pubs.size(), result.getTotal());
+        assertIterableEquals(pubs.subList(5, pubs.size()), result.getObjects());
+
+        // Test using a stream which will make multiple calls. Do not include journal.
+        selector = new PassClientSelector<>(Publication.class, 0, 2, filter, "id");
+        pubs.forEach(p -> p.setJournal(new Journal(journal.getId())));
+        assertIterableEquals(pubs, client.streamObjects(selector).collect(Collectors.toList()));
+    }
+
+    private static ZonedDateTime dt(String s) {
+        return ZonedDateTime.parse("2010-12-10T02:01:20.300Z", Util.dateTimeFormatter());
+    }
+
+    @Test
+    public void testAllObjects() {
+        User pi = new User();
+        pi.setAffiliation(Collections.singleton("affil"));
+        pi.setDisplayName("Farmer Bob");
+        pi.setEmail("farmerbob@example.com");
+        pi.setFirstName("Bob");
+        pi.setLastName("Bobberson");
+        pi.setLocatorIds(Collections.singletonList("locator1"));
+        pi.setMiddleName("Bobbit");
+        pi.setOrcidId("23xx-xxxx-xxxx-xxxx");
+        pi.setRoles(Arrays.asList(UserRole.SUBMITTER));
+        pi.setUsername("farmerbob1");
+
+        User copi = new User();
+        copi.setAffiliation(Collections.singleton("barn"));
+        copi.setDisplayName("Bessie The Cow");
+        copi.setEmail("bessie@example.com");
+        copi.setFirstName("Bessie");
+        copi.setLastName("Cow");
+        copi.setLocatorIds(Collections.singletonList("locator2"));
+        copi.setMiddleName("The");
+        copi.setOrcidId("12xx-xxxx-xxxx-xxxx");
+        copi.setRoles(Arrays.asList(UserRole.SUBMITTER));
+        copi.setUsername("bessie1");
+
+        User preparer = new User();
+        copi.setAffiliation(Collections.singleton("dairy"));
+        copi.setDisplayName("Darren Dairy");
+        copi.setEmail("darren@example.com");
+        copi.setFirstName("Darren");
+        copi.setLastName("Dairy");
+        copi.setLocatorIds(Collections.singletonList("locator4"));
+        copi.setOrcidId("15xx-xxxx-xxxx-xxxx");
+        copi.setRoles(Arrays.asList(UserRole.SUBMITTER));
+        copi.setUsername("darren1");
+
+        Repository repository = new Repository();
+
+        repository.setAgreementText("I agree to everything.");
+        repository.setDescription("Repository description");
+        repository.setFormSchema("form schema");
+        repository.setIntegrationType(IntegrationType.FULL);
+        repository.setName("Barn repository");
+        repository.setRepositoryKey("barn");
+        repository.setSchemas(Arrays.asList(URI.create("http://example.com/schema")));
+        repository.setUrl(URI.create("http://example.com/barn.html"));
+
+        Policy policy = new Policy();
+
+        policy.setDescription("This is a policy description");
+        policy.setInstitution(URI.create("https://jhu.edu"));
+        policy.setPolicyUrl(URI.create("http://example.com/policy/oa.html"));
+        policy.setRepositories(Arrays.asList(repository));
+        policy.setTitle("Policy title");
+
+        Funder primary = new Funder();
+
+        primary.setLocalKey("bovine");
+        primary.setName("Bovines R Us");
+        primary.setPolicy(policy);
+        primary.setUrl(URI.create("http://example.com/bovine"));
+
+        Funder direct = new Funder();
+
+        direct.setLocalKey("icecream");
+        direct.setName("Icecream is great");
+        direct.setPolicy(policy);
+        direct.setUrl(URI.create("http://example.com/ice"));
+
+        Grant grant = new Grant();
+
+        grant.setAwardDate(dt("2010-01-10T02:01:20.300Z"));
+        grant.setAwardNumber("moo42");
+        grant.setAwardStatus(AwardStatus.ACTIVE);
+        grant.setCoPis(Arrays.asList(copi));
+        grant.setDirectFunder(direct);
+        grant.setPrimaryFunder(primary);
+        grant.setEndDate(dt("2015-12-10T02:04:20.300Z"));
+        grant.setLocalKey("moo:42");
+        grant.setPi(pi);
+        grant.setProjectName("Moo Thru revival");
+        grant.setStartDate(dt("2011-02-13T01:05:20.300Z"));
+
+        Publisher publisher = new Publisher();
+
+        publisher.setName("Publisher ");
+        publisher.setPmcParticipation(null);
+
+        Journal journal = new Journal();
+
+        journal.setIssns(Arrays.asList("issn1"));
+        journal.setJournalName("Ice Cream International");
+        journal.setPmcParticipation(PmcParticipation.A);
+        journal.setPublisher(publisher);
+
+        Publication publication = new Publication();
+
+        publication.setDoi("doi");
+        publication.setIssue("3");
+        publication.setJournal(journal);
+        publication.setPmid("pmid");
+        publication.setPublicationAbstract("Let x be...");
+        publication.setTitle("This is a huge title");
+        publication.setVolume("1 liter");
+
+        Submission submission = new Submission();
+        submission.setAggregatedDepositStatus(AggregatedDepositStatus.ACCEPTED);
+        submission.setEffectivePolicies(Arrays.asList(policy));
+        submission.setGrants(Arrays.asList(grant));
+        submission.setMetadata("metadata");
+        submission.setPreparers(Arrays.asList(preparer));
+        submission.setPublication(publication);
+        submission.setSource(Source.PASS);
+        submission.setSubmissionStatus(null);
+        submission.setSubmitted(true);
+        submission.setSubmittedDate(dt("2012-12-10T02:01:20.300Z"));
+        submission.setSubmitter(pi);
+        submission.setSubmitterEmail(URI.create("mailto:" + pi.getEmail()));
+        submission.setSubmitterName(pi.getDisplayName());
+
+        SubmissionEvent event = new SubmissionEvent();
+        event.setComment("This is a comment.");
+        event.setEventType(EventType.SUBMITTED);
+        event.setLink(URI.create("http://example.com/link"));
+        event.setPerformedBy(pi);
+        event.setPerformedDate(dt("2010-12-10T02:01:20.300Z"));
+        event.setPerformerRole(PerformerRole.SUBMITTER);
+        event.setSubmission(submission);
+
+        RepositoryCopy rc = new RepositoryCopy();
+        rc.setAccessUrl(URI.create("http://example.com/repo/item"));
+        rc.setCopyStatus(CopyStatus.ACCEPTED);
+        rc.setExternalIds(Arrays.asList("rc1"));
+        rc.setPublication(publication);
+        rc.setRepository(repository);
+
+        File file = new File();
+
+        file.setDescription("This is a file");
+        file.setFileRole(FileRole.MANUSCRIPT);
+        file.setMimeType("application/pdf");
+        file.setName("ms.pdf");
+        file.setSubmission(submission);
+        file.setUri(URI.create("http://example.com/ms.pdf"));
+
+        Deposit deposit = new Deposit();
+
+        deposit.setDepositStatus(DepositStatus.ACCEPTED);
+        deposit.setRepository(repository);
+        deposit.setRepositoryCopy(rc);
+
+        Contributor contrib = new Contributor();
+
+        contrib.setAffiliation(Collections.singleton("field"));
+        contrib.setDisplayName("Connie Contributor");
+        contrib.setEmail("connie@example.com");
+        contrib.setFirstName("Connie");
+        contrib.setMiddleName("Charlie");
+        contrib.setLastName("Contributor");
+        contrib.setOrcidId("35xx-xxxx-xxxx-xxxx");
+        contrib.setRoles(Arrays.asList(ContributorRole.CORRESPONDING_AUTHOR));
+        contrib.setUser(pi);
+        contrib.setPublication(publication);
+
+        // Check that all the objects can be created.
+        // Order such that relationship targets are created first.
+        List<PassEntity> objects = Arrays.asList(pi, copi, preparer, repository, policy, primary, direct, grant,
+                publisher, journal, publication, submission, event, rc, file, deposit, contrib);
+
+        objects.forEach(o -> {
+            try {
+                client.createObject(o);
+                assertNotNull(o.getId());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // Check that objects can be retrieved.
+        // For equality test, relationship targets must only have id
+
+        policy.setRepositories(Arrays.asList(new Repository(repository.getId())));
+        primary.setPolicy(new Policy(policy.getId()));
+        direct.setPolicy(new Policy(policy.getId()));
+        grant.setCoPis(Arrays.asList(new User(copi.getId())));
+        grant.setPi(new User(pi.getId()));
+        grant.setDirectFunder(new Funder(direct.getId()));
+        grant.setPrimaryFunder(new Funder(primary.getId()));
+        journal.setPublisher(new Publisher(publisher.getId()));
+        publication.setJournal(new Journal(journal.getId()));
+        submission.setGrants(Arrays.asList(new Grant(grant.getId())));
+        submission.setEffectivePolicies(Arrays.asList(new Policy(policy.getId())));
+        submission.setPreparers(Arrays.asList(new User(preparer.getId())));
+        submission.setPublication(new Publication(publication.getId()));
+        submission.setSubmitter(new User(pi.getId()));
+        event.setPerformedBy(new User(pi.getId()));
+        event.setSubmission(new Submission(submission.getId()));
+        rc.setPublication(new Publication(publication.getId()));
+        rc.setRepository(new Repository(repository.getId()));
+        file.setSubmission(new Submission(submission.getId()));
+        deposit.setRepository(new Repository(repository.getId()));
+        deposit.setRepositoryCopy(new RepositoryCopy(rc.getId()));
+        contrib.setUser(new User(pi.getId()));
+        contrib.setPublication(new Publication(publication.getId()));
+
+        objects.forEach(o -> {
+            try {
+                assertEquals(o, client.getObject(o));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+}

--- a/pass-data-client/src/test/java/org/eclipse/pass/support/client/RSQLTest.java
+++ b/pass-data-client/src/test/java/org/eclipse/pass/support/client/RSQLTest.java
@@ -1,0 +1,29 @@
+package org.eclipse.pass.support.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class RSQLTest {
+    @Test
+    public void testOperations() {
+        assertEquals("name=='value'", RSQL.equals("name", "value"));
+        assertEquals("name==''", RSQL.equals("name", ""));
+        assertEquals("name=in=('value1','value2')", RSQL.in("name", "value1", "value2"));
+        assertEquals("name=out=('value1','value2')", RSQL.out("name", "value1", "value2"));
+        assertEquals("name!='value'", RSQL.notEquals("name", "value"));
+    }
+
+    @Test
+    public void testGrouping() {
+        assertEquals("(name1=='value1';name2=='value2')",
+                RSQL.and(RSQL.equals("name1", "value1"), RSQL.equals("name2", "value2")));
+        assertEquals("(name1=='value1',name2=='value2')",
+                RSQL.or(RSQL.equals("name1", "value1"), RSQL.equals("name2", "value2")));
+    }
+
+    @Test
+    public void testEscape() {
+        assertEquals("name=='v\\\\a\\'lu\\\"e'", RSQL.equals("name", "v\\a'lu\"e"));
+    }
+}

--- a/pass-data-client/src/test/java/org/eclipse/pass/support/client/model/ContributorModelTests.java
+++ b/pass-data-client/src/test/java/org/eclipse/pass/support/client/model/ContributorModelTests.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client.model;
+
+import static org.eclipse.pass.support.client.model.support.TestObjectCreator.createContributor;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.pass.support.client.model.support.TestValues;
+import org.junit.jupiter.api.Test;
+
+/**
+ * These tests do a simple check to ensure the equals / hashcode functions work.
+ *
+ * @author Karen Hanson
+ * @author Jim Martino
+ */
+public class ContributorModelTests {
+    @Test
+    public void testContributorEqualsAndHashCode() {
+        Contributor contributor1 = createContributor(TestValues.CONTRIBUTOR_ID_1, TestValues.USER_ID_1);
+        Contributor contributor2 = createContributor(TestValues.CONTRIBUTOR_ID_1, TestValues.USER_ID_1);
+
+        assertEquals(contributor1, contributor2);
+        assertEquals(contributor1.hashCode(), contributor2.hashCode());
+
+        contributor1.setFirstName("different");
+        assertTrue(!contributor1.equals(contributor2));
+    }
+
+    /**
+     * Test copy constructor creates a valid duplicate that is not the same object
+     */
+    @Test
+    public void testContributorCopyConstructor()  {
+        Contributor contributor = createContributor(TestValues.CONTRIBUTOR_ID_1, TestValues.USER_ID_1);
+        Contributor contributorCopy = new Contributor(contributor);
+        assertEquals(contributor, contributorCopy);
+
+        String newEmail = "differentemail@differentemail.com";
+        contributorCopy.setEmail(newEmail);
+        assertEquals(TestValues.USER_EMAIL, contributor.getEmail());
+        assertEquals(newEmail, contributorCopy.getEmail());
+
+        contributorCopy.setUser(createUser(TestValues.USER_ID_2));
+        assertEquals(TestValues.USER_ID_1, contributor.getUser().getId());
+        assertEquals(TestValues.USER_ID_2, contributorCopy.getUser().getId());
+    }
+
+    private User createUser(String id) {
+        User user = new User();
+        user.setId(id);
+        user.setFirstName(TestValues.USER_FIRST_NAME);
+        user.setMiddleName(TestValues.USER_MIDDLE_NAME);
+        user.setLastName(TestValues.USER_LAST_NAME);
+        user.setDisplayName(TestValues.USER_DISPLAY_NAME);
+        user.setEmail(TestValues.USER_EMAIL);
+        user.setOrcidId(TestValues.USER_ORCID_ID);
+        user.setAffiliation(TestValues.USER_AFFILIATION);
+
+        return user;
+    }
+}

--- a/pass-data-client/src/test/java/org/eclipse/pass/support/client/model/DepositModelTests.java
+++ b/pass-data-client/src/test/java/org/eclipse/pass/support/client/model/DepositModelTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client.model;
+
+import static org.eclipse.pass.support.client.model.support.TestObjectCreator.createDeposit;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.pass.support.client.model.support.TestValues;
+import org.junit.jupiter.api.Test;
+
+/**
+ * These tests do a simple check to ensure that the equals / hashcode functions work.
+ *
+ * @author Karen Hanson
+ * @author Jim Martino
+ */
+public class DepositModelTests {
+    @Test
+    public void testDepositEqualsAndHashCode()  {
+
+        Deposit deposit1 = createDeposit(TestValues.DEPOSIT_ID_1);
+        Deposit deposit2 = createDeposit(TestValues.DEPOSIT_ID_1);
+
+        assertEquals(deposit1, deposit2);
+        assertEquals(deposit1.hashCode(), deposit2.hashCode());
+
+        deposit1.setDepositStatusRef("different");
+        assertTrue(!deposit1.equals(deposit2));
+    }
+
+    /**
+     * Test copy constructor creates a valid duplicate that is not the same object
+     */
+    @Test
+    public void testDepositCopyConstructor()  {
+        Deposit deposit = createDeposit(TestValues.DEPOSIT_ID_1);
+        Deposit depositCopy = new Deposit(deposit);
+        assertEquals(deposit, depositCopy);
+
+        depositCopy.setDepositStatus(DepositStatus.REJECTED);
+        assertEquals(DepositStatus.of(TestValues.DEPOSIT_STATUS), deposit.getDepositStatus());
+        assertEquals(DepositStatus.REJECTED, depositCopy.getDepositStatus());
+
+        depositCopy.setId(TestValues.DEPOSIT_ID_2);
+        assertEquals(TestValues.DEPOSIT_ID_1, deposit.getId());
+        assertEquals(TestValues.DEPOSIT_ID_2, depositCopy.getId());
+    }
+}

--- a/pass-data-client/src/test/java/org/eclipse/pass/support/client/model/FileModelTests.java
+++ b/pass-data-client/src/test/java/org/eclipse/pass/support/client/model/FileModelTests.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client.model;
+
+import static org.eclipse.pass.support.client.model.support.TestObjectCreator.createSubmission;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+
+import org.eclipse.pass.support.client.model.support.TestValues;
+import org.junit.jupiter.api.Test;
+
+/**
+ * These tests do a simple check to ensure the equals / hashcode functions work.
+ *
+ * @author Karen Hanson
+ * @author Jim Martino
+ */
+public class FileModelTests {
+    @Test
+    public void testFileEqualsAndHashCode()  {
+
+        File file1 = createFile();
+        File file2 = createFile();
+
+        assertEquals(file1, file2);
+        assertEquals(file1.hashCode(), file2.hashCode());
+
+        file1.setDescription("different");
+        assertTrue(!file1.equals(file2));
+    }
+
+    /**
+     * Test copy constructor creates a valid duplicate that is not the same object
+     */
+    @Test
+    public void testFileCopyConstructor()  {
+        File file = createFile();
+        File fileCopy = new File(file);
+        assertEquals(file, fileCopy);
+
+        fileCopy.setFileRole(FileRole.SUPPLEMENTAL);
+        assertEquals(FileRole.of(TestValues.FILE_ROLE), file.getFileRole());
+        assertEquals(FileRole.SUPPLEMENTAL, fileCopy.getFileRole());
+
+        String newMimeType = "text/html";
+        fileCopy.setMimeType(newMimeType);
+        assertEquals(TestValues.FILE_MIMETYPE, file.getMimeType());
+        assertEquals(newMimeType, fileCopy.getMimeType());
+    }
+
+    private File createFile()  {
+        File file = new File();
+        file.setId(TestValues.FILE_ID_1);
+        file.setName(TestValues.FILE_NAME);
+        file.setUri(URI.create(TestValues.FILE_URI));
+        file.setDescription(TestValues.FILE_DESCRIPTION);
+        file.setFileRole(FileRole.of(TestValues.FILE_ROLE));
+        file.setMimeType(TestValues.FILE_MIMETYPE);
+        file.setSubmission(createSubmission(TestValues.SUBMISSION_ID_1));
+
+        return file;
+    }
+
+}

--- a/pass-data-client/src/test/java/org/eclipse/pass/support/client/model/FunderModelTests.java
+++ b/pass-data-client/src/test/java/org/eclipse/pass/support/client/model/FunderModelTests.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client.model;
+
+import static org.eclipse.pass.support.client.model.support.TestObjectCreator.createFunder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+
+import org.eclipse.pass.support.client.model.support.TestValues;
+import org.junit.jupiter.api.Test;
+
+/**
+ * These tests do a simple check to ensure the the equals / hashcode functions work.
+ *
+ * @author Karen Hanson
+ * @author Jim Martino
+ */
+public class FunderModelTests {
+    @Test
+    public void testFunderEqualsAndHashCode()  {
+        Funder funder1 = createFunder(TestValues.FUNDER_ID_1);
+        Funder funder2 = createFunder(TestValues.FUNDER_ID_1);
+
+        assertEquals(funder1, funder2);
+        assertEquals(funder1.hashCode(), funder2.hashCode());
+
+        funder1.setName("different");
+        assertTrue(!funder1.equals(funder2));
+    }
+
+    /**
+     * Test copy constructor creates a valid duplicate that is not the same object
+     */
+    @Test
+    public void testFunderCopyConstructor()  {
+        Funder funder = createFunder(TestValues.FUNDER_ID_1);
+        Funder funderCopy = new Funder(funder);
+        assertEquals(funder, funderCopy);
+
+        String newLocalKey = "different:key";
+        funderCopy.setLocalKey(newLocalKey);
+        assertEquals(TestValues.FUNDER_LOCALKEY, funder.getLocalKey());
+        assertEquals(newLocalKey, funderCopy.getLocalKey());
+
+        URI newUrl = URI.create("different:url");
+        funderCopy.setUrl(newUrl);
+        assertEquals(URI.create(TestValues.FUNDER_URL), funder.getUrl());
+        assertEquals(newUrl, funderCopy.getUrl());
+    }
+}

--- a/pass-data-client/src/test/java/org/eclipse/pass/support/client/model/GrantModelTests.java
+++ b/pass-data-client/src/test/java/org/eclipse/pass/support/client/model/GrantModelTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client.model;
+
+import static org.eclipse.pass.support.client.model.support.TestObjectCreator.createGrant;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.ZonedDateTime;
+
+import org.eclipse.pass.support.client.model.support.TestValues;
+import org.junit.jupiter.api.Test;
+
+/**
+ * These tests do a simple check to ensure the the equals / hashcode functions work.
+ *
+ * @author Karen Hanson
+ * @author Jim Martino
+ */
+public class GrantModelTests {
+    @Test
+    public void testGrantEqualsAndHashCode()  {
+
+        Grant grant1 = createGrant(TestValues.GRANT_ID_1);
+        Grant grant2 = createGrant(TestValues.GRANT_ID_1);
+
+        assertEquals(grant1, grant2);
+        assertEquals(grant1.hashCode(), grant2.hashCode());
+
+        grant1.setAwardNumber("different");
+        assertTrue(!grant1.equals(grant2));
+    }
+
+    /**
+     * Test copy constructor creates a valid duplicate that is not the same object
+     */
+    @Test
+    public void testGrantCopyConstructor()  {
+        Grant grant = createGrant(TestValues.GRANT_ID_1);
+        Grant grantCopy = new Grant(grant);
+        assertEquals(grant, grantCopy);
+
+        String newLocalKey = "different:key";
+        grantCopy.setLocalKey(newLocalKey);
+        assertEquals(TestValues.GRANT_LOCALKEY, grant.getLocalKey());
+        assertEquals(newLocalKey, grantCopy.getLocalKey());
+
+        ZonedDateTime zdt = ZonedDateTime.parse(TestValues.GRANT_AWARD_DATE_STR_1);
+        ZonedDateTime newAwardDate = ZonedDateTime.parse(TestValues.GRANT_AWARD_DATE_STR_2);
+        grantCopy.setAwardDate(newAwardDate);
+        assertEquals(zdt, grant.getAwardDate());
+        assertEquals(newAwardDate, grantCopy.getAwardDate());
+    }
+}

--- a/pass-data-client/src/test/java/org/eclipse/pass/support/client/model/JournalModelTests.java
+++ b/pass-data-client/src/test/java/org/eclipse/pass/support/client/model/JournalModelTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client.model;
+
+import static org.eclipse.pass.support.client.model.support.TestObjectCreator.createJournal;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.pass.support.client.model.support.TestValues;
+import org.junit.jupiter.api.Test;
+
+/**
+ * These tests do a simple check to ensure the the equals / hashcode functions work.
+ *
+ * @author Karen Hanson
+ * @author Jim Martino
+ */
+public class JournalModelTests {
+    @Test
+    public void testJournalEqualsAndHashCode()  {
+        Journal journal1 = createJournal(TestValues.JOURNAL_ID_1);
+        Journal journal2 = createJournal(TestValues.JOURNAL_ID_1);
+
+        assertEquals(journal1, journal2);
+        assertEquals(journal1.hashCode(), journal2.hashCode());
+
+        journal1.setJournalName("different");
+        assertTrue(!journal1.equals(journal2));
+    }
+
+    /**
+     * Test copy constructor creates a valid duplicate that is not the same object
+     */
+    @Test
+    public void testJournalCopyConstructor()  {
+        Journal journal = createJournal(TestValues.JOURNAL_ID_1);
+        List<String> issnsOrig = new ArrayList<String>(
+            Arrays.asList(TestValues.JOURNAL_ISSN_1, TestValues.JOURNAL_ISSN_2));
+        journal.setIssns(issnsOrig);
+        Journal journalCopy = new Journal(journal);
+
+        assertEquals(journal, journalCopy);
+
+        journalCopy.setPmcParticipation(PmcParticipation.A);
+        assertEquals(PmcParticipation.valueOf(TestValues.JOURNAL_PMCPARTICIPATION), journal.getPmcParticipation());
+        assertEquals(PmcParticipation.A, journalCopy.getPmcParticipation());
+
+        List<String> issnsNew = new ArrayList<String>(Arrays.asList("9876-1234"));
+        journalCopy.setIssns(issnsNew);
+        assertEquals(issnsOrig, journal.getIssns());
+        assertEquals(issnsNew, journalCopy.getIssns());
+    }
+}

--- a/pass-data-client/src/test/java/org/eclipse/pass/support/client/model/PolicyModelTests.java
+++ b/pass-data-client/src/test/java/org/eclipse/pass/support/client/model/PolicyModelTests.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client.model;
+
+import static org.eclipse.pass.support.client.model.support.TestObjectCreator.createPolicy;
+import static org.eclipse.pass.support.client.model.support.TestObjectCreator.createRepository;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.pass.support.client.model.support.TestValues;
+import org.junit.jupiter.api.Test;
+
+/**
+ * These tests do a simple check to ensure the the equals / hashcode functions work
+ *
+ * @author Karen Hanson
+ * @author Jim Martino
+ */
+public class PolicyModelTests {
+    @Test
+    public void testPolicyEqualsAndHashCode()  {
+        Policy policy1 = createPolicy(TestValues.POLICY_ID_1);
+        Policy policy2 = createPolicy(TestValues.POLICY_ID_1);
+
+        assertEquals(policy1, policy2);
+        assertEquals(policy1.hashCode(), policy2.hashCode());
+
+        policy1.setPolicyUrl(URI.create("https://somethingdifferent.test"));
+        assertTrue(!policy1.equals(policy2));
+    }
+
+    /**
+     * Test copy constructor creates a valid duplicate that is not the same object
+     */
+    @Test
+    public void testPolicyCopyConstructor()  {
+        Policy policy = createPolicy(TestValues.POLICY_ID_1);
+        List<Repository> repositoriesOrig =
+            new ArrayList<Repository>(Arrays.asList(createRepository(TestValues.REPOSITORY_ID_1),
+                                             createRepository(TestValues.REPOSITORY_ID_2)));
+        policy.setRepositories(repositoriesOrig);
+
+        Policy policyCopy = new Policy(policy);
+        assertEquals(policy, policyCopy);
+
+        URI newInstitution = URI.create("different:institution");
+        policyCopy.setInstitution(newInstitution);
+        assertEquals(URI.create(TestValues.INSTITUTION_ID_1), policy.getInstitution());
+        assertEquals(newInstitution, policyCopy.getInstitution());
+
+        List<Repository> repositoriesNew =
+            new ArrayList<Repository>(Arrays.asList(createRepository(TestValues.REPOSITORY_ID_2)));
+        policyCopy.setRepositories(repositoriesNew);
+        assertEquals(repositoriesOrig, policy.getRepositories());
+        assertEquals(repositoriesNew, policyCopy.getRepositories());
+    }
+}

--- a/pass-data-client/src/test/java/org/eclipse/pass/support/client/model/PublicationModelTests.java
+++ b/pass-data-client/src/test/java/org/eclipse/pass/support/client/model/PublicationModelTests.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client.model;
+
+import static org.eclipse.pass.support.client.model.support.TestObjectCreator.createPublication;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.pass.support.client.model.support.TestValues;
+import org.junit.jupiter.api.Test;
+
+/**
+ * These tests do a simple check to ensure the equals / hashcode functions work.
+ *
+ * @author Karen Hanson
+ * @author Jim Martino
+ */
+public class PublicationModelTests {
+    @Test
+    public void testSubmissionEqualsAndHashCode()  {
+        Publication publication1 = createPublication(TestValues.PUBLICATION_ID_1);
+        Publication publication2 = createPublication(TestValues.PUBLICATION_ID_1);
+
+        assertEquals(publication1, publication2);
+        assertEquals(publication1.hashCode(), publication2.hashCode());
+
+        publication1.setIssue("different");
+        assertTrue(!publication1.equals(publication2));
+    }
+
+    /**
+     * Test copy constructor creates a valid duplicate that is not the same object
+     */
+    @Test
+    public void testPublicationCopyConstructor()  {
+        Publication publication = createPublication(TestValues.PUBLICATION_ID_1);
+        Publication publicationCopy = new Publication(publication);
+        assertEquals(publication, publicationCopy);
+
+        String newDoi = "different:doi";
+        publicationCopy.setDoi(newDoi);
+        assertEquals(TestValues.PUBLICATION_DOI, publication.getDoi());
+        assertEquals(newDoi, publicationCopy.getDoi());
+
+        String newVolume = "abcdef";
+        publicationCopy.setVolume(newVolume);
+        assertEquals(TestValues.PUBLICATION_VOLUME, publication.getVolume());
+        assertEquals(newVolume, publicationCopy.getVolume());
+    }
+}

--- a/pass-data-client/src/test/java/org/eclipse/pass/support/client/model/PublisherModelTests.java
+++ b/pass-data-client/src/test/java/org/eclipse/pass/support/client/model/PublisherModelTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client.model;
+
+import static org.eclipse.pass.support.client.model.support.TestObjectCreator.createPublisher;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.pass.support.client.model.support.TestValues;
+import org.junit.jupiter.api.Test;
+
+/**
+ * These tests do a simple check to ensure the equals / hashcode functions work.
+ *
+ * @author Karen Hanson
+ * @author Jim Martino
+ */
+public class PublisherModelTests {
+    @Test
+    public void testPublisherEqualsAndHashCode()  {
+        Publisher publisher1 = createPublisher(TestValues.PUBLISHER_ID_1);
+        Publisher publisher2 = createPublisher(TestValues.PUBLISHER_ID_1);
+
+        assertEquals(publisher1, publisher2);
+        assertEquals(publisher1.hashCode(), publisher2.hashCode());
+
+        publisher1.setName("different");
+        assertTrue(!publisher1.equals(publisher2));
+    }
+
+    /**
+     * Test copy constructor creates a valid duplicate that is not the same object
+     */
+    @Test
+    public void testPublisherCopyConstructor()  {
+        Publisher publisher = createPublisher(TestValues.PUBLISHER_ID_1);
+        Publisher publisherCopy = new Publisher(publisher);
+        assertEquals(publisher, publisherCopy);
+
+        publisherCopy.setPmcParticipation(PmcParticipation.A);
+        assertEquals(PmcParticipation.valueOf(TestValues.PUBLISHER_PMCPARTICIPATION), publisher.getPmcParticipation());
+        assertEquals(PmcParticipation.A, publisherCopy.getPmcParticipation());
+    }
+}

--- a/pass-data-client/src/test/java/org/eclipse/pass/support/client/model/RepositoryCopyModelTests.java
+++ b/pass-data-client/src/test/java/org/eclipse/pass/support/client/model/RepositoryCopyModelTests.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client.model;
+
+import static org.eclipse.pass.support.client.model.support.TestObjectCreator.createPublication;
+import static org.eclipse.pass.support.client.model.support.TestObjectCreator.createRepository;
+import static org.eclipse.pass.support.client.model.support.TestObjectCreator.createRepositoryCopy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.pass.support.client.model.support.TestValues;
+import org.junit.jupiter.api.Test;
+
+/**
+ * These tests do a simple check to ensure the equals / hashcode functions work.
+ *
+ * @author Karen Hanson
+ * @author Jim Martino
+ */
+public class RepositoryCopyModelTests {
+    @Test
+    public void testRepositoryCopyEqualsAndHashCode()  {
+        RepositoryCopy repoCopy1 = createRepositoryCopy(TestValues.REPOSITORYCOPY_ID_1);
+        RepositoryCopy repoCopy2 = createRepositoryCopy(TestValues.REPOSITORYCOPY_ID_1);
+
+        assertEquals(repoCopy1, repoCopy2);
+        assertEquals(repoCopy1.hashCode(), repoCopy2.hashCode());
+
+        repoCopy1.setRepository(createRepository(TestValues.REPOSITORY_ID_2));
+        assertTrue(!repoCopy1.equals(repoCopy2));
+    }
+
+    /**
+     * Test copy constructor creates a valid duplicate that is not the same object
+     */
+    @Test
+    public void testRepositoryCopyCopyConstructor()  {
+        RepositoryCopy repositoryCopy = createRepositoryCopy(TestValues.REPOSITORYCOPY_ID_1);
+        List<String> externalIds = new ArrayList<String>(
+            Arrays.asList(TestValues.REPOSITORYCOPY_EXTERNALID_1, TestValues.REPOSITORYCOPY_EXTERNALID_2));
+        repositoryCopy.setExternalIds(externalIds);
+        RepositoryCopy repositoryCopyCopy = new RepositoryCopy(repositoryCopy);
+        assertEquals(repositoryCopy, repositoryCopyCopy);
+
+        Publication newPublication = createPublication(TestValues.PUBLICATION_ID_1);
+        repositoryCopyCopy.setPublication(newPublication);
+        assertEquals(createPublication(TestValues.PUBLICATION_ID_1), repositoryCopy.getPublication());
+        assertEquals(newPublication, repositoryCopyCopy.getPublication());
+
+        List<String> externalIdsNew = new ArrayList<String>(Arrays.asList(TestValues.REPOSITORYCOPY_EXTERNALID_2));
+        repositoryCopyCopy.setExternalIds(externalIdsNew);
+        assertEquals(externalIds, repositoryCopy.getExternalIds());
+        assertEquals(externalIdsNew, repositoryCopyCopy.getExternalIds());
+    }
+}

--- a/pass-data-client/src/test/java/org/eclipse/pass/support/client/model/RepositoryModelTests.java
+++ b/pass-data-client/src/test/java/org/eclipse/pass/support/client/model/RepositoryModelTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client.model;
+
+import static org.eclipse.pass.support.client.model.support.TestObjectCreator.createRepository;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.pass.support.client.model.support.TestValues;
+import org.junit.jupiter.api.Test;
+
+/**
+ * These tests do a simple check to ensure the equals / hashcode functions work.
+ *
+ * @author Karen Hanson
+ * @author Jim Martino
+ */
+public class RepositoryModelTests {
+    @Test
+    public void testRepositoryEqualsAndHashCode()  {
+        Repository repository1 = createRepository(TestValues.REPOSITORY_ID_1);
+        Repository repository2 = createRepository(TestValues.REPOSITORY_ID_1);
+
+        assertEquals(repository1, repository2);
+        assertEquals(repository1.hashCode(), repository2.hashCode());
+
+        repository1.setName("different");
+        assertTrue(!repository1.equals(repository2));
+    }
+
+    /**
+     * Test copy constructor creates a valid duplicate that is not the same object
+     */
+    @Test
+    public void testRepositoryCopyConstructor()  {
+        Repository repository = createRepository(TestValues.REPOSITORY_ID_1);
+        Repository repositoryCopy = new Repository(repository);
+        assertEquals(repository, repositoryCopy);
+
+        String newAgreementText = "new agreement text";
+        repositoryCopy.setAgreementText(newAgreementText);
+        assertEquals(TestValues.REPOSITORY_AGREEMENTTEXT, repository.getAgreementText());
+        assertEquals(newAgreementText, repositoryCopy.getAgreementText());
+
+        repositoryCopy.setIntegrationType(IntegrationType.ONE_WAY);
+        assertEquals(IntegrationType.of(TestValues.REPOSITORY_INTEGRATION_TYPE), repository.getIntegrationType());
+        assertEquals(IntegrationType.ONE_WAY, repositoryCopy.getIntegrationType());
+    }
+}

--- a/pass-data-client/src/test/java/org/eclipse/pass/support/client/model/SubmissionEventModelTests.java
+++ b/pass-data-client/src/test/java/org/eclipse/pass/support/client/model/SubmissionEventModelTests.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client.model;
+
+import static org.eclipse.pass.support.client.model.support.TestObjectCreator.createSubmission;
+import static org.eclipse.pass.support.client.model.support.TestObjectCreator.createUser;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.time.ZonedDateTime;
+
+import org.eclipse.pass.support.client.model.support.TestValues;
+import org.junit.jupiter.api.Test;
+
+/**
+ * These tests do a simple check to ensure the equals / hashcode functions work.
+ *
+ * @author Karen Hanson
+ * @author Jim Martino
+ */
+public class SubmissionEventModelTests {
+    @Test
+    public void testSubmissionEqualsAndHashCode()  {
+
+        SubmissionEvent submissionEvent1 = createSubmissionEvent();
+        SubmissionEvent submissionEvent2 = createSubmissionEvent();
+
+        assertEquals(submissionEvent1, submissionEvent2);
+        submissionEvent1.setPerformerRole(PerformerRole.SUBMITTER);
+        assertTrue(!submissionEvent1.equals(submissionEvent2));
+
+        assertTrue(submissionEvent1.hashCode() != submissionEvent2.hashCode());
+        submissionEvent1 = submissionEvent2;
+        assertEquals(submissionEvent1.hashCode(), submissionEvent2.hashCode());
+
+    }
+
+    /**
+     * Test copy constructor creates a valid duplicate that is not the same object
+     */
+    @Test
+    public void testSubmissionEventCopyConstructor()  {
+        SubmissionEvent submissionEvent = createSubmissionEvent();
+        SubmissionEvent submissionEventCopy = new SubmissionEvent(submissionEvent);
+        assertEquals(submissionEvent, submissionEventCopy);
+
+        URI newLink = URI.create("different:link");
+        submissionEventCopy.setLink(newLink);
+        assertEquals(URI.create(TestValues.SUBMISSIONEVENT_LINK), submissionEvent.getLink());
+        assertEquals(newLink, submissionEventCopy.getLink());
+
+        submissionEventCopy.setEventType(EventType.CANCELLED);
+        assertEquals(EventType.of(TestValues.SUBMISSIONEVENT_EVENT_TYPE),
+                     submissionEvent.getEventType());
+        assertEquals(EventType.CANCELLED, submissionEventCopy.getEventType());
+    }
+
+    private SubmissionEvent createSubmissionEvent()  {
+        SubmissionEvent submissionEvent = new SubmissionEvent();
+        submissionEvent.setId(TestValues.SUBMISSIONEVENT_ID);
+        submissionEvent.setEventType(EventType.of(TestValues.SUBMISSIONEVENT_EVENT_TYPE));
+        ZonedDateTime zdt = ZonedDateTime.parse(TestValues.SUBMISSIONEVENT_PERFORMED_DATE_STR);
+        submissionEvent.setPerformedDate(zdt);
+        submissionEvent.setPerformedBy(createUser(TestValues.USER_ID_1));
+        submissionEvent.setPerformerRole(PerformerRole.PREPARER);
+        submissionEvent.setSubmission(createSubmission(TestValues.SUBMISSION_ID_1));
+        submissionEvent.setComment(TestValues.SUBMISSIONEVENT_COMMENT);
+        submissionEvent.setLink(URI.create(TestValues.SUBMISSIONEVENT_LINK));
+
+        return submissionEvent;
+    }
+}

--- a/pass-data-client/src/test/java/org/eclipse/pass/support/client/model/SubmissionModelTests.java
+++ b/pass-data-client/src/test/java/org/eclipse/pass/support/client/model/SubmissionModelTests.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client.model;
+
+import static org.eclipse.pass.support.client.model.support.TestObjectCreator.createSubmission;
+import static org.eclipse.pass.support.client.model.support.TestObjectCreator.createUser;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.pass.support.client.model.support.TestValues;
+import org.junit.jupiter.api.Test;
+
+/**
+ * These tests do a simple check to ensure the equals / hashcode functions work.
+ * Note that in these tests every field is set, though in a reality, either
+ * submitter OR submitterName/submitterEmail would be set, not both at once.
+ *
+ * @author Karen Hanson
+ * @author Jim Martino
+ */
+public class SubmissionModelTests {
+    @Test
+    public void testSubmissionEqualsAndHashCode()  {
+        Submission submission1 = createSubmission(TestValues.SUBMISSION_ID_1);
+        Submission submission2 = createSubmission(TestValues.SUBMISSION_ID_1);
+
+        assertEquals(submission1, submission2);
+        assertEquals(submission1.hashCode(), submission2.hashCode());
+
+        submission1.setSubmissionStatus(SubmissionStatus.CANCELLED);
+        assertTrue(!submission1.equals(submission2));
+    }
+
+    /**
+     * Verifies that we can use the "submitted" status related to a SubmissionStatus.
+     */
+    @Test
+    public void testSubmissionStatusSubmitted()  {
+        assertFalse(SubmissionStatus.APPROVAL_REQUESTED.isSubmitted());
+        assertFalse(SubmissionStatus.CANCELLED.isSubmitted());
+        assertTrue(SubmissionStatus.COMPLETE.isSubmitted());
+
+        Submission submission = createSubmission(TestValues.SUBMISSION_ID_1);
+        assertTrue(submission.getSubmissionStatus().isSubmitted());
+    }
+
+    /**
+     * Test copy constructor creates a valid duplicate that is not the same object
+     */
+    @Test
+    public void testSubmissionCopyConstructor()  {
+        Submission submission = createSubmission(TestValues.SUBMISSION_ID_1);
+        List<User> preparersOrig = new ArrayList<>(Arrays.asList(createUser(TestValues.USER_ID_1)));
+        submission.setPreparers(preparersOrig);
+        Submission submissionCopy = new Submission(submission);
+        assertEquals(submission, submissionCopy);
+
+        submissionCopy.setSubmissionStatus(SubmissionStatus.COMPLETE);
+        assertEquals(SubmissionStatus.of(TestValues.SUBMISSION_STATUS), submission.getSubmissionStatus());
+        assertEquals(SubmissionStatus.COMPLETE, submissionCopy.getSubmissionStatus());
+
+        List<User> preparersNew = new ArrayList<>(
+            Arrays.asList(createUser(TestValues.USER_ID_1), createUser(TestValues.USER_ID_2)));
+        submissionCopy.setPreparers(preparersNew);
+        assertEquals(preparersOrig, submission.getPreparers());
+        assertEquals(preparersNew, submissionCopy.getPreparers());
+    }
+
+}

--- a/pass-data-client/src/test/java/org/eclipse/pass/support/client/model/UserModelTest.java
+++ b/pass-data-client/src/test/java/org/eclipse/pass/support/client/model/UserModelTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client.model;
+
+import static org.eclipse.pass.support.client.model.support.TestObjectCreator.createUser;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.pass.support.client.model.support.TestValues;
+import org.junit.jupiter.api.Test;
+
+/**
+ * These tests do a simple check to ensure the equals / hashcode functions work.
+ *
+ * @author Karen Hanson
+ * @author Jim Martino
+ */
+public class UserModelTest {
+    @Test
+    public void testUserEqualsAndHashCode()  {
+
+        User user1 = createUser(TestValues.USER_ID_1);
+        User user2 = createUser(TestValues.USER_ID_1);
+
+        assertEquals(user1, user2);
+        assertEquals(user1.hashCode(), user2.hashCode());
+
+        user1.setUsername("different");
+        assertTrue(!user1.equals(user2));
+    }
+
+    /**
+     * Test copy constructor creates a valid duplicate that is not the same object
+     */
+    @Test
+    public void testUserCopyConstructor()  {
+        User user = createUser(TestValues.USER_ID_1);
+        List<UserRole> rolesOrig = new ArrayList<UserRole>(Arrays.asList(UserRole.ADMIN));
+        user.setRoles(rolesOrig);
+
+        User userCopy = new User(user);
+        assertEquals(user, userCopy);
+
+        String newOrcidId = "https://orcid.org/0000-new-orcid-id";
+        userCopy.setOrcidId(newOrcidId);
+        assertEquals(TestValues.USER_ORCID_ID, user.getOrcidId());
+        assertEquals(newOrcidId, userCopy.getOrcidId());
+
+        List<UserRole> rolesNew = new ArrayList<>(Arrays.asList(UserRole.ADMIN, UserRole.SUBMITTER));
+        userCopy.setRoles(rolesNew);
+        assertEquals(rolesOrig, user.getRoles());
+        assertEquals(rolesNew, userCopy.getRoles());
+    }
+}

--- a/pass-data-client/src/test/java/org/eclipse/pass/support/client/model/support/TestObjectCreator.java
+++ b/pass-data-client/src/test/java/org/eclipse/pass/support/client/model/support/TestObjectCreator.java
@@ -1,0 +1,334 @@
+/*
+ * Copyright 2022 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.pass.support.client.model.support;
+
+import java.net.URI;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.pass.support.client.model.AggregatedDepositStatus;
+import org.eclipse.pass.support.client.model.AwardStatus;
+import org.eclipse.pass.support.client.model.Contributor;
+import org.eclipse.pass.support.client.model.CopyStatus;
+import org.eclipse.pass.support.client.model.Deposit;
+import org.eclipse.pass.support.client.model.DepositStatus;
+import org.eclipse.pass.support.client.model.Funder;
+import org.eclipse.pass.support.client.model.Grant;
+import org.eclipse.pass.support.client.model.IntegrationType;
+import org.eclipse.pass.support.client.model.Journal;
+import org.eclipse.pass.support.client.model.PmcParticipation;
+import org.eclipse.pass.support.client.model.Policy;
+import org.eclipse.pass.support.client.model.Publication;
+import org.eclipse.pass.support.client.model.Publisher;
+import org.eclipse.pass.support.client.model.Repository;
+import org.eclipse.pass.support.client.model.RepositoryCopy;
+import org.eclipse.pass.support.client.model.Source;
+import org.eclipse.pass.support.client.model.Submission;
+import org.eclipse.pass.support.client.model.SubmissionStatus;
+import org.eclipse.pass.support.client.model.User;
+import org.eclipse.pass.support.client.model.UserRole;
+
+/**
+ * Creates instances of model objects needed as fields on other objects used in
+ * testing
+ *
+ * @author Jim Martino
+ *
+ */
+public class TestObjectCreator {
+
+    private TestObjectCreator() {
+    }
+
+    /**
+     * Creates an instance of a Contributor
+     *
+     * @param contributorId the id for the object to be created
+     * @param userId        parameter for the user on this object
+     * @return the Contributor @
+     */
+    public static Contributor createContributor(String contributorId, String userId) {
+        Contributor contributor = new Contributor();
+        contributor.setId(contributorId);
+        contributor.setFirstName(TestValues.USER_FIRST_NAME);
+        contributor.setMiddleName(TestValues.USER_MIDDLE_NAME);
+        contributor.setLastName(TestValues.USER_LAST_NAME);
+        contributor.setDisplayName(TestValues.USER_DISPLAY_NAME);
+        contributor.setEmail(TestValues.USER_EMAIL);
+        contributor.setOrcidId(TestValues.USER_ORCID_ID);
+        contributor.setAffiliation(TestValues.USER_AFFILIATION);
+        contributor.setUser(createUser(userId));
+        contributor.setPublication(createPublication(TestValues.PUBLICATION_ID_1));
+
+        return contributor;
+    }
+
+    /**
+     * Creates an instance of a Deposit
+     *
+     * @param depositId the id for the object to be created
+     * @return the Deposit @
+     */
+    public static Deposit createDeposit(String depositId) {
+        Deposit deposit = new Deposit();
+        deposit.setId(depositId);
+        deposit.setDepositStatusRef(TestValues.DEPOSIT_STATUSREF);
+        deposit.setDepositStatus(DepositStatus.of(TestValues.DEPOSIT_STATUS));
+        deposit.setSubmission(createSubmission(TestValues.SUBMISSION_ID_1));
+        deposit.setRepository(createRepository(TestValues.REPOSITORY_ID_1));
+        deposit.setRepositoryCopy(createRepositoryCopy(TestValues.REPOSITORYCOPY_ID_1));
+
+        return deposit;
+    }
+
+    /**
+     * Creates an instance of a Funder
+     *
+     * @param funderId the id for the object to be created
+     * @return the Funder @
+     */
+    public static Funder createFunder(String funderId) {
+        Funder funder = new Funder();
+        funder.setId(funderId);
+        funder.setName(TestValues.FUNDER_NAME);
+        funder.setUrl(URI.create(TestValues.FUNDER_URL));
+        funder.setPolicy(createPolicy(TestValues.POLICY_ID_1));
+        funder.setLocalKey(TestValues.FUNDER_LOCALKEY);
+        return funder;
+    }
+
+    /**
+     * Creates an instance of a Grant
+     *
+     * @param grantId the id for the object to be created
+     * @return the Grant @
+     */
+    public static Grant createGrant(String grantId) {
+        Grant grant = new Grant();
+        grant.setId(grantId);
+        grant.setAwardNumber(TestValues.GRANT_AWARD_NUMBER);
+        grant.setAwardStatus(AwardStatus.of(TestValues.GRANT_STATUS));
+        grant.setLocalKey(TestValues.GRANT_LOCALKEY);
+        grant.setProjectName(TestValues.GRANT_PROJECT_NAME);
+        grant.setPrimaryFunder(createFunder(TestValues.FUNDER_ID_1));
+        grant.setDirectFunder(createFunder(TestValues.FUNDER_ID_2));
+        grant.setPi(createUser(TestValues.USER_ID_1));
+        List<User> coPis = new ArrayList<>();
+        coPis.add(createUser(TestValues.USER_ID_2));
+        coPis.add(createUser(TestValues.USER_ID_3));
+        grant.setCoPis(coPis);
+
+        ZonedDateTime zdt = ZonedDateTime.parse(TestValues.GRANT_AWARD_DATE_STR_1);
+        grant.setAwardDate(zdt);
+        zdt = ZonedDateTime.parse(TestValues.GRANT_START_DATE_STR);
+        grant.setStartDate(zdt);
+        zdt = ZonedDateTime.parse(TestValues.GRANT_END_DATE_STR);
+        grant.setEndDate(zdt);
+
+        return grant;
+    }
+
+    /**
+     * Creates an instance of a Journal
+     *
+     * @param journalId the id for the object to be created
+     * @return the Journal @
+     */
+    public static Journal createJournal(String journalId) {
+        Journal journal = new Journal();
+        journal.setId(journalId);
+        journal.setJournalName(TestValues.JOURNAL_NAME);
+        List<String> issns = new ArrayList<String>();
+        issns.add(TestValues.JOURNAL_ISSN_1);
+        issns.add(TestValues.JOURNAL_ISSN_2);
+        journal.setIssns(issns);
+        journal.setPublisher(createPublisher(TestValues.PUBLISHER_ID_1));
+        journal.setNlmta(TestValues.JOURNAL_NLMTA);
+        journal.setPmcParticipation(PmcParticipation.valueOf(TestValues.JOURNAL_PMCPARTICIPATION));
+        return journal;
+    }
+
+    /**
+     * Creates an instance of a Policy
+     *
+     * @param policyId the id for the object to be created
+     * @return the Policy @
+     */
+    public static Policy createPolicy(String policyId) {
+        Policy policy = new Policy();
+        policy.setId(policyId);
+        policy.setTitle(TestValues.POLICY_TITLE);
+        policy.setDescription(TestValues.POLICY_DESCRIPTION);
+        policy.setPolicyUrl(URI.create(TestValues.POLICY_URL));
+
+        List<Repository> repositories = new ArrayList<>();
+        repositories.add(createRepository(TestValues.REPOSITORY_ID_1));
+        repositories.add(createRepository(TestValues.REPOSITORY_ID_2));
+        policy.setRepositories(repositories);
+
+        policy.setInstitution(URI.create(TestValues.INSTITUTION_ID_1));
+
+        return policy;
+    }
+
+    /**
+     * Creates an instance of a Publication
+     *
+     * @param publicationId the id for the object to be created
+     * @return the Publication @
+     */
+    public static Publication createPublication(String publicationId) {
+        Publication publication = new Publication();
+        publication.setId(publicationId);
+        publication.setTitle(TestValues.PUBLICATION_TITLE);
+        publication.setPublicationAbstract(TestValues.PUBLICATION_ABSTRACT);
+        publication.setDoi(TestValues.PUBLICATION_DOI);
+        publication.setPmid(TestValues.PUBLICATION_PMID);
+        publication.setVolume(TestValues.PUBLICATION_VOLUME);
+        publication.setIssue(TestValues.PUBLICATION_ISSUE);
+        publication.setJournal(createJournal(TestValues.JOURNAL_ID_1));
+        return publication;
+    }
+
+    /**
+     * Creates an instance of a Publisher
+     *
+     * @param publisherId the id for the object to be created
+     * @return the Publisher @
+     */
+    public static Publisher createPublisher(String publisherId) {
+        Publisher publisher = new Publisher();
+        publisher.setId(publisherId);
+        publisher.setName(TestValues.PUBLISHER_NAME);
+        publisher.setPmcParticipation(PmcParticipation.valueOf(TestValues.PUBLISHER_PMCPARTICIPATION));
+
+        return publisher;
+    }
+
+    /**
+     * Creates an instance of a Repository
+     *
+     * @param repositoryId the id for the object to be created
+     * @return the Repository @
+     */
+    public static Repository createRepository(String repositoryId) {
+        Repository repository = new Repository();
+        repository.setId(repositoryId);
+        repository.setName(TestValues.REPOSITORY_NAME);
+        repository.setDescription(TestValues.REPOSITORY_DESCRIPTION);
+        repository.setUrl(URI.create(TestValues.REPOSITORY_URL));
+        repository.setAgreementText(TestValues.REPOSITORY_AGREEMENTTEXT);
+        repository.setFormSchema(TestValues.REPOSITORY_FORMSCHEMA);
+        repository.setIntegrationType(IntegrationType.of(TestValues.REPOSITORY_INTEGRATION_TYPE));
+        repository.setRepositoryKey(TestValues.REPOSITORY_KEY);
+
+        return repository;
+    }
+
+    /**
+     * Creates an instance of a RepositoryCopy
+     *
+     * @param repositoryCopyId the id for the object to be created
+     * @return the Repository Copy @
+     */
+    public static RepositoryCopy createRepositoryCopy(String repositoryCopyId) {
+        RepositoryCopy repositoryCopy = new RepositoryCopy();
+        repositoryCopy.setId(repositoryCopyId);
+        repositoryCopy.setCopyStatus(CopyStatus.of(TestValues.REPOSITORYCOPY_STATUS));
+        repositoryCopy.setAccessUrl(URI.create(TestValues.REPOSITORYCOPY_ACCESSURL));
+        repositoryCopy.setPublication(createPublication(TestValues.PUBLICATION_ID_1));
+        repositoryCopy.setRepository(createRepository(TestValues.REPOSITORY_ID_1));
+
+        List<String> externalIds = new ArrayList<String>();
+        externalIds.add(TestValues.REPOSITORYCOPY_EXTERNALID_1);
+        externalIds.add(TestValues.REPOSITORYCOPY_EXTERNALID_2);
+        repositoryCopy.setExternalIds(externalIds);
+
+        return repositoryCopy;
+    }
+
+    /**
+     * Creates an instance of a Submission
+     *
+     * @param submissionId the id for the object to be created
+     * @return the Submission @
+     */
+    public static Submission createSubmission(String submissionId) {
+        Submission submission = new Submission();
+        submission.setId(submissionId);
+        submission.setSubmissionStatus(SubmissionStatus.of(TestValues.SUBMISSION_STATUS));
+        submission.setAggregatedDepositStatus(AggregatedDepositStatus.of(TestValues.SUBMISSION_AGG_DEPOSIT_STATUS));
+        submission.setMetadata(TestValues.SUBMISSION_METADATA);
+        submission.setSubmitted(TestValues.SUBMISSION_SUBMITTED);
+        submission.setPublication(createPublication(TestValues.PUBLICATION_ID_1));
+        submission.setSubmitter(createUser(TestValues.USER_ID_1));
+        submission.setSubmitterName(TestValues.SUBMISSION_SUBMITTERNAME);
+        submission.setSubmitterEmail(URI.create(TestValues.SUBMISSION_SUBMITTEREMAIL));
+        submission.setSource(Source.PASS);
+
+        List<User> preparers = new ArrayList<User>();
+        preparers.add(createUser(TestValues.USER_ID_2));
+        submission.setPreparers(preparers);
+
+        List<Repository> repositories = new ArrayList<>();
+        repositories.add(createRepository(TestValues.REPOSITORY_ID_1));
+        repositories.add(createRepository(TestValues.REPOSITORY_ID_2));
+        submission.setRepositories(repositories);
+
+        List<Grant> grants = new ArrayList<>();
+        grants.add(createGrant(TestValues.GRANT_ID_1));
+        grants.add(createGrant(TestValues.GRANT_ID_2));
+        submission.setGrants(grants);
+
+        ZonedDateTime zdt = ZonedDateTime.parse(TestValues.SUBMISSION_DATE_STR);
+        submission.setSubmittedDate(zdt);
+
+        return submission;
+    }
+
+    /**
+     * Creates an instance of a User
+     *
+     * @param userId the id for the object to be created
+     * @return the User @
+     */
+    public static User createUser(String userId) {
+        User user = new User();
+        user.setId(userId);
+        user.setUsername(TestValues.USER_NAME);
+        user.setFirstName(TestValues.USER_FIRST_NAME);
+        user.setMiddleName(TestValues.USER_MIDDLE_NAME);
+        user.setLastName(TestValues.USER_LAST_NAME);
+        user.setDisplayName(TestValues.USER_DISPLAY_NAME);
+        user.setEmail(TestValues.USER_EMAIL);
+        user.setAffiliation(TestValues.USER_AFFILIATION);
+        user.setOrcidId(TestValues.USER_ORCID_ID);
+
+        List<String> locatorIds = new ArrayList<String>();
+        locatorIds.add(TestValues.USER_LOCATORID1);
+        locatorIds.add(TestValues.USER_LOCATORID2);
+        user.setLocatorIds(locatorIds);
+
+        List<UserRole> roles = new ArrayList<UserRole>();
+        roles.add(UserRole.of(TestValues.USER_ROLE_1));
+        roles.add(UserRole.of(TestValues.USER_ROLE_2));
+        user.setRoles(roles);
+
+        return user;
+    }
+}

--- a/pass-data-client/src/test/java/org/eclipse/pass/support/client/model/support/TestValues.java
+++ b/pass-data-client/src/test/java/org/eclipse/pass/support/client/model/support/TestValues.java
@@ -1,0 +1,515 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.pass.support.client.model.support;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Constants used in test data
+ *
+ * @author Karen Hanson
+ * @author Jim Martino
+ * @version $Id$
+ */
+public class TestValues {
+
+    private TestValues() {
+    }
+
+    /**
+     * A test value
+     */
+    public static final String CONTRIBUTOR_ID_1 = "1";
+
+    /**
+     * A test value
+     */
+    public static final String DEPOSIT_ID_1 = "2";
+
+    /**
+     * A test value
+     */
+    public static final String DEPOSIT_ID_2 = "3";
+
+    /**
+     * A test value
+     */
+    public static final String FILE_ID_1 = "4";
+
+    /**
+     * A test value
+     */
+    public static final String FUNDER_ID_1 = "5";
+
+    /**
+     * A test value
+     */
+    public static final String FUNDER_ID_2 = "6";
+
+    /**
+     * A test value
+     */
+    public static final String GRANT_ID_1 = "7";
+
+    /**
+     * A test value
+     */
+    public static final String GRANT_ID_2 = "8";
+
+    /**
+     * A test value
+     */
+    public static final String JOURNAL_ID_1 = "9";
+
+    /**
+     * A test value
+     */
+    public static final String JOURNAL_ID_2 = "10";
+
+    /**
+     * A test value
+     */
+    public static final String INSTITUTION_ID_1 = "https://example.org/fedora/institutions/1";
+
+    /**
+     * A test value
+     */
+    public static final String POLICY_ID_1 = "12";
+
+    /**
+     * A test value
+     */
+    public static final String PUBLICATION_ID_1 = "13";
+
+    /**
+     * A test value
+     */
+    public static final String PUBLISHER_ID_1 = "13";
+
+    /**
+     * A test value
+     */
+    public static final String REPOSITORY_ID_1 = "14";
+
+    /**
+     * A test value
+     */
+    public static final String REPOSITORY_ID_2 = "15";
+
+    /**
+     * A test value
+     */
+    public static final String REPOSITORYCOPY_ID_1 = "16";
+
+    /**
+     * A test value
+     */
+    public static final String SUBMISSION_ID_1 = "17";
+
+    /**
+     * A test value
+     */
+    public static final String SUBMISSION_ID_2 = "18";
+
+    /**
+     * A test value
+     */
+    public static final String SUBMISSIONEVENT_ID = "19";
+
+    /**
+     * A test value
+     */
+    public static final String USER_ID_1 = "20";
+
+    /**
+     * A test value
+     */
+    public static final String USER_ID_2 = "21";
+
+    /**
+     * A test value
+     */
+    public static final String USER_ID_3 = "22";
+
+    /**
+     * A test value
+     */
+    public static final String CONTRIBUTOR_ROLE_1 = "first-author";
+
+    /**
+     * A test value
+     */
+    public static final String CONTRIBUTOR_ROLE_2 = "author";
+
+    /**
+     * A test value
+     */
+    public static final String DEPOSIT_STATUS = "submitted";
+
+    /**
+     * A test value
+     */
+    public static final String DEPOSIT_STATUSREF = "http://depositstatusref.example/abc";
+
+    /**
+     * A test value
+     */
+    public static final String FILE_NAME = "article.pdf";
+
+    /**
+     * A test value
+     */
+    public static final String FILE_URI = "https://someplace.dl/a/b/c/article.pdf";
+
+    /**
+     * A test value
+     */
+    public static final String FILE_DESCRIPTION = "The file is an article";
+
+    /**
+     * A test value
+     */
+    public static final String FILE_ROLE = "manuscript";
+
+    /**
+     * A test value
+     */
+    public static final String FILE_MIMETYPE = "application/pdf";
+
+    /**
+     * A test value
+     */
+    public static final String FUNDER_NAME = "Funder A";
+
+    /**
+     * A test value
+     */
+    public static final String FUNDER_URL = "https://nih.gov";
+
+    /**
+     * A test value
+     */
+    public static final String FUNDER_LOCALKEY = "A12345";
+
+    /**
+     * A test value
+     */
+    public static final String GRANT_AWARD_NUMBER = "RH1234CDE";
+
+    /**
+     * A test value
+     */
+    public static final String GRANT_STATUS = "active";
+
+    /**
+     * A test value
+     */
+    public static final String GRANT_LOCALKEY = "ABC123";
+
+    /**
+     * A test value
+     */
+    public static final String GRANT_PROJECT_NAME = "Project A";
+
+    /**
+     * A test value
+     */
+    public static final String GRANT_AWARD_DATE_STR_1 = "2018-01-01T00:00:00.000Z";
+
+    /**
+     * A test value
+     */
+    public static final String GRANT_AWARD_DATE_STR_2 = "2019-01-01T00:00:00.000Z";
+
+    /**
+     * A test value
+     */
+    public static final String GRANT_START_DATE_STR = "2018-04-01T00:00:00.000Z";
+
+    /**
+     * A test value
+     */
+    public static final String GRANT_END_DATE_STR = "2020-04-30T00:00:00.000Z";
+
+    /**
+     * A test value
+     */
+    public static final String JOURNAL_NAME = "Test Journal";
+
+    /**
+     * A test value
+     */
+    public static final String JOURNAL_ISSN_1 = "1234-5678";
+
+    /**
+     * A test value
+     */
+    public static final String JOURNAL_ISSN_2 = "5678-1234";
+
+    /**
+     * A test value
+     */
+    public static final String JOURNAL_NLMTA = "TJ";
+
+    /**
+     * A test value
+     */
+    public static final String JOURNAL_PMCPARTICIPATION = "B";
+
+    /**
+     * A test value
+     */
+    public static final String POLICY_TITLE = "Policy A";
+
+    /**
+     * A test value
+     */
+    public static final String POLICY_DESCRIPTION = "You must submit to any OA repo";
+
+    /**
+     * A test value
+     */
+    public static final String POLICY_URL = "https://somefunder.org/policy";
+
+    /**
+     * A test value
+     */
+    public static final String PUBLICATION_TITLE = "Some article";
+
+    /**
+     * A test value
+     */
+    public static final String PUBLICATION_ABSTRACT = "An article about something";
+
+    /**
+     * A test value
+     */
+    public static final String PUBLICATION_PMID = "12345678";
+
+    /**
+     * A test value
+     */
+    public static final String PUBLICATION_DOI = "10.0101/1234abcd";
+
+    /**
+     * A test value
+     */
+    public static final String PUBLICATION_VOLUME = "5";
+
+    /**
+     * A test value
+     */
+    public static final String PUBLICATION_ISSUE = "123";
+
+    /**
+     * A test value
+     */
+    public static final String PUBLISHER_NAME = "Publisher A";
+
+    /**
+     * A test value
+     */
+    public static final String PUBLISHER_PMCPARTICIPATION = "A";
+
+    /**
+     * A test value
+     */
+    public static final String REPOSITORY_NAME = "Repository A";
+
+    /**
+     * A test value
+     */
+    public static final String REPOSITORY_DESCRIPTION = "An OA repository run by funder A";
+
+    /**
+     * A test value
+     */
+    public static final String REPOSITORY_AGREEMENTTEXT = "I agree to the repository deposit agreement";
+
+    /**
+     * A test value
+     */
+    public static final String REPOSITORY_URL = "https://repo-example.org/";
+
+    /**
+     * A test value
+     */
+    // todo: verify format of formSchema field
+    public static final String REPOSITORY_FORMSCHEMA = "{\"customFieldName\": \"String\"}";
+
+    /**
+     * A test value
+     */
+    public static final String REPOSITORY_INTEGRATION_TYPE = "web-link";
+
+    /**
+     * A test value
+     */
+    public static final String REPOSITORY_KEY = "nih-repository";
+
+    /**
+     * A test value
+     */
+    public static final String REPOSITORYCOPY_STATUS = "accepted";
+
+    /**
+     * A test value
+     */
+    public static final String REPOSITORYCOPY_EXTERNALID_1 = "PMC12345";
+
+    /**
+     * A test value
+     */
+    public static final String REPOSITORYCOPY_EXTERNALID_2 = "NIHMS1234";
+
+    /**
+     * A test value
+     */
+    public static final String REPOSITORYCOPY_ACCESSURL = "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC12345/";
+
+    /**
+     * A test value
+     */
+    public static final String SUBMISSION_AGG_DEPOSIT_STATUS = "in-progress";
+
+    /**
+     * A test value
+     */
+    public static final String SUBMISSION_STATUS = "submitted";
+
+    /**
+     * A test value
+     */
+    public static final String SUBMISSION_DATE_STR = "2018-01-05T12:12:12.000Z";
+
+    /**
+     * A test value
+     */
+    public static final String SUBMISSION_SOURCE = "pass";
+
+    /**
+     * A test value
+     */
+    public static final Boolean SUBMISSION_SUBMITTED = true;
+
+    /**
+     * A test value
+     */
+    public static final String SUBMISSION_METADATA = "{\"customFieldName\": \"value\"}";
+
+    /**
+     * A test value
+     */
+    public static final String SUBMISSION_SUBMITTERNAME = "J Smith";
+
+    /**
+     * A test value
+     */
+    public static final String SUBMISSION_SUBMITTEREMAIL = "mailto:j.smith@example.com";
+
+    /**
+     * A test value
+     */
+    public static final String SUBMISSIONEVENT_EVENT_TYPE = "approval-requested";
+
+    /**
+     * A test value
+     */
+    public static final String SUBMISSIONEVENT_PERFORMED_DATE_STR = "2018-01-06T12:12:12.000Z";
+
+    /**
+     * A test value
+     */
+    public static final String SUBMISSIONEVENT_PERFORMER_ROLE = "preparer";
+
+    /**
+     * A test valuue
+     */
+    public static final String SUBMISSIONEVENT_COMMENT = "Does this look OK?";
+
+    /**
+     * A test value
+     */
+    public static final String SUBMISSIONEVENT_LINK = "https://example.org/ember/path/to/submission";
+
+    /**
+     * A test value
+     */
+    public static final String USER_NAME = "am12345";
+
+    /**
+     * A test value
+     */
+    public static final String USER_FIRST_NAME = "June";
+
+    /**
+     * A test value
+     */
+    public static final String USER_MIDDLE_NAME = "Marie";
+
+    /**
+     * A test value
+     */
+    public static final String USER_LAST_NAME = "Smith";
+
+    /**
+     * A test value
+     */
+    public static final String USER_DISPLAY_NAME = "June Smith";
+
+    /**
+     * A test value
+     */
+    public static final String USER_EMAIL = "js@example.com";
+
+    /**
+     * A test value
+     */
+    public static final String USER_LOCATORID1 = "johnshopkins.edu:employeeid:12345";
+
+    /**
+     * A test value
+     */
+    public static final String USER_LOCATORID2 = "johnshopkins.edu:hopkinsid:DRA2D";
+
+    /**
+     * A test value
+     */
+    public static final String USER_ORCID_ID = "https://orcid.org/0000-1111-2222-3333";
+
+    /**
+     * A test value
+     */
+    @SuppressWarnings("serial")
+    public static final Set<String> USER_AFFILIATION = new HashSet<String>() {
+        {
+            add("Johns Hopkins University");
+        }
+    };
+
+    /**
+     * A test value
+     */
+    public static final String USER_ROLE_1 = "admin";
+
+    /**
+     * A test value
+     */
+    public static final String USER_ROLE_2 = "submitter";
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.eclipse.pass</groupId>
+    <artifactId>eclipse-pass-parent</artifactId>
+    <version>0.2.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>pass-support</artifactId>
+  <packaging>pom</packaging>
+
+  <name>PASS backend</name>
+  <description>PASS support module</description>
+  <url>https://github.com/eclipse-pass/pass-support</url>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Jim Martino</name>
+      <email>jrm.jhu@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins Univeristy</organization>
+      <organizationUrl>https://www.library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Mark Patton</name>
+      <email>mpatton@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins Univeristy</organization>
+      <organizationUrl>https://www.library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>John Abrahams</name>
+      <email>jabrah20@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://www.library.jhu.edu/</organizationUrl>
+    </developer>
+  </developers>
+
+  <modules>
+    <module>pass-data-client</module>
+  </modules>
+
+  <scm>
+    <connection>scm:git:https://github.com/eclipse-pass/pass-support.git</connection>
+    <developerConnection>scm:git:https://github.com/eclipse-pass/pass-support.git</developerConnection>
+    <url>https://github.com/eclipse-pass/pass-support</url>
+    <tag>HEAD</tag>
+  </scm>
+
+  <properties>
+    <junit.version>4.12</junit.version>
+    <elide.version>6.1.8</elide.version>
+    <spring.version>2.5.6</spring.version>
+    <junit.jupiter.version>5.5.2</junit.jupiter.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+    </dependencies>
+  </dependencyManagement>
+
+  <repositories>
+    <repository>
+      <id>sonatype-nexus-snapshots</id>
+      <name>Sonatype Nexus Snapshots</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>${maven-source-plugin.version}</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>${maven-surefire-plugin.version}</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>${maven-javadoc-plugin.version}</version>
+          <executions>
+            <execution>
+              <id>attach-javadocs</id>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+	
+        <plugin>
+          <groupId>io.fabric8</groupId>
+          <artifactId>docker-maven-plugin</artifactId>
+          <version>${docker-maven-plugin.version}</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>build-helper-maven-plugin</artifactId>
+          <version>${build-helper-maven-plugin.version}</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <version>${maven-failsafe-plugin.version}</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-war-plugin</artifactId>
+          <version>${maven-war-plugin.version}</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
This pr sets up the pass-support module and also adds a pass-data-client module.
The pass-data-client module provides a library for doing CRUD on PASS objects using the PASS API as produced by pass-core.

You will note that the pr duplicates the Java model in pass-core. This is pretty much unavoidable given the different technologies being used in each case. Each technology requires the Java model be constructed somewhat differently and be annotated differently. Sharing the code seems more trouble than it is worth. There is also a great deal of overlap between between the PassClient designs in pass-core and pass-support. But the designs do have some differences (see relationship handling) and the implementations are completely different.

The integration test runs pass-core using docker. I explored running the pass-core jar directly, but ultimately using a docker container seemed less complex and resulted in fewer entanglements with pass-core. The test writes and reads every type of object and uses every field of those types.

The PassClient implementation supports doing basic auth to pass-core. It remains to be seen how authentication will actually work.
