### PR TITLE
Fix authentication

### DIFF
--- a/pass-data-client/pom.xml
+++ b/pass-data-client/pom.xml
@@ -4,16 +4,18 @@
   <parent>
     <groupId>org.eclipse.pass</groupId>
     <artifactId>pass-support</artifactId>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>pass-data-client</artifactId>
-  <version>0.3.0-SNAPSHOT</version>
+  <version>0.4.0-SNAPSHOT</version>
 
   <!-- Properties for ITs -->
   <properties>
     <pass.core.port>8080</pass.core.port>
     <pass.core.url>http://localhost:8080</pass.core.url>
+    <pass.core.backend.user>backend</pass.core.backend.user>
+    <pass.core.backend.password>backend</pass.core.backend.password>
   </properties>
   
   <dependencies>
@@ -78,11 +80,17 @@
             <image>
               <name>ghcr.io/eclipse-pass/pass-core-main:%v</name>
               <run>
+		<env>
+                  <PASS_CORE_BASE_URL>${pass.core.url}</PASS_CORE_BASE_URL>
+                  <PASS_CORE_BACKEND_USER>${pass.core.backend.user}</PASS_CORE_BACKEND_USER>
+                  <PASS_CORE_BACKEND_PASSWORD>${pass.core.backend.password}</PASS_CORE_BACKEND_PASSWORD>		  
+		</env>
                 <wait>
                   <http>
                     <url>
                       ${pass.core.url}/data/grant
                     </url>
+		    <status>401</status>
                   </http>
                   <time>60000</time>
                 </wait>

--- a/pass-data-client/src/test/java/org/eclipse/pass/support/client/JsonApiPassClientIT.java
+++ b/pass-data-client/src/test/java/org/eclipse/pass/support/client/JsonApiPassClientIT.java
@@ -50,7 +50,10 @@ public class JsonApiPassClientIT {
     @BeforeAll
     public static void setup() {
         String base_url = System.getProperty("pass.core.url", "http://localhost:8080");
-        client = new JsonApiPassClient(base_url);
+        String backend_user = System.getProperty("pass.core.backend.user", "backend");
+        String backend_password = System.getProperty("pass.core.backend.password", "backend");
+
+        client = new JsonApiPassClient(base_url, backend_user, backend_password);
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -5,14 +5,14 @@
   <parent>
     <groupId>org.eclipse.pass</groupId>
     <artifactId>eclipse-pass-parent</artifactId>
-    <version>0.3.0</version>
+    <version>0.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>pass-support</artifactId>
-  <version>0.3.0-SNAPSHOT</version>
+  <version>0.4.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
-  <name>PASS backend</name>
+  <name>PASS support</name>
   <description>PASS support module</description>
   <url>https://github.com/eclipse-pass/pass-support</url>
   <licenses>


### PR DESCRIPTION
As of 0.4.0, the pass-data-clients need to authenticate as the backend user.  Setup the docker environment and the tests to do so.

The pr also updates everything to 0.4.0-SNAPSHOT.