### PR TITLE
Fix data client update

### DIFF
--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/JsonApiPassClient.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/JsonApiPassClient.java
@@ -169,7 +169,7 @@ public class JsonApiPassClient implements PassClient {
         String url = get_url(obj);
         RequestBody body = RequestBody.create(json, JSON_API_MEDIA_TYPE);
         Request request = new Request.Builder().url(url).header("Accept", JSON_API_CONTENT_TYPE)
-                .addHeader("Content-Type", JSON_API_CONTENT_TYPE).post(body).build();
+                .addHeader("Content-Type", JSON_API_CONTENT_TYPE).patch(body).build();
 
         Response response = client.newCall(request).execute();
 

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/PassClient.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/PassClient.java
@@ -79,7 +79,8 @@ public interface PassClient {
     <T extends PassEntity> void createObject(T obj) throws IOException;
 
     /**
-     * Update an existing object.
+     * Update an existing object. Note that a relationship cannot be removed by
+     * setting it to null.
      *
      * @param <T> type of the object
      * @param obj object to update

--- a/pass-data-client/src/test/java/org/eclipse/pass/support/client/JsonApiPassClientIT.java
+++ b/pass-data-client/src/test/java/org/eclipse/pass/support/client/JsonApiPassClientIT.java
@@ -39,6 +39,7 @@ import org.eclipse.pass.support.client.model.RepositoryCopy;
 import org.eclipse.pass.support.client.model.Source;
 import org.eclipse.pass.support.client.model.Submission;
 import org.eclipse.pass.support.client.model.SubmissionEvent;
+import org.eclipse.pass.support.client.model.SubmissionStatus;
 import org.eclipse.pass.support.client.model.User;
 import org.eclipse.pass.support.client.model.UserRole;
 import org.junit.jupiter.api.BeforeAll;
@@ -130,21 +131,39 @@ public class JsonApiPassClientIT {
     @Test
     public void testUpdateObject() throws IOException {
 
-        Publication pub = new Publication();
-        pub.setTitle("Ten puns");
+        Publication pub1 = new Publication();
+        pub1.setTitle("Ten puns");
 
-        client.createObject(pub);
+        Publication pub2 = new Publication();
+        pub1.setTitle("Twenty puns");
+
+        client.createObject(pub1);
+        client.createObject(pub2);
 
         Submission sub = new Submission();
 
         sub.setAggregatedDepositStatus(AggregatedDepositStatus.NOT_STARTED);
         sub.setSource(Source.PASS);
-        sub.setPublication(pub);
+        sub.setPublication(pub1);
         sub.setSubmitterName("Name");
         sub.setSubmitted(false);
 
         client.createObject(sub);
 
+        assertEquals(sub, client.getObject(sub, "publication"));
+
+        // Try to update pub1 attributes
+        pub1.setTitle("Different title");
+
+        client.updateObject(pub1);
+        assertEquals(pub1, client.getObject(pub1));
+
+        // Try to update sub attributes and relationship
+        sub.setSource(Source.OTHER);
+        sub.setSubmissionStatus(SubmissionStatus.CANCELLED);
+        sub.setPublication(pub2);
+
+        client.updateObject(sub);
         assertEquals(sub, client.getObject(sub, "publication"));
     }
 


### PR DESCRIPTION
The updateObject method was doing a post, not the required patch.
Also document the behavior of trying to update a relationship with null.
Correct the updateObject test such that it actually tests updates