### PR TITLE
Update NIH award Format in the award number normalizer

### DIFF
--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/ModelUtil.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/ModelUtil.java
@@ -43,7 +43,8 @@ public class ModelUtil {
         }
 
         //if matching the NIH format, then normalize it to the expected format by removing leading zeros
-        if (awardNumber.toUpperCase().matches("[0-9]*-*\\s*[A-Z]{1,2}[0-9]{1,2}\s*[A-Z]{2}[A-Z0-9]{6}-*[A-Z0-9]*")) {
+        if (awardNumber
+                .toUpperCase().matches("[0-9]*-*\\s*[A-Z]{1,2}[0-9]{1,2}[A-Z]?\s*[A-Z]{2}[A-Z0-9]{6}-*[A-Z0-9]*")) {
             //remove leading zeros, whitespace and make uppercase
             awardNumber = awardNumber
                     .replaceFirst("^0+-*(?!$)", "")

--- a/pass-data-client/src/test/java/org/eclipse/pass/support/client/ModelUtilTest.java
+++ b/pass-data-client/src/test/java/org/eclipse/pass/support/client/ModelUtilTest.java
@@ -27,10 +27,13 @@ public class ModelUtilTest {
     public void testNihAwardNumberCorrectFormatWithSpace() throws IOException {
         String awardNumber1 = "K99 NS062901";
         String awardNumber2 = "P50 AI074285";
+        String awardNumber3 = "P2C HD042854";
         String awardNumber1Expected = "K99NS062901";
         String awardNumber2Expected = "P50AI074285";
+        String awardNumber3Expected = "P2CHD042854";
         assertEquals(awardNumber1Expected, ModelUtil.normalizeAwardNumber(awardNumber1));
         assertEquals(awardNumber2Expected, ModelUtil.normalizeAwardNumber(awardNumber2));
+        assertEquals(awardNumber3Expected, ModelUtil.normalizeAwardNumber(awardNumber3));
     }
 
     @Test


### PR DESCRIPTION
normalizeAwardNumber() does not capture award numbers that have the format [A-Z][0-9][A-Z], most activity codes are 1 letter followed by 2 numbers or two letters followed by 1 number; however there are cases of letter, number, letter e.g. P2C HD042854

Note: P2C activity codes make up a very small portion of award numbers. Only 2 were found in 1 year's worth of data from PMC

ref: https://www.era.nih.gov/files/Deciphering-NIH-Application.pdf
https://grants.nih.gov/grants/funding/ac_search_results.htm

To test: `mvn verify`