### PR TITLE
Port submission status service

### DIFF
--- a/pass-data-client/pom.xml
+++ b/pass-data-client/pom.xml
@@ -36,7 +36,13 @@
       <artifactId>javapoet</artifactId>
       <version>${javapoet.version}</version>
     </dependency>
-    
+
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>${logback.version}</version>
+    </dependency>
+
     <!-- Test dependencies -->
 
     <dependency>
@@ -52,6 +58,21 @@
       <version>${junit.jupiter.version}</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/SubmissionStatusCalculator.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/SubmissionStatusCalculator.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.pass.support.client.model.CopyStatus;
+import org.eclipse.pass.support.client.model.Deposit;
+import org.eclipse.pass.support.client.model.DepositStatus;
+import org.eclipse.pass.support.client.model.EventType;
+import org.eclipse.pass.support.client.model.Repository;
+import org.eclipse.pass.support.client.model.RepositoryCopy;
+import org.eclipse.pass.support.client.model.SubmissionEvent;
+import org.eclipse.pass.support.client.model.SubmissionStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A utility to calculate and validate the Submission Status. Separate calculations are provided depending
+ * on whether the Submission has been submitted or not since different data and rules apply
+ *
+ * @author Karen Hanson
+ */
+public class SubmissionStatusCalculator {
+
+    private SubmissionStatusCalculator() {
+    }
+
+    private static final Logger LOG = LoggerFactory.getLogger(SubmissionStatusCalculator.class);
+
+    /**
+     * Calculates the appropriate post-Submission status based on data provided.
+     * <p>
+     * Post-Submission calculations uses the {@code Deposits} and {@code RepositoryCopies} associated
+     * with a {@code Submission's} {@code Repositories} to determine the status of a Submission
+     * after it has been submitted ({@code Submission.status=true}.
+     * </p>
+     *
+     * @param repositoryIds    Submission repository ids
+     * @param deposits         Submission deposits
+     * @param repositoryCopies Submission repository copies
+     * @return Calculated submission status
+     */
+    public static SubmissionStatus calculatePostSubmissionStatus(List<String> repositoryIds,
+                                                                 List<Deposit> deposits,
+                                                                 List<RepositoryCopy> repositoryCopies) {
+        if (repositoryIds == null) {
+            repositoryIds = new ArrayList<String>();
+        }
+        if (deposits == null) {
+            deposits = new ArrayList<Deposit>();
+        }
+        if (repositoryCopies == null) {
+            repositoryCopies = new ArrayList<RepositoryCopy>();
+        }
+
+        Map<String, SubmissionStatus> statusMap = mapPostSubmissionRepositoryStatuses(repositoryIds, deposits,
+                                                                                   repositoryCopies);
+        return calculateFromStatusMap(statusMap);
+    }
+
+    /**
+     * Calculates the appropriate pre-Submission status based on data provided.
+     * <p>
+     * Pre-Submission calculations use the {@code SubmissionEvents} associated with Submission
+     * to determine the status of a Submission before it has been submitted Submission.submitted=false.
+     * </p>
+     * <p>
+     * If a default status is provided, it will be returned <em>only if</em> a status cannot be determined from the
+     * submission events. If no default status is provided, <em>and</em> a status cannot be determined from the
+     * submission events, then this method returns {@code MANUSCRIPT_REQUIRED} in order to maintain backwards
+     * compatibility.
+     * </p>
+     *
+     * @param submissionEvents List of submission events
+     * @param defaultStatus    the the status to be returned if no status can be determined from the submission
+     *                         events, may
+     *                         be {@code null}
+     * @return calculated submission status, or the default status if one cannot be calculated from the events
+     */
+    public static SubmissionStatus calculatePreSubmissionStatus(List<SubmissionEvent> submissionEvents,
+                                                                SubmissionStatus defaultStatus) {
+        if (submissionEvents == null) {
+            submissionEvents = new ArrayList<SubmissionEvent>();
+        }
+        if (submissionEvents.size() > 0) {
+            // should only be used to set a status if the status is starting as null since UI is best for setting
+            // status,
+            // but will warn if the most recent event does not reflect current status
+            EventType mostRecentEventType = Collections
+                .max(submissionEvents, Comparator.comparing(SubmissionEvent::getPerformedDate))
+                .getEventType();
+
+            return mapEventTypeToSubmissionStatus(mostRecentEventType);
+
+        } else {
+            // has not yet been acted on; may be awaiting a manuscript, or the UI may have set the status.
+            if (defaultStatus == null) {
+                return SubmissionStatus.MANUSCRIPT_REQUIRED;
+            }
+
+            return defaultStatus;
+        }
+    }
+
+    /**
+     * Checks validity of {@link SubmissionStatus} change, will throw exception or output a warning if there are any
+     * validation issue with the change
+     *
+     * @param submitted  Whether the submission is submitted
+     * @param fromStatus Original status
+     * @param toStatus   Desired new status
+     */
+    public static void validateStatusChange(boolean submitted, SubmissionStatus fromStatus, SubmissionStatus toStatus) {
+        if (toStatus == null) {
+            throw new IllegalArgumentException("The new status cannot be null");
+        }
+        if (submitted) {
+            if (!toStatus.isSubmitted()) {
+                String msg = String.format(
+                    "Failed to validate the change of status due to conflicting data. The status "
+                    + "`%s` cannot be assigned to a Submission that has not yet been submitted. There may be a data " +
+                    "issue.",
+                    fromStatus);
+                throw new RuntimeException(msg);
+            }
+        } else {
+            if (toStatus.isSubmitted()) {
+                String msg = String.format(
+                    "Failed to validate the change of status due to conflicting data. The status "
+                    + "`%s` cannot be assigned to a Submission that has already been submitted. There may be a data " +
+                    "issue.",
+                    fromStatus);
+                throw new RuntimeException(msg);
+            }
+            if (fromStatus != null && fromStatus.isSubmitted()) {
+                String msg = String.format(
+                    "Failed to validate the change of status due to conflicting data. The current "
+                    + "status of the Submission is `%s`. This indicates that the Submission was already submitted and "
+                    + "therefore should not be assigned a pre-submission status. There may be a data issue.",
+                    fromStatus);
+                throw new RuntimeException(msg);
+            }
+
+            if (fromStatus != null && !toStatus.equals(fromStatus)) {
+                LOG.warn(
+                    "The current status of the Submission conflicts with the status calculated based on the most " +
+                    "recent SubmissionEvent. "
+                    + "The status on the Submission record is `{}`, while the calculated status is `{}`. The UI is " +
+                    "responsible for setting "
+                    + "pre-Submission statuses, but this mismatch may indicate a data issue.", fromStatus, toStatus);
+            }
+        }
+
+    }
+
+    private static SubmissionStatus calculateFromStatusMap(Map<String, SubmissionStatus> statusMap) {
+        //we only need to know if a status is present or not to determine combined status
+        Set<SubmissionStatus> statuses = new HashSet<SubmissionStatus>(statusMap.values());
+
+        if (statuses.contains(SubmissionStatus.NEEDS_ATTENTION)) {
+            return SubmissionStatus.NEEDS_ATTENTION;
+        } else if (statuses.size() == 1 && statuses.contains(SubmissionStatus.COMPLETE)) {
+            return SubmissionStatus.COMPLETE;
+        } else {
+            return SubmissionStatus.SUBMITTED;
+        }
+    }
+
+    private static Map<String, SubmissionStatus> mapPostSubmissionRepositoryStatuses(List<String> repositoryIds,
+                                                                                  List<Deposit> deposits,
+                                                                                  List<RepositoryCopy> repoCopies) {
+
+        Map<String, SubmissionStatus> statusMap = new HashMap<String, SubmissionStatus>();
+
+        for (String id: repositoryIds) {
+            statusMap.put(id, null);
+        }
+        for (Deposit d : deposits) {
+            if (DepositStatus.REJECTED.equals(d.getDepositStatus())) {
+                statusMap.put(d.getRepository().getId(), SubmissionStatus.NEEDS_ATTENTION);
+            } else {
+                statusMap.put(d.getRepository().getId(), SubmissionStatus.SUBMITTED);
+            }
+        }
+        for (RepositoryCopy rc : repoCopies) {
+            Repository repo = rc.getRepository();
+            CopyStatus copyStatus = rc.getCopyStatus();
+
+            if (CopyStatus.COMPLETE.equals(copyStatus)) {
+                statusMap.put(repo.getId(), SubmissionStatus.COMPLETE);
+            } else if (CopyStatus.REJECTED.equals(copyStatus) || CopyStatus.STALLED.equals(copyStatus)) {
+                statusMap.put(repo.getId(), SubmissionStatus.NEEDS_ATTENTION);
+            } else {
+                // There is a RepositoryCopy and nothing is wrong. Note in this state, it will overwrite a status of
+                // REJECTED on the Deposit. This assumes that if all is OK with the RepositoryCopy things have been
+                // resolved.
+                statusMap.put(repo.getId(), SubmissionStatus.SUBMITTED);
+            }
+        }
+
+        return statusMap;
+    }
+
+    private static SubmissionStatus mapEventTypeToSubmissionStatus(EventType eventType) {
+        switch (eventType) {
+            case APPROVAL_REQUESTED:
+                return SubmissionStatus.APPROVAL_REQUESTED;
+            case APPROVAL_REQUESTED_NEWUSER:
+                return SubmissionStatus.APPROVAL_REQUESTED;
+            case SUBMITTED:
+                return SubmissionStatus.SUBMITTED;
+            case CANCELLED:
+                return SubmissionStatus.CANCELLED;
+            case CHANGES_REQUESTED:
+                return SubmissionStatus.CHANGES_REQUESTED;
+            default:
+                return null;
+        }
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/SubmissionStatusService.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/SubmissionStatusService.java
@@ -1,0 +1,230 @@
+package org.eclipse.pass.support.client;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.eclipse.pass.support.client.model.Deposit;
+import org.eclipse.pass.support.client.model.PassEntity;
+import org.eclipse.pass.support.client.model.Repository;
+import org.eclipse.pass.support.client.model.RepositoryCopy;
+import org.eclipse.pass.support.client.model.Submission;
+import org.eclipse.pass.support.client.model.SubmissionEvent;
+import org.eclipse.pass.support.client.model.SubmissionStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A service for calculating and updating the `Submission.submissionStatus` value based on data
+ * related to the Submission. By default, there is a division of responsibility in calculating
+ * this status, with pre-submission statuses being managed by the UI, and post-Submission statuses
+ * being managed by back-end services. For this reason, pre-submission statuses will only be changed
+ * if the starting value is null, or overrideUIStatus is true.
+ *
+ * @author Karen Hanson
+ */
+public class SubmissionStatusService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SubmissionStatusService.class);
+
+    private PassClient client;
+
+    /**
+     * Initiate service
+     */
+    public SubmissionStatusService() {
+        this.client = PassClient.newInstance();
+    }
+
+    /**
+     * Supports setting a specific client.
+     *
+     * @param client PASS client
+     */
+    public SubmissionStatusService(PassClient client) {
+        if (client == null) {
+            throw new IllegalArgumentException("PassClient cannot be null");
+        }
+        this.client = client;
+    }
+
+    /**
+     * Calculates the appropriate {@link SubmissionStatus} for the {@code Submission.id} provided.
+     * This is based on the status of associated {@link Deposit}s and {@link RepositoryCopy}s for
+     * {@code submitted} records, and the existing status (if any) and {@link SubmissionEvent}s for unsubmitted records.
+     *
+     * @param submissionId Submission URI
+     * @return calculated submission status.
+     */
+    public SubmissionStatus calculateSubmissionStatus(String submissionId) {
+        Submission submission = loadSubmission(submissionId);
+        return calculateSubmissionStatus(submission);
+    }
+
+    /**
+     * Calculates the appropriate {@link SubmissionStatus} for the {@link Submission} provided.
+     * This is based on the status of associated {@link Deposit}s and {@link RepositoryCopy}s for
+     * {@code submitted} records, and the existing status (if any) and {@link SubmissionEvent}s for unsubmitted records.
+     *
+     * @param submission The submission
+     * @return Calculated submission status
+     */
+    public SubmissionStatus calculateSubmissionStatus(Submission submission) {
+        if (submission == null) {
+            throw new IllegalArgumentException("submission cannot be null");
+        }
+        if (submission.getId() == null) {
+            throw new IllegalArgumentException(
+                "No status could be calculated for the Submission as it does not have a `Submission.id`.");
+        }
+
+        SubmissionStatus fromStatus = submission.getSubmissionStatus();
+        SubmissionStatus toStatus;
+
+        if (!submission.getSubmitted()) {
+            List<SubmissionEvent> submissionEvents = getRelationshipSubject(SubmissionEvent.class, "submission.id",
+                    submission.getId());
+
+            // Calculate the pre-submission status, defaulting to the existing status if one cannot be determined
+            // from the submission events.
+            toStatus = SubmissionStatusCalculator.calculatePreSubmissionStatus(submissionEvents,
+                                                                               submission.getSubmissionStatus());
+
+        } else {
+            List<Deposit> deposits = getRelationshipSubject(Deposit.class, "submission.id", submission.getId());
+            List<RepositoryCopy> repositoryCopies = getRelationshipSubject(RepositoryCopy.class,
+                    "publication.id", submission.getPublication().getId());
+
+            toStatus = SubmissionStatusCalculator.calculatePostSubmissionStatus(submission.getRepositories()
+                    .stream().map(Repository::getId).collect(Collectors.toList()), deposits,
+                    repositoryCopies);
+        }
+
+        try {
+            SubmissionStatusCalculator.validateStatusChange(submission.getSubmitted(), fromStatus, toStatus);
+        } catch (RuntimeException ex) {
+            String msg = String.format("Cannot change status from %s to %s on Submission %s. "
+                                       + "The following explaination was provided: %s", fromStatus, toStatus,
+                                       submission.getId(), ex.getMessage());
+            throw new RuntimeException(msg);
+        }
+
+        return toStatus;
+
+    }
+
+    <T extends PassEntity> List<T> getRelationshipSubject(Class<T> type, String predicate,
+            String targetId, String... include) {
+        PassClientSelector<T> sel = new PassClientSelector<>(type);
+        sel.setFilter(RSQL.equals(predicate, targetId));
+        sel.setInclude(include);
+
+        try {
+            return client.streamObjects(sel).collect(Collectors.toList());
+        } catch (IOException e) {
+            String msg = String.format("Failed to retrieve objects with target %s and predicate %s. "
+                    + "The following explaination was provided: %s", targetId, predicate, e.getMessage());
+            throw new RuntimeException(msg);
+        }
+    }
+
+    /**
+     * Calculates the appropriate {@link SubmissionStatus} for the {@code Submission.id} provided.
+     * <p>
+     * This is based on the status of associated {@link Deposit}s and {@link RepositoryCopy}s for
+     * {@code submitted} records, and {@link SubmissionEvent}s for unsubmitted records then updates
+     * the status as appropriate.
+     * </p>
+     * <p>
+     * The UI will typically have responsibility for updating the {@code submissionStatus} before
+     * the {@link Submission} is submitted. Therefore, by default this service will not replace
+     * the existing status of an unsubmitted record unless the starting value was null (i.e. it has not
+     * been populated yet). To override this constraint, and replace the value anyway, use the method
+     * {@code calculateAndUpdateSubmissionStatus(boolean overrideUIStatus)} and supply a parameter of {@code true}
+     * </p>
+     *
+     * @param submissionId Submission URI
+     * @return Calculated submission status
+     */
+    public SubmissionStatus calculateAndUpdateSubmissionStatus(String submissionId) {
+        return calculateAndUpdateSubmissionStatus(submissionId, false);
+    }
+
+    /**
+     * Calculates the appropriate {@link SubmissionStatus} for the {@link Submission} provided.
+     *
+     * <p>
+     * This is based on the status of associated {@link Deposit}s and {@link RepositoryCopy}s for
+     * {@code submitted} records, and {@link SubmissionEvent}s for unsubmitted records then updates
+     * the status as appropriate.
+     * </p>
+     * <p>
+     * The UI will typically have responsibility for updating the {@code submissionStatus} before
+     * the {@link Submission} is submitted. Therefore, by default this service will not replace
+     * the existing status of an unsubmitted record unless the starting value was null (i.e. it has not
+     * been populated yet). To override this constraint, set the {@code overrideUIStatus} parameter to
+     * {@code true}
+     * </p>
+     *
+     * @param submissionId     Submission identifier
+     * @param overrideUIStatus - {@code true} will override the current pre-submission status on the
+     *                         {@code Submission} record, regardless of whether it was set by the UI.
+     *                         {@code false} will not replace the current submission value, and favor the value set
+     *                         by the UI
+     * @return calculated submission status.
+     */
+    public SubmissionStatus calculateAndUpdateSubmissionStatus(String submissionId, boolean overrideUIStatus) {
+
+        Submission submission = loadSubmission(submissionId);
+
+        SubmissionStatus fromStatus = submission.getSubmissionStatus();
+        SubmissionStatus toStatus = calculateSubmissionStatus(submission);
+
+        if (fromStatus == null || !fromStatus.equals(toStatus)) {
+
+            //Applies special rule - this service should not overwrite what the UI has set the status to
+            //unless the original status was null or this service has been specifically configured to do so
+            //by setting overrideUIStatus to true.
+            if (!overrideUIStatus && !submission.getSubmitted() && fromStatus != null) {
+                LOG.info("Status of Submission {} did not change because pre-submission UI statuses are protected. "
+                         + "The current status will stay as `{}`", submission.getId(), fromStatus);
+                return fromStatus;
+            }
+
+            submission.setSubmissionStatus(toStatus);
+            LOG.info("Updating status of Submission {} from `{}` to `{}`", submission.getId(), fromStatus, toStatus);
+            try {
+                client.updateObject(submission);
+            } catch (IOException e) {
+                String msg = String.format("Failed to retrieve Submission with ID %s from the database", submissionId);
+                throw new RuntimeException(msg);
+            }
+
+        } else {
+            LOG.debug("Status of Submission {} did not change. The current status is `{}`", submission.getId(),
+                      fromStatus);
+        }
+
+        return toStatus;
+    }
+
+    /**
+     * Load submission based on identifier
+     *
+     * @param submissionId Submission identifier
+     * @return The submission
+     */
+    private Submission loadSubmission(String submissionId) {
+        if (submissionId == null) {
+            throw new IllegalArgumentException("submissionId cannot be null");
+        }
+        Submission submission = null;
+        try {
+            submission = client.getObject(Submission.class, submissionId, "repositories", "publication");
+        } catch (IOException ex) {
+            String msg = String.format("Failed to retrieve Submission with ID %s from the database", submissionId);
+            throw new RuntimeException(msg);
+        }
+        return submission;
+    }
+}

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/CopyStatus.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/CopyStatus.java
@@ -23,7 +23,7 @@ import java.util.Map;
  */
 public enum CopyStatus {
     /**
-     * The target Repository has rejected the Deposit
+     * The target Repository has accepted the Deposit
      */
     ACCEPTED("accepted"),
     /**

--- a/pass-data-client/src/test/java/org/eclipse/pass/support/client/JsonApiPassClientIT.java
+++ b/pass-data-client/src/test/java/org/eclipse/pass/support/client/JsonApiPassClientIT.java
@@ -252,6 +252,11 @@ public class JsonApiPassClientIT {
         selector = new PassClientSelector<>(Publication.class, 0, 2, filter, "id");
         pubs.forEach(p -> p.setJournal(new Journal(journal.getId())));
         assertIterableEquals(pubs, client.streamObjects(selector).collect(Collectors.toList()));
+
+        // Test searching on a relationship. Do not include journal.
+        filter = RSQL.equals("journal.id", journal.getId());
+        selector = new PassClientSelector<>(Publication.class, 0, 100, filter, "id");
+        assertIterableEquals(pubs, client.streamObjects(selector).collect(Collectors.toList()));
     }
 
     @Test

--- a/pass-data-client/src/test/java/org/eclipse/pass/support/client/SubmissionStatusCalculatorTest.java
+++ b/pass-data-client/src/test/java/org/eclipse/pass/support/client/SubmissionStatusCalculatorTest.java
@@ -44,6 +44,7 @@ public class SubmissionStatusCalculatorTest {
     private final String repo1Id = "repository:1";
     private final String repo2Id = "repository:2";
     private final String repo3Id = "repository:3";
+    private ZonedDateTime last = ZonedDateTime.now();
 
     private Deposit deposit(DepositStatus status, String repId) {
         Deposit d = new Deposit();
@@ -59,10 +60,14 @@ public class SubmissionStatusCalculatorTest {
         return r;
     }
 
-    private SubmissionEvent submissionEvent(ZonedDateTime dt, EventType eventType) {
+    // Make the performed date later on each call
+    private SubmissionEvent submissionEvent(EventType eventType) {
         SubmissionEvent event = new SubmissionEvent();
-        event.setPerformedDate(dt);
+        event.setPerformedDate(last);
         event.setEventType(eventType);
+
+        last = last.plusDays(1);
+
         return event;
     }
 
@@ -405,19 +410,19 @@ public class SubmissionStatusCalculatorTest {
     @Test
     public void testPreSubmissionStatusApprovalRequested() {
         List<SubmissionEvent> submissionEvents =
-            Arrays.asList(submissionEvent(ZonedDateTime.now(), EventType.APPROVAL_REQUESTED));
+            Arrays.asList(submissionEvent(EventType.APPROVAL_REQUESTED));
         assertEquals(SubmissionStatus.APPROVAL_REQUESTED,
                      SubmissionStatusCalculator.calculatePreSubmissionStatus(submissionEvents, null));
 
         submissionEvents =
-            Arrays.asList(submissionEvent(ZonedDateTime.now(), EventType.APPROVAL_REQUESTED_NEWUSER));
+            Arrays.asList(submissionEvent(EventType.APPROVAL_REQUESTED_NEWUSER));
         assertEquals(SubmissionStatus.APPROVAL_REQUESTED,
                      SubmissionStatusCalculator.calculatePreSubmissionStatus(submissionEvents, null));
 
         submissionEvents =
-            Arrays.asList(submissionEvent(ZonedDateTime.now(), EventType.APPROVAL_REQUESTED_NEWUSER),
-                          submissionEvent(ZonedDateTime.now(), EventType.CHANGES_REQUESTED),
-                          submissionEvent(ZonedDateTime.now(), EventType.APPROVAL_REQUESTED));
+            Arrays.asList(submissionEvent(EventType.APPROVAL_REQUESTED_NEWUSER),
+                          submissionEvent(EventType.CHANGES_REQUESTED),
+                          submissionEvent(EventType.APPROVAL_REQUESTED));
         assertEquals(SubmissionStatus.APPROVAL_REQUESTED,
                      SubmissionStatusCalculator.calculatePreSubmissionStatus(submissionEvents, null));
 
@@ -431,21 +436,21 @@ public class SubmissionStatusCalculatorTest {
     @Test
     public void testPreSubmissionStatusChangesRequested() {
         List<SubmissionEvent> submissionEvents =
-            Arrays.asList(submissionEvent(ZonedDateTime.now(), EventType.CHANGES_REQUESTED));
+            Arrays.asList(submissionEvent(EventType.CHANGES_REQUESTED));
         assertEquals(SubmissionStatus.CHANGES_REQUESTED,
                      SubmissionStatusCalculator.calculatePreSubmissionStatus(submissionEvents, null));
 
         submissionEvents =
-            Arrays.asList(submissionEvent(ZonedDateTime.now(), EventType.APPROVAL_REQUESTED),
-                          submissionEvent(ZonedDateTime.now(), EventType.CHANGES_REQUESTED));
+            Arrays.asList(submissionEvent(EventType.APPROVAL_REQUESTED),
+                          submissionEvent(EventType.CHANGES_REQUESTED));
         assertEquals(SubmissionStatus.CHANGES_REQUESTED,
                      SubmissionStatusCalculator.calculatePreSubmissionStatus(submissionEvents, null));
 
         submissionEvents =
-            Arrays.asList(submissionEvent(ZonedDateTime.now(), EventType.APPROVAL_REQUESTED),
-                          submissionEvent(ZonedDateTime.now(), EventType.CHANGES_REQUESTED),
-                          submissionEvent(ZonedDateTime.now(), EventType.APPROVAL_REQUESTED),
-                          submissionEvent(ZonedDateTime.now(), EventType.CHANGES_REQUESTED));
+            Arrays.asList(submissionEvent(EventType.APPROVAL_REQUESTED),
+                          submissionEvent(EventType.CHANGES_REQUESTED),
+                          submissionEvent(EventType.APPROVAL_REQUESTED),
+                          submissionEvent(EventType.CHANGES_REQUESTED));
         assertEquals(SubmissionStatus.CHANGES_REQUESTED,
                      SubmissionStatusCalculator.calculatePreSubmissionStatus(submissionEvents, null));
 
@@ -459,21 +464,21 @@ public class SubmissionStatusCalculatorTest {
     @Test
     public void testPreSubmissionStatusCancelled() {
         List<SubmissionEvent> submissionEvents =
-            Arrays.asList(submissionEvent(ZonedDateTime.now(), EventType.CANCELLED));
+            Arrays.asList(submissionEvent(EventType.CANCELLED));
         assertEquals(SubmissionStatus.CANCELLED,
                 SubmissionStatusCalculator.calculatePreSubmissionStatus(submissionEvents, null));
 
         submissionEvents =
-            Arrays.asList(submissionEvent(ZonedDateTime.now(), EventType.APPROVAL_REQUESTED),
-                          submissionEvent(ZonedDateTime.now(), EventType.CANCELLED));
+            Arrays.asList(submissionEvent(EventType.APPROVAL_REQUESTED),
+                          submissionEvent(EventType.CANCELLED));
         assertEquals(SubmissionStatus.CANCELLED,
                 SubmissionStatusCalculator.calculatePreSubmissionStatus(submissionEvents, null));
 
         submissionEvents =
-            Arrays.asList(submissionEvent(ZonedDateTime.now(), EventType.APPROVAL_REQUESTED),
-                          submissionEvent(ZonedDateTime.now(), EventType.CHANGES_REQUESTED),
-                          submissionEvent(ZonedDateTime.now(), EventType.APPROVAL_REQUESTED),
-                          submissionEvent(ZonedDateTime.now(), EventType.CANCELLED));
+            Arrays.asList(submissionEvent(EventType.APPROVAL_REQUESTED),
+                          submissionEvent(EventType.CHANGES_REQUESTED),
+                          submissionEvent(EventType.APPROVAL_REQUESTED),
+                          submissionEvent(EventType.CANCELLED));
         assertEquals(SubmissionStatus.CANCELLED,
                 SubmissionStatusCalculator.calculatePreSubmissionStatus(submissionEvents, null));
 

--- a/pass-data-client/src/test/java/org/eclipse/pass/support/client/SubmissionStatusCalculatorTest.java
+++ b/pass-data-client/src/test/java/org/eclipse/pass/support/client/SubmissionStatusCalculatorTest.java
@@ -1,0 +1,571 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.pass.support.client.model.CopyStatus;
+import org.eclipse.pass.support.client.model.Deposit;
+import org.eclipse.pass.support.client.model.DepositStatus;
+import org.eclipse.pass.support.client.model.EventType;
+import org.eclipse.pass.support.client.model.Repository;
+import org.eclipse.pass.support.client.model.RepositoryCopy;
+import org.eclipse.pass.support.client.model.SubmissionEvent;
+import org.eclipse.pass.support.client.model.SubmissionStatus;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the SubmissionStatusCalculator utility functions
+ *
+ * @author Karen Hanson
+ */
+public class SubmissionStatusCalculatorTest {
+    private final String repo1Id = "repository:1";
+    private final String repo2Id = "repository:2";
+    private final String repo3Id = "repository:3";
+
+    private Deposit deposit(DepositStatus status, String repId) {
+        Deposit d = new Deposit();
+        d.setDepositStatus(status);
+        d.setRepository(new Repository(repId));
+        return d;
+    }
+
+    private RepositoryCopy repoCopy(CopyStatus status, String repoId) {
+        RepositoryCopy r = new RepositoryCopy();
+        r.setCopyStatus(status);
+        r.setRepository(new Repository(repoId));
+        return r;
+    }
+
+    private SubmissionEvent submissionEvent(ZonedDateTime dt, EventType eventType) {
+        SubmissionEvent event = new SubmissionEvent();
+        event.setPerformedDate(dt);
+        event.setEventType(eventType);
+        return event;
+    }
+
+    /**
+     * 3 repositories listed, deposits only, no repositoryCopies. As long as none are rejected, it
+     * should always be SUBMITTED
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testPostSubmissionStatusDepositOnlySubmitted() throws Exception {
+        List<String> repositories = Arrays.asList(repo1Id, repo2Id, repo3Id);
+
+        List<Deposit> deposits = Arrays.asList(deposit(DepositStatus.ACCEPTED, repo1Id),
+                                               deposit(DepositStatus.FAILED, repo2Id));
+        assertEquals(SubmissionStatus.SUBMITTED,
+                SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, deposits, null));
+
+        deposits = Arrays.asList(deposit(DepositStatus.ACCEPTED, repo1Id),
+                                 deposit(DepositStatus.FAILED, repo2Id),
+                                 deposit(DepositStatus.ACCEPTED, repo3Id));
+
+        assertEquals(SubmissionStatus.SUBMITTED,
+                SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, deposits, null));
+
+        deposits = Arrays.asList(deposit(DepositStatus.ACCEPTED, repo1Id),
+                                 deposit(DepositStatus.ACCEPTED, repo2Id),
+                                 deposit(DepositStatus.ACCEPTED, repo3Id));
+        assertEquals(SubmissionStatus.SUBMITTED,
+                SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, deposits, null));
+
+    }
+
+    /**
+     * 3 repositories listed, no deposits, repositoryCopies only. As long as none are rejected, it
+     * should always be SUBMITTED
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testPostSubmissionStatusRepoCopyOnlySubmitted() throws Exception {
+        List<String> repositories = Arrays.asList(repo1Id, repo2Id, repo3Id);
+        List<RepositoryCopy> repositoryCopies = Arrays.asList(repoCopy(CopyStatus.COMPLETE, repo1Id));
+
+        assertEquals(SubmissionStatus.SUBMITTED,
+                     SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, null, repositoryCopies));
+
+        repositoryCopies = Arrays.asList(repoCopy(CopyStatus.COMPLETE, repo1Id),
+                                         repoCopy(CopyStatus.COMPLETE, repo2Id));
+        assertEquals(SubmissionStatus.SUBMITTED,
+                     SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, null, repositoryCopies));
+
+        //add one more in-progress repocopy
+        repositoryCopies = Arrays.asList(repoCopy(CopyStatus.COMPLETE, repo1Id),
+                                         repoCopy(CopyStatus.COMPLETE, repo2Id),
+                                         repoCopy(CopyStatus.IN_PROGRESS, repo3Id));
+        assertEquals(SubmissionStatus.SUBMITTED,
+                     SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, null, repositoryCopies));
+
+    }
+
+    /**
+     * 1 repositories listed, no deposits, repositoryCopy only. copyStatus is null
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testSubmittedNoDepositCopyNoStatus() throws Exception {
+        List<String> repositories = Arrays.asList(repo1Id);
+        List<RepositoryCopy> repositoryCopies = Arrays.asList(repoCopy(null, repo1Id));
+
+        assertEquals(SubmissionStatus.SUBMITTED,
+                     SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, null, repositoryCopies));
+    }
+
+    /**
+     * 1 repositories listed, no deposits, repositoryCopy only. copyStatus is null
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testSubmittedDepositNullStatusNoRepoCopy() throws Exception {
+        List<String> repositories = Arrays.asList(repo1Id);
+        List<Deposit> deposits = Arrays.asList(deposit(null, repo1Id));
+
+        assertEquals(SubmissionStatus.SUBMITTED,
+                SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, deposits, null));
+    }
+
+    /**
+     * 3 repositories with various states for deposits and repositoryCopies all of which should come out as
+     * having the status of SUBMITTED
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testPostSubmissionStatusDepositAndRepoCopySubmitted() throws Exception {
+        List<String> repositories = Arrays.asList(repo1Id, repo2Id, repo3Id);
+
+        List<Deposit> deposits = Arrays.asList(deposit(DepositStatus.ACCEPTED, repo1Id),
+                                               deposit(DepositStatus.FAILED, repo2Id));
+
+        List<RepositoryCopy> repositoryCopies = Arrays.asList(repoCopy(CopyStatus.COMPLETE, repo1Id));
+
+        assertEquals(SubmissionStatus.SUBMITTED,
+                SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories,
+                        deposits, repositoryCopies));
+
+        repositoryCopies = Arrays.asList(repoCopy(CopyStatus.COMPLETE, repo1Id),
+                                         repoCopy(CopyStatus.COMPLETE, repo2Id));
+        assertEquals(SubmissionStatus.SUBMITTED,
+                SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories,
+                        deposits, repositoryCopies));
+
+        deposits = Arrays.asList(deposit(DepositStatus.ACCEPTED, repo1Id),
+                                 deposit(DepositStatus.FAILED, repo2Id),
+                                 deposit(DepositStatus.ACCEPTED, repo3Id));
+        assertEquals(SubmissionStatus.SUBMITTED,
+                SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories,
+                        deposits, repositoryCopies));
+
+        //add one more in-progress repocopy
+        repositoryCopies = Arrays.asList(repoCopy(CopyStatus.COMPLETE, repo1Id),
+                                         repoCopy(CopyStatus.COMPLETE, repo2Id),
+                                         repoCopy(CopyStatus.IN_PROGRESS, repo3Id));
+        assertEquals(SubmissionStatus.SUBMITTED,
+                SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories,
+                        deposits, repositoryCopies));
+    }
+
+    /**
+     * Tests various situations with Deposits only that should trigger {@code SubmissionStatus.NEEDS_ATTENTION}
+     * as the {@code Submission.submissionStatus} value
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testPostSubmissionStatusDepositOnlyNeedsAttention() throws Exception {
+        //1 repo 1 rejected deposit
+        List<String> repositories = Arrays.asList(repo1Id);
+        List<Deposit> deposits = Arrays.asList(deposit(DepositStatus.REJECTED, repo1Id));
+        assertEquals(SubmissionStatus.NEEDS_ATTENTION,
+                     SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, deposits, null));
+
+        // 3 repo, 2 deposits, 1 rejected
+        repositories = Arrays.asList(repo1Id, repo2Id, repo3Id);
+        deposits = Arrays.asList(deposit(DepositStatus.ACCEPTED, repo1Id),
+                                 deposit(DepositStatus.REJECTED, repo2Id));
+        assertEquals(SubmissionStatus.NEEDS_ATTENTION,
+                     SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, deposits, null));
+
+        // 3 repo, 3 deposits, 1 rejected
+        deposits = Arrays.asList(deposit(DepositStatus.REJECTED, repo1Id),
+                                 deposit(DepositStatus.ACCEPTED, repo2Id),
+                                 deposit(DepositStatus.ACCEPTED, repo3Id));
+        assertEquals(SubmissionStatus.NEEDS_ATTENTION,
+                     SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, deposits, null));
+
+    }
+
+    /**
+     * Tests various situations with RepositoryCopies only that should trigger {@code SubmissionStatus.NEEDS_ATTENTION}
+     * as the {@code Submission.submissionStatus} value
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testPostSubmissionStatusRepoCopyOnlyNeedsAttention() throws Exception {
+        List<String> repositories = Arrays.asList(repo1Id);
+        List<RepositoryCopy> repositoryCopies = Arrays.asList(repoCopy(CopyStatus.REJECTED, repo1Id));
+        assertEquals(SubmissionStatus.NEEDS_ATTENTION,
+                     SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, null, repositoryCopies));
+
+        repositoryCopies = Arrays.asList(repoCopy(CopyStatus.STALLED, repo1Id));
+        assertEquals(SubmissionStatus.NEEDS_ATTENTION,
+                     SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, null, repositoryCopies));
+
+        repositories = Arrays.asList(repo1Id, repo2Id, repo3Id);
+        repositoryCopies = Arrays.asList(repoCopy(CopyStatus.COMPLETE, repo1Id),
+                                         repoCopy(CopyStatus.STALLED, repo2Id));
+        assertEquals(SubmissionStatus.NEEDS_ATTENTION,
+                     SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, null, repositoryCopies));
+
+        //add one more in-progress repocopy
+        repositoryCopies = Arrays.asList(repoCopy(CopyStatus.COMPLETE, repo1Id),
+                                         repoCopy(CopyStatus.REJECTED, repo2Id),
+                                         repoCopy(CopyStatus.IN_PROGRESS, repo3Id));
+        assertEquals(SubmissionStatus.NEEDS_ATTENTION,
+                     SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, null, repositoryCopies));
+    }
+
+    /**
+     * Various numbers of repositories with various states for deposits and repositoryCopies all of which
+     * should come out as having status of {@code SubmissionStatus.NEEDS_ATTENTION}
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testPostSubmissionStatusDepositAndRepoCopyNeedsAttention() throws Exception {
+        List<String> repositories = Arrays.asList(repo1Id, repo2Id);
+        List<Deposit> deposits = Arrays.asList(deposit(DepositStatus.ACCEPTED, repo1Id),
+                                               deposit(DepositStatus.REJECTED, repo2Id));
+        List<RepositoryCopy> repositoryCopies = Arrays.asList(repoCopy(CopyStatus.COMPLETE, repo1Id));
+        assertEquals(SubmissionStatus.NEEDS_ATTENTION,
+                SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories,
+                        deposits, repositoryCopies));
+
+        deposits = Arrays.asList(deposit(DepositStatus.ACCEPTED, repo1Id),
+                                 deposit(DepositStatus.ACCEPTED, repo2Id));
+        repositoryCopies = Arrays.asList(repoCopy(CopyStatus.COMPLETE, repo1Id),
+                                         repoCopy(CopyStatus.STALLED, repo2Id));
+        assertEquals(SubmissionStatus.NEEDS_ATTENTION,
+                SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories,
+                        deposits, repositoryCopies));
+
+        repositoryCopies = Arrays.asList(repoCopy(CopyStatus.IN_PROGRESS, repo1Id),
+                                         repoCopy(CopyStatus.REJECTED, repo2Id));
+        assertEquals(SubmissionStatus.NEEDS_ATTENTION,
+                SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories,
+                        deposits, repositoryCopies));
+
+        repositories = Arrays.asList(repo1Id, repo2Id, repo3Id);
+        deposits = Arrays.asList(deposit(DepositStatus.ACCEPTED, repo1Id),
+                                 deposit(DepositStatus.ACCEPTED, repo2Id),
+                                 deposit(DepositStatus.FAILED, repo2Id));
+        repositoryCopies = Arrays.asList(repoCopy(CopyStatus.COMPLETE, repo2Id),
+                                         repoCopy(CopyStatus.STALLED, repo3Id));
+        assertEquals(SubmissionStatus.NEEDS_ATTENTION,
+                SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories,
+                        deposits, repositoryCopies));
+
+    }
+
+    /**
+     * This confirms that if there are completed repository copies for each repository listed, the status is complete,
+     * regardless of whether there is a deposit for each one or not.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testPostSubmissionStatusComplete() throws Exception {
+        List<String> repositories = Arrays.asList(repo1Id);
+        List<RepositoryCopy> repositoryCopies = Arrays.asList(repoCopy(CopyStatus.COMPLETE, repo1Id));
+        assertEquals(SubmissionStatus.COMPLETE,
+                     SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, null, repositoryCopies));
+
+        List<Deposit> deposits = Arrays.asList(deposit(DepositStatus.ACCEPTED, repo1Id));
+        assertEquals(SubmissionStatus.COMPLETE,
+                SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories,
+                        deposits, repositoryCopies));
+
+        repositories = Arrays.asList(repo1Id, repo2Id, repo3Id);
+        deposits = Arrays.asList(deposit(DepositStatus.ACCEPTED, repo1Id),
+                                 deposit(DepositStatus.REJECTED, repo2Id));
+        repositoryCopies = Arrays.asList(repoCopy(CopyStatus.COMPLETE, repo1Id),
+                                         repoCopy(CopyStatus.COMPLETE, repo2Id),
+                                         repoCopy(CopyStatus.COMPLETE, repo3Id));
+        assertEquals(SubmissionStatus.COMPLETE,
+                SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories,
+                        deposits, repositoryCopies));
+
+        assertEquals(SubmissionStatus.COMPLETE,
+                     SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories, null, repositoryCopies));
+
+    }
+
+    /**
+     * This confirms that if you try to provide a null for all values, it will assume submitted.
+     * This would only happen if the only repositories were web linked and therefore there is no
+     * Deposit to process.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testPostSubmissionStatusNulls() throws Exception {
+        SubmissionStatus status = SubmissionStatusCalculator.calculatePostSubmissionStatus(null, null, null);
+        assertEquals(SubmissionStatus.SUBMITTED, status);
+    }
+
+    /**
+     * This confirms that even if a Deposit is rejected, a RepositoryCopy's status will override the Deposit status
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testPostSubmissionStatusRepoCopyOverrideDeposit() throws Exception {
+        List<String> repositories = Arrays.asList(repo1Id);
+        List<Deposit> deposits = Arrays.asList(deposit(DepositStatus.REJECTED, repo1Id));
+        List<RepositoryCopy> repositoryCopies = Arrays.asList(repoCopy(CopyStatus.COMPLETE, repo1Id));
+        assertEquals(SubmissionStatus.COMPLETE,
+                SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories,
+                        deposits, repositoryCopies));
+
+        repositoryCopies = Arrays.asList(repoCopy(CopyStatus.IN_PROGRESS, repo1Id));
+        assertEquals(SubmissionStatus.SUBMITTED,
+                SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories,
+                        deposits, repositoryCopies));
+
+        repositories = Arrays.asList(repo1Id, repo2Id);
+        deposits = Arrays.asList(deposit(DepositStatus.ACCEPTED, repo1Id),
+                                 deposit(DepositStatus.REJECTED, repo2Id));
+        repositoryCopies = Arrays.asList(repoCopy(CopyStatus.COMPLETE, repo1Id),
+                                         repoCopy(CopyStatus.IN_PROGRESS, repo2Id));
+        assertEquals(SubmissionStatus.SUBMITTED,
+                SubmissionStatusCalculator.calculatePostSubmissionStatus(repositories,
+                        deposits, repositoryCopies));
+    }
+
+    /**
+     * Confirms that MANUSCRIPT_REQUIRED is appropriately assigned as a pre-submission status.
+     */
+    @Test
+    public void testPreSubmissionStatusManuscriptExpected() {
+        assertEquals(SubmissionStatus.MANUSCRIPT_REQUIRED,
+                SubmissionStatusCalculator.calculatePreSubmissionStatus(null, null));
+        assertEquals(SubmissionStatus.MANUSCRIPT_REQUIRED,
+                     SubmissionStatusCalculator.calculatePreSubmissionStatus(new ArrayList<SubmissionEvent>(), null));
+        assertEquals(SubmissionStatus.MANUSCRIPT_REQUIRED,
+                     SubmissionStatusCalculator.calculatePreSubmissionStatus(null,
+                             SubmissionStatus.MANUSCRIPT_REQUIRED));
+        assertEquals(SubmissionStatus.MANUSCRIPT_REQUIRED,
+                     SubmissionStatusCalculator.calculatePreSubmissionStatus(Collections.emptyList(),
+                             SubmissionStatus.MANUSCRIPT_REQUIRED));
+    }
+
+    @Test
+    public void testPreSubmissionStatusDraftExpected() {
+        assertEquals(SubmissionStatus.DRAFT, SubmissionStatusCalculator.calculatePreSubmissionStatus(null,
+                SubmissionStatus.DRAFT));
+
+        // in fact, the logic inside the calculator will default to supplied status if there are no submission events
+        // provided, rather than hard-coding a return.
+        assertEquals(SubmissionStatus.SUBMITTED, SubmissionStatusCalculator.calculatePreSubmissionStatus(null,
+                SubmissionStatus.SUBMITTED));
+    }
+
+    /**
+     * Tests various scenarios where outcome should be APPROVAL_REQUESTED
+     */
+    @Test
+    public void testPreSubmissionStatusApprovalRequested() {
+        List<SubmissionEvent> submissionEvents =
+            Arrays.asList(submissionEvent(ZonedDateTime.now(), EventType.APPROVAL_REQUESTED));
+        assertEquals(SubmissionStatus.APPROVAL_REQUESTED,
+                     SubmissionStatusCalculator.calculatePreSubmissionStatus(submissionEvents, null));
+
+        submissionEvents =
+            Arrays.asList(submissionEvent(ZonedDateTime.now(), EventType.APPROVAL_REQUESTED_NEWUSER));
+        assertEquals(SubmissionStatus.APPROVAL_REQUESTED,
+                     SubmissionStatusCalculator.calculatePreSubmissionStatus(submissionEvents, null));
+
+        submissionEvents =
+            Arrays.asList(submissionEvent(ZonedDateTime.now(), EventType.APPROVAL_REQUESTED_NEWUSER),
+                          submissionEvent(ZonedDateTime.now(), EventType.CHANGES_REQUESTED),
+                          submissionEvent(ZonedDateTime.now(), EventType.APPROVAL_REQUESTED));
+        assertEquals(SubmissionStatus.APPROVAL_REQUESTED,
+                     SubmissionStatusCalculator.calculatePreSubmissionStatus(submissionEvents, null));
+
+        assertEquals(SubmissionStatus.APPROVAL_REQUESTED,
+                     SubmissionStatusCalculator.calculatePreSubmissionStatus(submissionEvents, SubmissionStatus.DRAFT));
+    }
+
+    /**
+     * Tests various scenarios in which the pre-submission status should be "CHANGES_REQUESTED"
+     */
+    @Test
+    public void testPreSubmissionStatusChangesRequested() {
+        List<SubmissionEvent> submissionEvents =
+            Arrays.asList(submissionEvent(ZonedDateTime.now(), EventType.CHANGES_REQUESTED));
+        assertEquals(SubmissionStatus.CHANGES_REQUESTED,
+                     SubmissionStatusCalculator.calculatePreSubmissionStatus(submissionEvents, null));
+
+        submissionEvents =
+            Arrays.asList(submissionEvent(ZonedDateTime.now(), EventType.APPROVAL_REQUESTED),
+                          submissionEvent(ZonedDateTime.now(), EventType.CHANGES_REQUESTED));
+        assertEquals(SubmissionStatus.CHANGES_REQUESTED,
+                     SubmissionStatusCalculator.calculatePreSubmissionStatus(submissionEvents, null));
+
+        submissionEvents =
+            Arrays.asList(submissionEvent(ZonedDateTime.now(), EventType.APPROVAL_REQUESTED),
+                          submissionEvent(ZonedDateTime.now(), EventType.CHANGES_REQUESTED),
+                          submissionEvent(ZonedDateTime.now(), EventType.APPROVAL_REQUESTED),
+                          submissionEvent(ZonedDateTime.now(), EventType.CHANGES_REQUESTED));
+        assertEquals(SubmissionStatus.CHANGES_REQUESTED,
+                     SubmissionStatusCalculator.calculatePreSubmissionStatus(submissionEvents, null));
+
+        assertEquals(SubmissionStatus.CHANGES_REQUESTED,
+                     SubmissionStatusCalculator.calculatePreSubmissionStatus(submissionEvents, SubmissionStatus.DRAFT));
+    }
+
+    /**
+     * Tests various scenarios in which the pre-submission status should be "CANCELLED"
+     */
+    @Test
+    public void testPreSubmissionStatusCancelled() {
+        List<SubmissionEvent> submissionEvents =
+            Arrays.asList(submissionEvent(ZonedDateTime.now(), EventType.CANCELLED));
+        assertEquals(SubmissionStatus.CANCELLED,
+                SubmissionStatusCalculator.calculatePreSubmissionStatus(submissionEvents, null));
+
+        submissionEvents =
+            Arrays.asList(submissionEvent(ZonedDateTime.now(), EventType.APPROVAL_REQUESTED),
+                          submissionEvent(ZonedDateTime.now(), EventType.CANCELLED));
+        assertEquals(SubmissionStatus.CANCELLED,
+                SubmissionStatusCalculator.calculatePreSubmissionStatus(submissionEvents, null));
+
+        submissionEvents =
+            Arrays.asList(submissionEvent(ZonedDateTime.now(), EventType.APPROVAL_REQUESTED),
+                          submissionEvent(ZonedDateTime.now(), EventType.CHANGES_REQUESTED),
+                          submissionEvent(ZonedDateTime.now(), EventType.APPROVAL_REQUESTED),
+                          submissionEvent(ZonedDateTime.now(), EventType.CANCELLED));
+        assertEquals(SubmissionStatus.CANCELLED,
+                SubmissionStatusCalculator.calculatePreSubmissionStatus(submissionEvents, null));
+
+        assertEquals(SubmissionStatus.CANCELLED,
+                SubmissionStatusCalculator.calculatePreSubmissionStatus(submissionEvents, SubmissionStatus.DRAFT));
+    }
+
+    /**
+     * Makes sure typical status changes log as valid. Some of these will generate warnings
+     * since this service is not supposed to change the pre-Submission statuses - it will warn
+     * when one is being changed.
+     */
+    @Test
+    public void testValidateStatusChangeOK() {
+        //if any of there throw exception the test fails:
+        SubmissionStatusCalculator.validateStatusChange(false, SubmissionStatus.APPROVAL_REQUESTED,
+                SubmissionStatus.CHANGES_REQUESTED);
+        SubmissionStatusCalculator.validateStatusChange(false, SubmissionStatus.CHANGES_REQUESTED,
+                SubmissionStatus.APPROVAL_REQUESTED);
+        SubmissionStatusCalculator.validateStatusChange(false, SubmissionStatus.CHANGES_REQUESTED,
+                SubmissionStatus.CANCELLED);
+
+        SubmissionStatusCalculator.validateStatusChange(false, SubmissionStatus.DRAFT,
+                SubmissionStatus.APPROVAL_REQUESTED);
+        SubmissionStatusCalculator.validateStatusChange(false, SubmissionStatus.DRAFT,
+                SubmissionStatus.CHANGES_REQUESTED);
+        SubmissionStatusCalculator.validateStatusChange(false, SubmissionStatus.DRAFT,
+                SubmissionStatus.CANCELLED);
+
+        SubmissionStatusCalculator.validateStatusChange(true, SubmissionStatus.APPROVAL_REQUESTED,
+                SubmissionStatus.SUBMITTED);
+        SubmissionStatusCalculator.validateStatusChange(true, SubmissionStatus.MANUSCRIPT_REQUIRED,
+                SubmissionStatus.SUBMITTED);
+        SubmissionStatusCalculator.validateStatusChange(true, SubmissionStatus.SUBMITTED,
+                SubmissionStatus.COMPLETE);
+        SubmissionStatusCalculator.validateStatusChange(true, SubmissionStatus.SUBMITTED,
+                SubmissionStatus.NEEDS_ATTENTION);
+        SubmissionStatusCalculator.validateStatusChange(true, SubmissionStatus.NEEDS_ATTENTION,
+                SubmissionStatus.SUBMITTED);
+        SubmissionStatusCalculator.validateStatusChange(true, SubmissionStatus.NEEDS_ATTENTION,
+                SubmissionStatus.COMPLETE);
+        SubmissionStatusCalculator.validateStatusChange(true, SubmissionStatus.DRAFT,
+                SubmissionStatus.SUBMITTED);
+        SubmissionStatusCalculator.validateStatusChange(true, SubmissionStatus.DRAFT,
+                SubmissionStatus.COMPLETE);
+    }
+
+    /**
+     * Should fail based on assigning submitted status to unsubmitted
+     */
+    @Test
+    public void testSettingStatusUnsubmittedShouldFail() {
+        assertThrows(Exception.class, () -> {
+            SubmissionStatusCalculator.validateStatusChange(true, SubmissionStatus.APPROVAL_REQUESTED,
+                    SubmissionStatus.CHANGES_REQUESTED);
+        });
+    }
+
+    /**
+     * Should fail based on change from submitted to unsubmitted status
+     */
+    @Test
+    public void testChangingStatusToUnsubmittedShouldFail() {
+        assertThrows(Exception.class, () -> {
+            SubmissionStatusCalculator.validateStatusChange(false, SubmissionStatus.SUBMITTED,
+                    SubmissionStatus.CANCELLED);
+        });
+    }
+
+    /**
+     * Should fail based on Submission have submitted=false but trying to assign post-submission status
+     */
+    @Test
+    public void testAssigningToNonsubmittedShouldFail() {
+        assertThrows(Exception.class, () -> {
+            SubmissionStatusCalculator.validateStatusChange(false, SubmissionStatus.APPROVAL_REQUESTED,
+                    SubmissionStatus.SUBMITTED);
+        });
+    }
+
+    /**
+     * Should be OK, but log should show a warning
+     *
+     * todo: Doesn't actually check logs for the warning
+     */
+    @Test
+    public void testApprovalRequestToChangesRequestedShouldLogWarning() {
+        try {
+            SubmissionStatusCalculator.validateStatusChange(false, SubmissionStatus.APPROVAL_REQUESTED,
+                    SubmissionStatus.CHANGES_REQUESTED);
+        } catch (Exception ex) {
+            fail("Exception should not have been thrown, just a warning for this.");
+        }
+    }
+}

--- a/pass-data-client/src/test/java/org/eclipse/pass/support/client/SubmissionStatusServiceTest.java
+++ b/pass-data-client/src/test/java/org/eclipse/pass/support/client/SubmissionStatusServiceTest.java
@@ -1,0 +1,122 @@
+package org.eclipse.pass.support.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import org.eclipse.pass.support.client.model.CopyStatus;
+import org.eclipse.pass.support.client.model.Deposit;
+import org.eclipse.pass.support.client.model.DepositStatus;
+import org.eclipse.pass.support.client.model.EventType;
+import org.eclipse.pass.support.client.model.Publication;
+import org.eclipse.pass.support.client.model.Repository;
+import org.eclipse.pass.support.client.model.RepositoryCopy;
+import org.eclipse.pass.support.client.model.Submission;
+import org.eclipse.pass.support.client.model.SubmissionEvent;
+import org.eclipse.pass.support.client.model.SubmissionStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit test for simple App.
+ */
+@ExtendWith(MockitoExtension.class)
+public class SubmissionStatusServiceTest {
+    @Mock
+    private PassClient client;
+
+    private SubmissionStatusService service;
+
+    /**
+     * Basic test to ensure that appropriate calls are made to client when
+     * calculating status of submitted Submission
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testCalcSubmissionStatusPostSubmission() throws Exception {
+        Repository repo1 = new Repository("repo1");
+        Repository repo2 = new Repository("repo2");
+
+        Deposit dep1 = new Deposit("dep1");
+        Deposit dep2 = new Deposit("dep2");
+
+        RepositoryCopy rc1 = new RepositoryCopy("rc1");
+        RepositoryCopy rc2 = new RepositoryCopy("rc2");
+
+        Publication pub = new Publication("publication:1");
+
+        Submission submission = new Submission("submission:1");
+        submission.setRepositories(Arrays.asList(repo1, repo2));
+        submission.setPublication(pub);
+        submission.setSubmitted(true);
+        submission.setSubmissionStatus(SubmissionStatus.SUBMITTED);
+
+        dep1.setSubmission(submission);
+        dep1.setRepository(repo1);
+        dep1.setRepositoryCopy(rc1);
+        dep1.setDepositStatus(DepositStatus.ACCEPTED);
+
+        dep2.setSubmission(submission);
+        dep2.setRepository(repo2);
+        dep2.setRepositoryCopy(rc2);
+        dep2.setDepositStatus(DepositStatus.ACCEPTED);
+
+        rc1.setPublication(pub);
+        rc1.setCopyStatus(CopyStatus.ACCEPTED);
+        rc1.setRepository(repo1);
+
+        rc2.setPublication(pub);
+        rc2.setCopyStatus(CopyStatus.ACCEPTED);
+        rc2.setRepository(repo2);
+
+        service = new SubmissionStatusService(client);
+
+        when(client.streamObjects(Mockito.any())).thenReturn(Stream.of(dep1, dep2)).thenReturn(Stream.of(rc1, rc2));
+
+        SubmissionStatus newStatus = service.calculateSubmissionStatus(submission);
+        assertEquals(SubmissionStatus.SUBMITTED, newStatus);
+    }
+
+    /**
+     * Basic test to ensure that appropriate calls are made to client when
+     * calculating status of Submission not yet submitted.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testCalcSubmissionStatusPreSubmission() throws Exception {
+        Repository repo1 = new Repository("repo1");
+        Repository repo2 = new Repository("repo2");
+
+        Publication pub = new Publication("publication:1");
+
+        SubmissionEvent ev1 = new SubmissionEvent("ev1");
+        SubmissionEvent ev2 = new SubmissionEvent("ev2");
+
+        Submission submission = new Submission("submission:1");
+        submission.setRepositories(Arrays.asList(repo1, repo2));
+        submission.setPublication(pub);
+        submission.setSubmitted(false);
+
+        ev1.setSubmission(submission);
+        ev1.setEventType(EventType.APPROVAL_REQUESTED);
+        ev1.setPerformedDate(ZonedDateTime.now());
+        ev2.setSubmission(submission);
+        ev2.setEventType(EventType.CHANGES_REQUESTED);
+        ev2.setPerformedDate(ev1.getPerformedDate().plusHours(2));
+
+        service = new SubmissionStatusService(client);
+
+        when(client.streamObjects(Mockito.any())).thenReturn(Stream.of(ev1, ev2));
+
+        SubmissionStatus newStatus = service.calculateSubmissionStatus(submission);
+        assertEquals(SubmissionStatus.CHANGES_REQUESTED, newStatus);
+    }
+}


### PR DESCRIPTION
This pr ports SubmissionStatusService from the old pass-java-client.

Other changes:
- Small javadoc correction to CopyStatus
- Add a test for searching on a relationship