### PR TITLE
671 Add Dspace User and Password to application.properties

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+*.sh text eol=lf
+*.cfg text eol=lf
+*.patch text eol=lf
+*.conf text eol=lf
+*.crt text eol=lf
+*.key text eol=lf

--- a/pass-deposit-services/deposit-core/src/main/resources/application.properties
+++ b/pass-deposit-services/deposit-core/src/main/resources/application.properties
@@ -20,12 +20,11 @@ pass.client.url=${PASS_CLIENT_URL:localhost:8080}
 pass.client.user=${PASS_CLIENT_USER:fakeuser}
 pass.client.password=${PASS_CLIENT_PASSWORD:fakepassword}
 
-ftp.host=${FTP_HOST:localhost}
-ftp.port=${FTP_PORT:21}
+ftp.host=${PMC_FTP_HOST:localhost}
+ftp.port=${PMC_FTP_PORT:21}
 
-#dspace.host=${DSPACE_HOST:localhost}
-#dspace.port=${DSPACE_PORT:8181}
-dspace.server=${DSPACE_SERVER:dspace:8080}
+dspace.host=${DSPACE_HOST:localhost}
+dspace.port=${DSPACE_PORT:8181}
 dspace.user=${DSPACE_USER:test@test.edu}
 dspace.password=${DSPACE_PASSWORD:admin}
 

--- a/pass-deposit-services/deposit-core/src/main/resources/application.properties
+++ b/pass-deposit-services/deposit-core/src/main/resources/application.properties
@@ -22,6 +22,8 @@ pass.client.password=${PASS_CLIENT_PASSWORD:fakepassword}
 
 pmc.ftp.host=${PMC_FTP_HOST:localhost}
 pmc.ftp.port=${PMC_FTP_PORT:21}
+pmc.ftp.user=${PMC_FTP_USER:nihmsftpuser}
+pmc.ftp.password=${PMC_FTP_PASSWORD:nihmsftppass}
 
 dspace.host=${DSPACE_HOST:localhost}
 dspace.port=${DSPACE_PORT:8181}

--- a/pass-deposit-services/deposit-core/src/main/resources/application.properties
+++ b/pass-deposit-services/deposit-core/src/main/resources/application.properties
@@ -20,11 +20,12 @@ pass.client.url=${PASS_CLIENT_URL:localhost:8080}
 pass.client.user=${PASS_CLIENT_USER:fakeuser}
 pass.client.password=${PASS_CLIENT_PASSWORD:fakepassword}
 
-ftp.host=${PMC_FTP_HOST:localhost}
-ftp.port=${PMC_FTP_PORT:21}
+pmc.ftp.host=${PMC_FTP_HOST:localhost}
+pmc.ftp.port=${PMC_FTP_PORT:21}
 
 dspace.host=${DSPACE_HOST:localhost}
 dspace.port=${DSPACE_PORT:8181}
+dspace.server=${DSPACE_SERVER:dspace}
 dspace.user=${DSPACE_USER:test@test.edu}
 dspace.password=${DSPACE_PASSWORD:admin}
 

--- a/pass-deposit-services/deposit-core/src/main/resources/application.properties
+++ b/pass-deposit-services/deposit-core/src/main/resources/application.properties
@@ -23,8 +23,11 @@ pass.client.password=${PASS_CLIENT_PASSWORD:fakepassword}
 ftp.host=${FTP_HOST:localhost}
 ftp.port=${FTP_PORT:21}
 
-dspace.host=${DSPACE_HOST:localhost}
-dspace.port=${DSPACE_PORT:8181}
+#dspace.host=${DSPACE_HOST:localhost}
+#dspace.port=${DSPACE_PORT:8181}
+dspace.server=${DSPACE_SERVER:dspace:8080}
+dspace.user=${DSPACE_USER:test@test.edu}
+dspace.password=${DSPACE_PASSWORD:admin}
 
 pass.deposit.repository.configuration=${PASS_DEPOSIT_REPOSITORY_CONFIGURATION:classpath:/repositories.json}
 pass.deposit.workers.concurrency=${PASS_DEPOSIT_WORKERS_CONCURRENCY:4}

--- a/pass-deposit-services/deposit-core/src/main/resources/repositories.json
+++ b/pass-deposit-services/deposit-core/src/main/resources/repositories.json
@@ -14,8 +14,6 @@
     },
     "transport-config": {
       "protocol-binding": {
-        "username": "${dspace.user}",
-        "password": "${dspace.password}",
         "protocol": "filesystem",
         "baseDir": "target/packages",
         "createIfMissing": "true",

--- a/pass-deposit-services/deposit-core/src/main/resources/repositories.json
+++ b/pass-deposit-services/deposit-core/src/main/resources/repositories.json
@@ -14,6 +14,8 @@
     },
     "transport-config": {
       "protocol-binding": {
+        "username": "${dspace.user}",
+        "password": "${dspace.password}",
         "protocol": "filesystem",
         "baseDir": "target/packages",
         "createIfMissing": "true",

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/config/repository/SimpleClassMappingTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/config/repository/SimpleClassMappingTest.java
@@ -54,8 +54,8 @@ public class SimpleClassMappingTest extends AbstractJacksonMappingTest {
                                                    "        \"protocol\": \"ftp\",\n" +
                                                    "        \"username\": \"ftpuser\",\n" +
                                                    "        \"password\": \"ftppass\",\n" +
-                                                   "        \"server-fqdn\": \"${ftp.host}\",\n" +
-                                                   "        \"server-port\": \"${ftp.port}\",\n" +
+                                                   "        \"server-fqdn\": \"${pmc.ftp.host}\",\n" +
+                                                   "        \"server-port\": \"${pmc.ftp.port}\",\n" +
                                                    "        \"data-type\": \"binary\",\n" +
                                                    "        \"transfer-mode\": \"stream\",\n" +
                                                    "        \"use-pasv\": true,\n" +


### PR DESCRIPTION
The separate `server-fqdn` and `server-port` were not working for the `SWORDv2` transport in the `deposit-repositories.json`. These variables have been set to `null` and are replaced with a new environment variable `dspace.server` in pass-docker. In order to achieve this in the `application.properties` two new variables were required: `dspace.user` and `dspace.password`

This is related to PR: https://github.com/eclipse-pass/pass-docker/pull/353

Both this PR in `pass-support` and the PR in `pass-docker` need to be checked out to test locally.

Other things to note:

- Needed to add the .gitattributes to handle the EOL on a windows machine
- Change the environment variable FTP_HOST to PMC_FTP_HOST

Testing: 

- Run pass-docker and pull images, but remove the `deposit-services-core` image
    - `docker compose -f docker-compose.yml -f eclipse-pass.local.yml up -d --no-build --quiet-pull --pull always`
    - After retrieving all images. Bring pass-docker down and remove all volumes
         - `docker compose -p pass-docker down -v`
     - Remove the image `deposit-services-core`
- Create the `deposit-services-core` image locally. 
- Run pass-docker without pulling images and include the deposit-services, dspace and ftp
     - `docker compose -p pass-docker -f docker-compose.yml -f eclipse-pass.local.yml -f docker-compose-deposit.yml -f docker-compose-dspace.yml up -d --no-build`
     - Create the Admin:
     - `docker compose -p pass-docker -f dspace-cli.yml run --rm dspace-cli create-administrator -e test@test.edu -f admin -l user -p admin -c en`
     - Load sample data:
     - `docker compose -p pass-docker -f dspace-cli.yml -f dspace-cli.ingest.yml run --rm dspace-cli`
