### PR TITLE
Handle normalization of an award number consisting of whitespace

### DIFF
--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/ModelUtil.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/ModelUtil.java
@@ -1,6 +1,5 @@
 package org.eclipse.pass.support.client;
 
-import java.io.IOException;
 import java.time.format.DateTimeFormatter;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -10,10 +9,10 @@ import org.apache.commons.lang3.StringUtils;
 /**
  * Utilities for working with the model.
  */
-public class Util {
+public class ModelUtil {
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
 
-    private Util() {}
+    private ModelUtil() {}
 
     /**
      * The ZonedDateTime fields in the model must use this formatter.
@@ -31,13 +30,17 @@ public class Util {
      * award number.
      * @param awardNumber award number to normalize
      * @return normalized award number
-     * @throws IOException if the award number cannot be normalized
      */
-    public static String grantAwardNumberNormalizer(String awardNumber) throws IOException {
-        if (StringUtils.isEmpty(awardNumber)) {
+    public static String normalizeAwardNumber(String awardNumber) {
+        if (awardNumber == null) {
             return null;
         }
+
         awardNumber = awardNumber.trim();
+
+        if (awardNumber.isEmpty()) {
+            return null;
+        }
 
         //if matching the NIH format, then normalize it to the expected format by removing leading zeros
         if (awardNumber.toUpperCase().matches("[0-9]*-*\\s*[A-Z]{1,2}[0-9]{1,2}\s*[A-Z]{2}[A-Z0-9]{6}-*[A-Z0-9]*")) {
@@ -47,6 +50,7 @@ public class Util {
                     .replaceAll("\\s", "")
                     .toUpperCase();
         }
+
         return awardNumber;
     }
 
@@ -65,11 +69,11 @@ public class Util {
      *  5) Leading zeros following by a hyphen: 000-A01 BC123456
      *  5) Application type that has a leading number 1-9: 1A01 BC123456
      * @param awardNumber
-     * @return
+     * @return RSQL
      */
-    public static String grantAwardNumberNormalizeSearch(String awardNumber, String rsqlFieldName) throws IOException {
+    public static String createAwardNumberQuery(String awardNumber, String rsqlFieldName) {
         if (StringUtils.isEmpty(awardNumber)) {
-            throw new IOException("Award number cannot be empty");
+            throw new IllegalArgumentException("Award number cannot be empty");
         }
         String awardNumberNihMinSet = "";
         if (awardNumber.toUpperCase().matches("[0-9]*-*\\s*[A-Z]{1,2}[0-9]{1,2}\s*[A-Z]{2}[0-9]{6}-*[A-Z0-9]*")) {
@@ -87,7 +91,7 @@ public class Util {
             }
         }
 
-        String normalizedNihGrant = Util.grantAwardNumberNormalizer(awardNumber);
+        String normalizedNihGrant = ModelUtil.normalizeAwardNumber(awardNumber);
 
         if (awardNumber.equals(normalizedNihGrant) && StringUtils.isEmpty(awardNumberNihMinSet)) {
             return RSQL.equals(rsqlFieldName, awardNumber);

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/adapter/ZonedDateTimeAdapter.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/adapter/ZonedDateTimeAdapter.java
@@ -4,7 +4,7 @@ import java.time.ZonedDateTime;
 
 import com.squareup.moshi.FromJson;
 import com.squareup.moshi.ToJson;
-import org.eclipse.pass.support.client.Util;
+import org.eclipse.pass.support.client.ModelUtil;
 
 /**
  * Map type to JSON.
@@ -16,7 +16,7 @@ public class ZonedDateTimeAdapter {
      */
     @ToJson
     public String toJson(ZonedDateTime value) {
-        return value.format(Util.dateTimeFormatter());
+        return value.format(ModelUtil.dateTimeFormatter());
     }
 
     /**
@@ -25,6 +25,6 @@ public class ZonedDateTimeAdapter {
      */
     @FromJson
     public ZonedDateTime fromJson(String s) {
-        return ZonedDateTime.parse(s, Util.dateTimeFormatter());
+        return ZonedDateTime.parse(s, ModelUtil.dateTimeFormatter());
     }
 }

--- a/pass-data-client/src/test/java/org/eclipse/pass/support/client/JsonApiPassClientIT.java
+++ b/pass-data-client/src/test/java/org/eclipse/pass/support/client/JsonApiPassClientIT.java
@@ -309,7 +309,7 @@ public class JsonApiPassClientIT {
     }
 
     private static ZonedDateTime dt(String s) {
-        return ZonedDateTime.parse(s, Util.dateTimeFormatter());
+        return ZonedDateTime.parse(s, ModelUtil.dateTimeFormatter());
     }
 
     @Test

--- a/pass-data-client/src/test/java/org/eclipse/pass/support/client/ModelUtilTest.java
+++ b/pass-data-client/src/test/java/org/eclipse/pass/support/client/ModelUtilTest.java
@@ -15,11 +15,12 @@ import org.junit.jupiter.api.Test;
 /**
  * This is a test class to test the utility methods in the pass-data-client Util class.
  */
-public class UtilTest {
+public class ModelUtilTest {
     @Test
     public void testNullAndEmptyAwardNumber() throws IOException {
-        assertNull(Util.grantAwardNumberNormalizer(null));
-        assertNull(Util.grantAwardNumberNormalizer(""));
+        assertNull(ModelUtil.normalizeAwardNumber(null));
+        assertNull(ModelUtil.normalizeAwardNumber(""));
+        assertNull(ModelUtil.normalizeAwardNumber("  "));
     }
 
     @Test
@@ -28,8 +29,8 @@ public class UtilTest {
         String awardNumber2 = "P50 AI074285";
         String awardNumber1Expected = "K99NS062901";
         String awardNumber2Expected = "P50AI074285";
-        assertEquals(awardNumber1Expected, Util.grantAwardNumberNormalizer(awardNumber1));
-        assertEquals(awardNumber2Expected, Util.grantAwardNumberNormalizer(awardNumber2));
+        assertEquals(awardNumber1Expected, ModelUtil.normalizeAwardNumber(awardNumber1));
+        assertEquals(awardNumber2Expected, ModelUtil.normalizeAwardNumber(awardNumber2));
     }
 
     @Test
@@ -42,10 +43,10 @@ public class UtilTest {
         String expectedAwardNumber2 = "U01CA078284-05S2";
         String expectedAwardNumber3 = "U01CA078284-05S2";
         String expectedAwardNumber4 = "1R01AR074846-A1";
-        assertEquals(expectedAwardNumber1, Util.grantAwardNumberNormalizer(awardNumber1));
-        assertEquals(expectedAwardNumber2, Util.grantAwardNumberNormalizer(awardNumber2));
-        assertEquals(expectedAwardNumber3, Util.grantAwardNumberNormalizer(awardNumber3));
-        assertEquals(expectedAwardNumber4, Util.grantAwardNumberNormalizer(awardNumber4));
+        assertEquals(expectedAwardNumber1, ModelUtil.normalizeAwardNumber(awardNumber1));
+        assertEquals(expectedAwardNumber2, ModelUtil.normalizeAwardNumber(awardNumber2));
+        assertEquals(expectedAwardNumber3, ModelUtil.normalizeAwardNumber(awardNumber3));
+        assertEquals(expectedAwardNumber4, ModelUtil.normalizeAwardNumber(awardNumber4));
     }
 
     @Test
@@ -60,10 +61,10 @@ public class UtilTest {
         String expectedNonNih1 = "000 000844";
         String expectedNonNih2 = "CBET0732580";
 
-        assertEquals(expectedNih1, Util.grantAwardNumberNormalizer(awardNumberNih1));
-        assertEquals(expectedNih2, Util.grantAwardNumberNormalizer(awardNumberNih2));
-        assertEquals(expectedNonNih1, Util.grantAwardNumberNormalizer(awardNumberNonNih1));
-        assertEquals(expectedNonNih2, Util.grantAwardNumberNormalizer(awardNumberNonNih2));
+        assertEquals(expectedNih1, ModelUtil.normalizeAwardNumber(awardNumberNih1));
+        assertEquals(expectedNih2, ModelUtil.normalizeAwardNumber(awardNumberNih2));
+        assertEquals(expectedNonNih1, ModelUtil.normalizeAwardNumber(awardNumberNonNih1));
+        assertEquals(expectedNonNih2, ModelUtil.normalizeAwardNumber(awardNumberNonNih2));
     }
 
     @Test
@@ -76,12 +77,12 @@ public class UtilTest {
         String expectedNumber = "A01RH123456";
         String expectedNumber2 = "A01RH123456-A1";
 
-        assertEquals(expectedNumber, Util.grantAwardNumberNormalizer(awardNumber1));
-        assertEquals(expectedNumber, Util.grantAwardNumberNormalizer(awardNumber2));
-        assertEquals(expectedNumber, Util.grantAwardNumberNormalizer(awardNumber3));
+        assertEquals(expectedNumber, ModelUtil.normalizeAwardNumber(awardNumber1));
+        assertEquals(expectedNumber, ModelUtil.normalizeAwardNumber(awardNumber2));
+        assertEquals(expectedNumber, ModelUtil.normalizeAwardNumber(awardNumber3));
 
         // This one is a special case, because the A1 is part of the award number,and should normalize with it
-        assertEquals(expectedNumber2, Util.grantAwardNumberNormalizer(awardNumber4));
+        assertEquals(expectedNumber2, ModelUtil.normalizeAwardNumber(awardNumber4));
     }
 
     /**
@@ -93,10 +94,10 @@ public class UtilTest {
      */
     @Test
     public void testAwardNumberWithValidData() throws IOException, URISyntaxException {
-        URI testAwardNumberUri = UtilTest.class.getResource("/valid_award_numbers.csv").toURI();
+        URI testAwardNumberUri = ModelUtilTest.class.getResource("/valid_award_numbers.csv").toURI();
         List<String> awardNumbers = Files.readAllLines(Paths.get(testAwardNumberUri));
         for (String awardNumber : awardNumbers) {
-            assertEquals(awardNumber, Util.grantAwardNumberNormalizer(awardNumber));
+            assertEquals(awardNumber, ModelUtil.normalizeAwardNumber(awardNumber));
         }
     }
 
@@ -121,10 +122,10 @@ public class UtilTest {
         String expectedCase3 = "(awardNumber==' R01 CA078284',awardNumber=='R01CA078284',awardNumber=='*R01CA078284*')";
         String expectedCase4 = "(awardNumber=='R01CA078284',awardNumber=='*R01CA078284*')";
 
-        assertEquals(expectedCase1, Util.grantAwardNumberNormalizeSearch(awardNumberCase1,"awardNumber"));
-        assertEquals(expectedCase2, Util.grantAwardNumberNormalizeSearch(awardNumberCase2,"awardNumber"));
-        assertEquals(expectedCase3, Util.grantAwardNumberNormalizeSearch(awardNumberCase3,"awardNumber"));
-        assertEquals(expectedCase4, Util.grantAwardNumberNormalizeSearch(awardNumberCase4,"awardNumber"));
+        assertEquals(expectedCase1, ModelUtil.createAwardNumberQuery(awardNumberCase1,"awardNumber"));
+        assertEquals(expectedCase2, ModelUtil.createAwardNumberQuery(awardNumberCase2,"awardNumber"));
+        assertEquals(expectedCase3, ModelUtil.createAwardNumberQuery(awardNumberCase3,"awardNumber"));
+        assertEquals(expectedCase4, ModelUtil.createAwardNumberQuery(awardNumberCase4,"awardNumber"));
 
     }
 

--- a/pass-grant-loader/pass-grant-data/src/main/java/org/eclipse/pass/support/grant/data/CoeusConnector.java
+++ b/pass-grant-loader/pass-grant-data/src/main/java/org/eclipse/pass/support/grant/data/CoeusConnector.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import org.eclipse.pass.support.client.Util;
+import org.eclipse.pass.support.client.ModelUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -109,7 +109,7 @@ public class CoeusConnector implements GrantConnector {
                 Map<String, String> rowMap = new HashMap<>();
 
                 rowMap.put(CoeusFieldNames.C_GRANT_AWARD_NUMBER,
-                        Util.grantAwardNumberNormalizer(rs.getString(CoeusFieldNames.C_GRANT_AWARD_NUMBER)));
+                        ModelUtil.normalizeAwardNumber(rs.getString(CoeusFieldNames.C_GRANT_AWARD_NUMBER)));
                 rowMap.put(CoeusFieldNames.C_GRANT_AWARD_STATUS, rs.getString(CoeusFieldNames.C_GRANT_AWARD_STATUS));
                 rowMap.put(CoeusFieldNames.C_GRANT_LOCAL_KEY, rs.getString(CoeusFieldNames.C_GRANT_LOCAL_KEY));
                 rowMap.put(CoeusFieldNames.C_GRANT_PROJECT_NAME, rs.getString(CoeusFieldNames.C_GRANT_PROJECT_NAME));

--- a/pass-nihms-loader/nihms-pass-client/src/main/java/org/eclipse/pass/client/nihms/NihmsPassClientService.java
+++ b/pass-nihms-loader/nihms-pass-client/src/main/java/org/eclipse/pass/client/nihms/NihmsPassClientService.java
@@ -31,11 +31,11 @@ import org.eclipse.pass.client.nihms.cache.NihmsRepositoryCopyIdCache;
 import org.eclipse.pass.client.nihms.cache.PublicationIdCache;
 import org.eclipse.pass.client.nihms.cache.UserPubSubmissionsCache;
 import org.eclipse.pass.loader.nihms.util.ConfigUtil;
+import org.eclipse.pass.support.client.ModelUtil;
 import org.eclipse.pass.support.client.PassClient;
 import org.eclipse.pass.support.client.PassClientResult;
 import org.eclipse.pass.support.client.PassClientSelector;
 import org.eclipse.pass.support.client.RSQL;
-import org.eclipse.pass.support.client.Util;
 import org.eclipse.pass.support.client.model.Deposit;
 import org.eclipse.pass.support.client.model.Grant;
 import org.eclipse.pass.support.client.model.Journal;
@@ -184,7 +184,7 @@ public class NihmsPassClientService {
         // if we are here, there was nothing cached and we need to figure out which grant to return
         List<Grant> grants;
         PassClientSelector<Grant> grantSelector = new PassClientSelector<Grant>(Grant.class);
-        String normalizedAwardNumberFilter = Util.grantAwardNumberNormalizeSearch(awardNumber, AWARD_NUMBER_FLD);
+        String normalizedAwardNumberFilter = ModelUtil.createAwardNumberQuery(awardNumber, AWARD_NUMBER_FLD);
         grantSelector.setFilter(normalizedAwardNumberFilter);
         Stream<Grant> grantStream = passClient.streamObjects(grantSelector);
         grants = grantStream.toList();

--- a/pass-nihms-loader/nihms-pass-client/src/test/java/org/eclipse/pass/client/nihms/NihmsPassClientServiceTest.java
+++ b/pass-nihms-loader/nihms-pass-client/src/test/java/org/eclipse/pass/client/nihms/NihmsPassClientServiceTest.java
@@ -38,11 +38,11 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.stream.Stream;
 
+import org.eclipse.pass.support.client.ModelUtil;
 import org.eclipse.pass.support.client.PassClient;
 import org.eclipse.pass.support.client.PassClientResult;
 import org.eclipse.pass.support.client.PassClientSelector;
 import org.eclipse.pass.support.client.RSQL;
-import org.eclipse.pass.support.client.Util;
 import org.eclipse.pass.support.client.model.Deposit;
 import org.eclipse.pass.support.client.model.Grant;
 import org.eclipse.pass.support.client.model.Publication;
@@ -98,7 +98,7 @@ public class NihmsPassClientServiceTest {
      */
     @Test
     public void testFindGrantByAwardNumberNoMatch() throws IOException {
-        String awardFilter = Util.grantAwardNumberNormalizeSearch(awardNumber, AWARD_NUMBER_FLD);
+        String awardFilter = ModelUtil.createAwardNumberQuery(awardNumber, AWARD_NUMBER_FLD);
 
         Stream<Grant> mockGrantResult = Stream.empty();
 
@@ -115,11 +115,11 @@ public class NihmsPassClientServiceTest {
      */
     @Test
     public void testFindGrantByAwardNumberHasMatch() throws Exception {
-        String awardFilter = Util.grantAwardNumberNormalizeSearch(awardNumber, AWARD_NUMBER_FLD);
-        String awardFilter1 = Util.grantAwardNumberNormalizeSearch(awardNumber1, AWARD_NUMBER_FLD);
-        String awardFilter2 = Util.grantAwardNumberNormalizeSearch(awardNumber2, AWARD_NUMBER_FLD);
-        String awardFilter3 = Util.grantAwardNumberNormalizeSearch(awardNumber3, AWARD_NUMBER_FLD);
-        String awardFilter4 = Util.grantAwardNumberNormalizeSearch(awardNumber4, AWARD_NUMBER_FLD);
+        String awardFilter = ModelUtil.createAwardNumberQuery(awardNumber, AWARD_NUMBER_FLD);
+        String awardFilter1 = ModelUtil.createAwardNumberQuery(awardNumber1, AWARD_NUMBER_FLD);
+        String awardFilter2 = ModelUtil.createAwardNumberQuery(awardNumber2, AWARD_NUMBER_FLD);
+        String awardFilter3 = ModelUtil.createAwardNumberQuery(awardNumber3, AWARD_NUMBER_FLD);
+        String awardFilter4 = ModelUtil.createAwardNumberQuery(awardNumber4, AWARD_NUMBER_FLD);
 
         Grant grant1 = new Grant("1");
         grant1.setAwardNumber(awardNumber);
@@ -198,9 +198,9 @@ public class NihmsPassClientServiceTest {
      */
     @Test
     public void testFindGrantByAwardNumberCanNormalizeHasMatch() throws Exception {
-        String awardFilter1 = Util.grantAwardNumberNormalizeSearch("K23 HL153778-1A1", AWARD_NUMBER_FLD);
-        String awardFilter2 = Util.grantAwardNumberNormalizeSearch("S10 OD025226-1", AWARD_NUMBER_FLD);
-        String awardFilter3 = Util.grantAwardNumberNormalizeSearch("R55 AR050026-1", AWARD_NUMBER_FLD);
+        String awardFilter1 = ModelUtil.createAwardNumberQuery("K23 HL153778-1A1", AWARD_NUMBER_FLD);
+        String awardFilter2 = ModelUtil.createAwardNumberQuery("S10 OD025226-1", AWARD_NUMBER_FLD);
+        String awardFilter3 = ModelUtil.createAwardNumberQuery("R55 AR050026-1", AWARD_NUMBER_FLD);
 
         Grant grant1 = new Grant("1");
         grant1.setAwardNumber("K23 HL153778");


### PR DESCRIPTION
Make sure that an award number consisting only of whitespace is normalized to null.
Renames the Util class and the award number methods to be more clear.
Removes the uneeded thrown IOException from one method and changes the other IOException to an IllegalArgumentException