### PR TITLE
Fix PassClient.updateObject handling of null values

### DIFF
--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/PassClient.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/PassClient.java
@@ -79,8 +79,7 @@ public interface PassClient {
     <T extends PassEntity> void createObject(T obj) throws IOException;
 
     /**
-     * Update an existing object. Note that a relationship cannot be removed by
-     * setting it to null.
+     * Update an existing object.
      *
      * @param <T> type of the object
      * @param obj object to update

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/Grant.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/Grant.java
@@ -17,6 +17,7 @@ package org.eclipse.pass.support.client.model;
 
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -245,7 +246,7 @@ public class Grant implements PassEntity {
      * @param coPis the coPis to set
      */
     public void setCoPis(List<User> coPis) {
-        this.coPis = coPis;
+        this.coPis = coPis == null ? Collections.emptyList() : coPis;
     }
 
     /**

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/Grant.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/Grant.java
@@ -17,7 +17,6 @@ package org.eclipse.pass.support.client.model;
 
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -246,7 +245,7 @@ public class Grant implements PassEntity {
      * @param coPis the coPis to set
      */
     public void setCoPis(List<User> coPis) {
-        this.coPis = coPis == null ? Collections.emptyList() : coPis;
+        this.coPis = coPis == null ? new ArrayList<>() : coPis;
     }
 
     /**

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/Journal.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/Journal.java
@@ -30,6 +30,7 @@ import jsonapi.ToOne;
  */
 
 @Resource(type = "journal")
+
 public class Journal implements PassEntity {
     /**
      * Unique id for the resource.

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/Policy.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/Policy.java
@@ -17,6 +17,7 @@ package org.eclipse.pass.support.client.model;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -160,7 +161,7 @@ public class Policy implements PassEntity {
      * @param repositories list repositories to set
      */
     public void setRepositories(List<Repository> repositories) {
-        this.repositories = repositories;
+        this.repositories = repositories == null ? Collections.emptyList() : repositories;
     }
 
     @Override

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/Policy.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/Policy.java
@@ -17,7 +17,6 @@ package org.eclipse.pass.support.client.model;
 
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -161,7 +160,7 @@ public class Policy implements PassEntity {
      * @param repositories list repositories to set
      */
     public void setRepositories(List<Repository> repositories) {
-        this.repositories = repositories == null ? Collections.emptyList() : repositories;
+        this.repositories = repositories == null ? new ArrayList<>() : repositories;
     }
 
     @Override

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/Submission.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/Submission.java
@@ -18,7 +18,6 @@ package org.eclipse.pass.support.client.model;
 import java.net.URI;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -286,7 +285,7 @@ public class Submission implements PassEntity {
      * @param repositories the repositories to set
      */
     public void setRepositories(List<Repository> repositories) {
-        this.repositories = repositories == null ? Collections.emptyList() : repositories;
+        this.repositories = repositories == null ? new ArrayList<>() : repositories;
     }
 
     /**
@@ -350,7 +349,7 @@ public class Submission implements PassEntity {
      * @param preparers the preparers to set
      */
     public void setPreparers(List<User> preparers) {
-        this.preparers = preparers == null ? Collections.emptyList() : preparers;
+        this.preparers = preparers == null ? new ArrayList<>() : preparers;
     }
 
     /**
@@ -364,7 +363,7 @@ public class Submission implements PassEntity {
      * @param grants the grants to set
      */
     public void setGrants(List<Grant> grants) {
-        this.grants = grants == null ? Collections.emptyList() : grants;
+        this.grants = grants == null ? new ArrayList<>() : grants;
     }
 
     /**
@@ -378,7 +377,7 @@ public class Submission implements PassEntity {
      * @param effectivePolicies the policies being satisfied upon submission
      */
     public void setEffectivePolicies(List<Policy> effectivePolicies) {
-        this.effectivePolicies = effectivePolicies == null ? Collections.emptyList() : effectivePolicies;
+        this.effectivePolicies = effectivePolicies == null ? new ArrayList<>() : effectivePolicies;
     }
 
     @Override

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/Submission.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/Submission.java
@@ -18,6 +18,7 @@ package org.eclipse.pass.support.client.model;
 import java.net.URI;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -285,7 +286,7 @@ public class Submission implements PassEntity {
      * @param repositories the repositories to set
      */
     public void setRepositories(List<Repository> repositories) {
-        this.repositories = repositories;
+        this.repositories = repositories == null ? Collections.emptyList() : repositories;
     }
 
     /**
@@ -349,7 +350,7 @@ public class Submission implements PassEntity {
      * @param preparers the preparers to set
      */
     public void setPreparers(List<User> preparers) {
-        this.preparers = preparers;
+        this.preparers = preparers == null ? Collections.emptyList() : preparers;
     }
 
     /**
@@ -363,7 +364,7 @@ public class Submission implements PassEntity {
      * @param grants the grants to set
      */
     public void setGrants(List<Grant> grants) {
-        this.grants = grants;
+        this.grants = grants == null ? Collections.emptyList() : grants;
     }
 
     /**
@@ -377,7 +378,7 @@ public class Submission implements PassEntity {
      * @param effectivePolicies the policies being satisfied upon submission
      */
     public void setEffectivePolicies(List<Policy> effectivePolicies) {
-        this.effectivePolicies = effectivePolicies;
+        this.effectivePolicies = effectivePolicies == null ? Collections.emptyList() : effectivePolicies;
     }
 
     @Override

--- a/pass-data-client/src/test/java/org/eclipse/pass/support/client/JsonApiPassClientIT.java
+++ b/pass-data-client/src/test/java/org/eclipse/pass/support/client/JsonApiPassClientIT.java
@@ -154,7 +154,11 @@ public class JsonApiPassClientIT {
 
         // Try to update pub1 attributes
         pub1.setTitle("Different title");
+        client.updateObject(pub1);
+        assertEquals(pub1, client.getObject(pub1));
 
+        // Try to remove attribute
+        pub1.setTitle(null);
         client.updateObject(pub1);
         assertEquals(pub1, client.getObject(pub1));
 
@@ -162,9 +166,45 @@ public class JsonApiPassClientIT {
         sub.setSource(Source.OTHER);
         sub.setSubmissionStatus(SubmissionStatus.CANCELLED);
         sub.setPublication(pub2);
-
         client.updateObject(sub);
         assertEquals(sub, client.getObject(sub, "publication"));
+
+        // Try to remove the relationship
+        sub.setPublication(null);
+        client.updateObject(sub);
+        assertEquals(sub, client.getObject(sub, "publication"));
+    }
+
+    @Test
+    public void testUpdateObjectMultipleRelationships() throws IOException {
+        Repository rep1 = new Repository();
+        rep1.setDescription("one");
+
+        Repository rep2 = new Repository();
+        rep2.setDescription("two");
+
+        client.createObject(rep1);
+        client.createObject(rep2);
+
+        Submission sub = new Submission();
+        sub.setSubmitterName("Bob");
+
+        client.createObject(sub);
+
+        // Add multiple value relationship
+        sub.setRepositories(Arrays.asList(rep1, rep2));
+        client.updateObject(sub);
+        assertEquals(sub, client.getObject(sub, "repositories"));
+
+        // Delete one value of relationship
+        sub.setRepositories(Arrays.asList(rep2));
+        client.updateObject(sub);
+        assertEquals(sub, client.getObject(sub, "repositories"));
+
+        // Try to delete the relationship
+        sub.setRepositories(null);
+        client.updateObject(sub);
+        assertEquals(sub, client.getObject(sub, "repositories"));
     }
 
     @Test
@@ -213,7 +253,7 @@ public class JsonApiPassClientIT {
     }
 
     private static ZonedDateTime dt(String s) {
-        return ZonedDateTime.parse("2010-12-10T02:01:20.300Z", Util.dateTimeFormatter());
+        return ZonedDateTime.parse(s, Util.dateTimeFormatter());
     }
 
     @Test


### PR DESCRIPTION
This pr makes sure that PassClient.updateObject correctly serializes null values into the JSON API document for the patch request. Before attributes and relationships with null values were not included in the serialization which prevented those values from being deleted when doing an update.

Handling the to one relationships was a bit awkward, but it seems to work. Handling the too many relationships required making sure that the lists holding the references are never null.

In order to test do a `mvn clean verify`.



