### PR TITLE
Add nihmsetl.repository.id

### DIFF
--- a/pass-nihms-loader/nihms-data-transform-load/src/main/java/org/eclipse/pass/loader/nihms/NihmsTransformLoadApp.java
+++ b/pass-nihms-loader/nihms-data-transform-load/src/main/java/org/eclipse/pass/loader/nihms/NihmsTransformLoadApp.java
@@ -42,7 +42,7 @@ public class NihmsTransformLoadApp {
      * These are the only system properties that can be loaded in from the properties file.
      * Existing values will not be overwritten, these will just be added if missing.
      */
-    private static final String[] SYSTEM_PROPERTIES = {"pass.core.user", "pass.core.password",
+    private static final String[] SYSTEM_PROPERTIES = {"pass.core.user", "pass.core.password", "nihmsetl.repository.id",
                                                        "pass.core.url", "nihmsetl.data.dir", "nihmsetl.pmcurl.template",
                                                        "nihmsetl.loader.cachepath"};
 


### PR DESCRIPTION
Added nihmsetl.repository.id to the set of allowed system properties to be read into from the config file.

To test:
`mvn verify`

Note: I tested locally, manually putting in grants, and setting up the nihms repo. Took that ID put it in the config file, and after running, verified submissions were associated with that nihms repo ID.