### PR TITLE
Fix grant loader comparison logic

### DIFF
--- a/pass-grant-loader/pass-grant-data/src/main/java/org/eclipse/pass/support/grant/data/AbstractDefaultPassUpdater.java
+++ b/pass-grant-loader/pass-grant-data/src/main/java/org/eclipse/pass/support/grant/data/AbstractDefaultPassUpdater.java
@@ -38,8 +38,12 @@ import java.io.IOException;
 import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.pass.support.client.PassClient;
@@ -311,6 +315,24 @@ abstract class AbstractDefaultPassUpdater implements PassUpdater {
         } else {
             System.out.println("No records were processed in this update");
         }
+    }
+
+    /**
+     * Returns the Pass entity ID of passEntity. This method is null-safe.
+     * @param passEntity the passEntity
+     * @return the ID of passEntity or null if passEntity is null or the ID is null
+     */
+    protected String getPassEntityId(PassEntity passEntity) {
+        return Optional.ofNullable(passEntity).map(PassEntity::getId).orElse(null);
+    }
+
+    /**
+     * Returns a Set of Pass entity ID of passEntities.
+     * @param passEntities the list of passEntities
+     * @return the Set of passEntity IDs
+     */
+    protected Set<String> getPassEntityIds(List<? extends PassEntity> passEntities) {
+        return passEntities.stream().map(PassEntity::getId).collect(Collectors.toSet());
     }
 
     private void updateUsers(Collection<Map<String, String>> results) {

--- a/pass-grant-loader/pass-grant-data/src/main/java/org/eclipse/pass/support/grant/data/DifferenceLogger.java
+++ b/pass-grant-loader/pass-grant-data/src/main/java/org/eclipse/pass/support/grant/data/DifferenceLogger.java
@@ -59,7 +59,8 @@ public class DifferenceLogger {
                     getPassEntityDiffs((PassEntity) value1, (PassEntity) value2, values, field);
                 } else if (value1 instanceof List || value2 instanceof List) {
                     getListDiffs((List<PassEntity>) value1, (List<PassEntity>) value2, values, field);
-                } else if (!Objects.equals(value1, value2)) {
+                } else if (!field.getName().equals("id")
+                    && !Objects.equals(value1, value2)) {
                     values.add(field.getName() + ": " + value1 + " -> " + value2);
                 }
             }

--- a/pass-grant-loader/pass-grant-data/src/main/java/org/eclipse/pass/support/grant/data/JhuPassInitUpdater.java
+++ b/pass-grant-loader/pass-grant-data/src/main/java/org/eclipse/pass/support/grant/data/JhuPassInitUpdater.java
@@ -15,8 +15,6 @@
  */
 package org.eclipse.pass.support.grant.data;
 
-import java.util.HashSet;
-
 import org.eclipse.pass.support.client.model.Grant;
 import org.eclipse.pass.support.client.model.User;
 
