### PR TITLE
Fix Unit Test That Fails on Windows

### DIFF
--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/provider/j10p/DspaceMetadataDomWriterTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/provider/j10p/DspaceMetadataDomWriterTest.java
@@ -237,9 +237,13 @@ public class DspaceMetadataDomWriterTest {
         java.io.File metsxml = tempDir.resolve("testSimple-mets.xml").toFile();
 
         LOG.debug(">>>> Writing test METS output to {}", metsxml);
-        underTest.write(new FileOutputStream(metsxml));
+        try (FileOutputStream fos = new FileOutputStream(metsxml)) {
+            underTest.write(fos);
+        }
         if (LOG.isDebugEnabled()) {
-            IOUtils.copy(new FileInputStream(metsxml), System.err);
+            try (FileInputStream fis = new FileInputStream(metsxml)) {
+                IOUtils.copy(fis, System.err);
+            }
         }
     }
 


### PR DESCRIPTION
There is a unit test failure in Pass-Support. The writeSampleMets test fails with the following error:

`Suppressed: java.nio.file.FileSystemException: C:\Users\tsande16\AppData\Local\Temp\junit12966328472033608479\testSimple-mets.xml: The process cannot access the file because it is being used by another process`

- Closing the output **AND** input stream using try-with-resources, fixes this error on a windows machine.
- No resolution why manually closing the streams was needed on Windows and not Mac/Linux.
- Multiple attempts at other resolutions did not resolve the error: https://github.com/eclipse-pass/main/issues/660