### PR TITLE
Fix failed deposit retry submission status bug

### DIFF
--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/FailedDepositRetry.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/FailedDepositRetry.java
@@ -61,7 +61,8 @@ public class FailedDepositRetry {
     public void retryFailedDeposit(Deposit failedDeposit) {
         try {
             Deposit deposit = passClient.getObject(failedDeposit, "submission", "repository");
-            final Submission submission = deposit.getSubmission();
+            final Submission submission = passClient.getObject(deposit.getSubmission(),
+                "publication", "submitter");
             final Repository repository = deposit.getRepository();
 
             final Packager packager = packagerRegistry.get(repository.getRepositoryKey());

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/FailedDepositRetryIT.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/FailedDepositRetryIT.java
@@ -15,6 +15,7 @@
  */
 package org.eclipse.pass.deposit.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -66,9 +67,13 @@ public class FailedDepositRetryIT extends AbstractDepositIT {
 
         Deposit actualDeposit = actualDeposits.getResult().iterator().next();
         Deposit updatedDeposit = passClient.getObject(actualDeposit, "repositoryCopy");
-        RepositoryCopy popRepoCopy = passClient.getObject(updatedDeposit.getRepositoryCopy(), "repository");
+        RepositoryCopy popRepoCopy = passClient.getObject(updatedDeposit.getRepositoryCopy(),
+            "repository", "publication");
         updatedDeposit.setRepositoryCopy(popRepoCopy);
         verify(passClient).updateObject(eq(updatedDeposit));
+        assertEquals(submission.getPublication().getId(), popRepoCopy.getPublication().getId());
+        assertEquals(1, submission.getRepositories().size());
+        assertEquals(submission.getRepositories().get(0).getId(), popRepoCopy.getRepository().getId());
     }
 
     private Submission initFailedSubmissionDeposit() throws Exception {

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/FailedDepositRetryTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/FailedDepositRetryTest.java
@@ -64,6 +64,7 @@ public class FailedDepositRetryTest {
         Submission submission = new Submission();
         deposit1.setSubmission(submission);
         when(passClient.getObject(same(deposit1), any())).thenReturn(deposit1);
+        when(passClient.getObject(same(submission), any())).thenReturn(submission);
         when(packagerRegistry.get(any())).thenReturn(packager);
         DepositSubmission depositSubmission = new DepositSubmission();
         DepositFile depositFile1 = new DepositFile();


### PR DESCRIPTION
There was a bug in the failed deposit retry code where if the deposit succeeded, when the RepositoryCopy object was created, the associated Publication of the Submission was null, so the associated Publication of the RepositoryCopy was null.  This causes the Submission status update logic to fall down because it requires that the submission Deposit.RepositoryCopy have a matching Publication in order to update submission status.

PR with script to fix null repo_copy.publication_id in stage database is here: https://github.com/eclipse-pass/pass-core/pull/69

The PR in pass-core should be merged after this PR is merged and deployed to stage.