@@ -75,50 +73,59 @@ public class JhuPassInitUpdater extends JhuPassUpdater {
      */
 
     private boolean grantNeedsUpdate(Grant system, Grant stored) {
-        if (system.getAwardNumber() != null ? !system.getAwardNumber()
-            .equals(
-                stored.getAwardNumber()) : stored.getAwardNumber() != null) {
+        if (system.getAwardNumber() != null
+            ? !system.getAwardNumber().equals(stored.getAwardNumber())
+            : stored.getAwardNumber() != null) {
             return true;
         }
-        if (system.getAwardStatus() != null ? !system.getAwardStatus()
-            .equals(
-                stored.getAwardStatus()) : stored.getAwardStatus() != null) {
+        if (system.getAwardStatus() != null
+            ? !system.getAwardStatus().equals(stored.getAwardStatus())
+            : stored.getAwardStatus() != null) {
             return true;
         }
-        if (system.getLocalKey() != null ? !system.getLocalKey()
-            .equals(stored.getLocalKey()) : stored.getLocalKey() != null) {
+        if (system.getLocalKey() != null
+            ? !system.getLocalKey().equals(stored.getLocalKey())
+            : stored.getLocalKey() != null) {
             return true;
         }
-        if (system.getProjectName() != null ? !system.getProjectName()
-            .equals(
-                stored.getProjectName()) : stored.getProjectName() != null) {
+        if (system.getProjectName() != null
+            ? !system.getProjectName().equals(stored.getProjectName())
+            : stored.getProjectName() != null) {
             return true;
         }
-        if (system.getPrimaryFunder() != null ? !system.getPrimaryFunder().equals(
-            stored.getPrimaryFunder()) : stored.getPrimaryFunder() != null) {
+        if (system.getPrimaryFunder() != null
+            ? !system.getPrimaryFunder().getId().equals(getPassEntityId(stored.getPrimaryFunder()))
+            : stored.getPrimaryFunder() != null) {
             return true;
         }
-        if (system.getDirectFunder() != null ? !system.getDirectFunder().equals(
-            stored.getDirectFunder()) : stored.getDirectFunder() != null) {
+        if (system.getDirectFunder() != null
+            ? !system.getDirectFunder().getId().equals(getPassEntityId(stored.getDirectFunder()))
+            : stored.getDirectFunder() != null) {
             return true;
         }
-        if (system.getPi() != null ? !system.getPi().equals(stored.getPi()) : stored.getPi() != null) {
+        if (system.getPi() != null
+            ? !system.getPi().getId().equals(getPassEntityId(stored.getPi()))
+            : stored.getPi() != null) {
             return true;
         }
-        if (system.getCoPis() != null ? !new HashSet(system.getCoPis()).equals(
-            new HashSet(stored.getCoPis())) : stored.getCoPis() != null) {
+        if (system.getCoPis() != null
+            ? !getPassEntityIds(system.getCoPis()).equals(getPassEntityIds(stored.getCoPis()))
+            : stored.getCoPis() != null) {
             return true;
         }
-        if (system.getAwardDate() != null ? system.getAwardDate()
-            .isBefore(stored.getAwardDate()) : stored.getAwardDate() != null) {
+        if (system.getAwardDate() != null
+            ? system.getAwardDate().isBefore(stored.getAwardDate())
+            : stored.getAwardDate() != null) {
             return true;
         }
-        if (system.getStartDate() != null ? system.getStartDate()
-            .isBefore(stored.getStartDate()) : stored.getStartDate() != null) {
+        if (system.getStartDate() != null
+            ? system.getStartDate().isBefore(stored.getStartDate())
+            : stored.getStartDate() != null) {
             return true;
         }
-        if (system.getEndDate() != null ? system.getEndDate()
-            .isAfter(stored.getEndDate()) : stored.getEndDate() != null) {
+        if (system.getEndDate() != null
+            ? system.getEndDate().isAfter(stored.getEndDate())
+            : stored.getEndDate() != null) {
             return true;
         }
         return false;
@@ -132,7 +139,7 @@ public class JhuPassInitUpdater extends JhuPassUpdater {
      * @return the Grant object which represents the Pass object, with any new information from COEUS merged in
      */
     private Grant updateGrant(Grant system, Grant stored) {
-        differenceLogger.log(system, stored);
+        differenceLogger.log(stored, system);
         stored.setAwardNumber(system.getAwardNumber());
         stored.setAwardStatus(system.getAwardStatus());
         stored.setLocalKey(system.getLocalKey());

--- a/pass-grant-loader/pass-grant-data/src/main/java/org/eclipse/pass/support/grant/data/JhuPassUpdater.java
+++ b/pass-grant-loader/pass-grant-data/src/main/java/org/eclipse/pass/support/grant/data/JhuPassUpdater.java
@@ -146,11 +146,14 @@ public class JhuPassUpdater extends AbstractDefaultPassUpdater {
         if (system.getName() != null && !system.getName().equals(stored.getName())) {
             return true;
         }
-        if (system.getLocalKey() != null ? !system.getLocalKey()
-            .equals(stored.getLocalKey()) : stored.getLocalKey() != null) {
+        if (system.getLocalKey() != null
+            ? !system.getLocalKey().equals(stored.getLocalKey())
+            : stored.getLocalKey() != null) {
             return true;
         }
-        if (system.getPolicy() != null ? !system.getPolicy().equals(stored.getPolicy()) : stored.getPolicy() != null) {
+        if (system.getPolicy() != null
+            ? !system.getPolicy().getId().equals(getPassEntityId(stored.getPolicy()))
+            : stored.getPolicy() != null) {
             return true;
         }
         return false;
@@ -244,20 +247,24 @@ public class JhuPassUpdater extends AbstractDefaultPassUpdater {
      * @return a boolean which asserts whether the two supplied Grants are "COEUS equal"
      */
     private boolean grantNeedsUpdate(Grant system, Grant stored) {
-        if (system.getAwardStatus() != null ? !system.getAwardStatus()
-            .equals(
-                stored.getAwardStatus()) : stored.getAwardStatus() != null) {
+        if (system.getAwardStatus() != null
+            ? !system.getAwardStatus().equals(stored.getAwardStatus())
+            : stored.getAwardStatus() != null) {
             return true;
         }
-        if (system.getPi() != null ? !system.getPi().equals(stored.getPi()) : stored.getPi() != null) {
+        if (system.getPi() != null
+            ? !system.getPi().getId().equals(getPassEntityId(stored.getPi()))
+            : stored.getPi() != null) {
             return true;
         }
-        if (system.getCoPis() != null ? !new HashSet(system.getCoPis()).equals(
-            new HashSet(stored.getCoPis())) : stored.getCoPis() != null) {
+        if (system.getCoPis() != null
+            ? !getPassEntityIds(system.getCoPis()).equals(getPassEntityIds(stored.getCoPis()))
+            : stored.getCoPis() != null) {
             return true;
         }
-        if (system.getEndDate() != null ? system.getEndDate()
-            .isAfter(stored.getEndDate()) : stored.getEndDate() != null) {
+        if (system.getEndDate() != null
+            ? system.getEndDate().isAfter(stored.getEndDate())
+            : stored.getEndDate() != null) {
             return true;
         }
         return false;


### PR DESCRIPTION
This PR fixes an issue where entities were being updated in grant loader even though there were not any changes.  This happened because entities that had associations to other entities had comparisons using equals the the associated entities are not always completely populated.  I changed the comparison logic to compare entity IDs when checking to see if an entity association has changed.