### PR TITLE
Update nihms pmc deposits using email integration

### DIFF
--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/Deposit.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/Deposit.java
@@ -49,6 +49,11 @@ public class Deposit implements PassEntity, PassVersionedEntity {
     private String depositStatusRef;
 
     /**
+     * A status message pertaining to the deposit.
+     */
+    private String statusMessage;
+
+    /**
      * Status of deposit
      */
     private DepositStatus depositStatus;
@@ -153,6 +158,20 @@ public class Deposit implements PassEntity, PassVersionedEntity {
      */
     public void setDepositStatusRef(String depositStatusRef) {
         this.depositStatusRef = depositStatusRef;
+    }
+
+    /**
+     * @return the statusMessage
+     */
+    public String getStatusMessage() {
+        return statusMessage;
+    }
+
+    /**
+     * @param statusMessage the statusMessage to set
+     */
+    public void setStatusMessage(String statusMessage) {
+        this.statusMessage = statusMessage;
     }
 
     /**

--- a/pass-deposit-services/assembler-api/src/main/java/org/eclipse/pass/deposit/assembler/MetadataBuilder.java
+++ b/pass-deposit-services/assembler-api/src/main/java/org/eclipse/pass/deposit/assembler/MetadataBuilder.java
@@ -46,6 +46,15 @@ public interface MetadataBuilder {
     MetadataBuilder spec(String spec);
 
     /**
+     * Sets the {@link PackageStream.Metadata#packageDepositStatusRef()} of the {@code PackageStream}.
+     *
+     * @param packageDepositStatusRef the package specification
+     * @return this builder
+     * @see PackageStream.Metadata#packageDepositStatusRef()
+     */
+    MetadataBuilder packageDepositStatusRef(String packageDepositStatusRef);
+
+    /**
      * Sets the {@link PackageStream.Metadata#mimeType()} of the {@code PackageStream}, as returned by
      * {@link PackageStream#open()}
      *

--- a/pass-deposit-services/assembler-api/src/main/java/org/eclipse/pass/deposit/assembler/PackageOptions.java
+++ b/pass-deposit-services/assembler-api/src/main/java/org/eclipse/pass/deposit/assembler/PackageOptions.java
@@ -98,11 +98,4 @@ public interface PackageOptions {
 
     }
 
-    /**
-     * Funder Mapping for Nihms Packages
-     */
-    interface FunderMapping {
-        String KEY = "FUNDER-MAPPING";
-    }
-
 }

--- a/pass-deposit-services/assembler-api/src/main/java/org/eclipse/pass/deposit/assembler/PackageStream.java
+++ b/pass-deposit-services/assembler-api/src/main/java/org/eclipse/pass/deposit/assembler/PackageStream.java
@@ -90,6 +90,8 @@ public interface PackageStream {
          */
         String spec();
 
+        String packageDepositStatusRef();
+
         /**
          * The mime type of the package serialization returned by {@link #open()}.
          *

--- a/pass-deposit-services/deposit-core/pom.xml
+++ b/pass-deposit-services/deposit-core/pom.xml
@@ -44,11 +44,6 @@
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-quartz</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-json</artifactId>
     </dependency>
 

--- a/pass-deposit-services/deposit-core/pom.xml
+++ b/pass-deposit-services/deposit-core/pom.xml
@@ -65,6 +65,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jsoup</groupId>
+      <artifactId>jsoup</artifactId>
+      <version>1.16.2</version>
+    </dependency>
+
+    <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>amazon-sqs-java-messaging-lib</artifactId>
       <version>${amazon.sqs.version}</version>

--- a/pass-deposit-services/deposit-core/pom.xml
+++ b/pass-deposit-services/deposit-core/pom.xml
@@ -58,6 +58,18 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-mail</artifactId>
+      <version>${spring-boot-maven-plugin.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.integration</groupId>
+      <artifactId>spring-integration-mail</artifactId>
+      <version>6.2.0</version>
+    </dependency>
+
+    <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>amazon-sqs-java-messaging-lib</artifactId>
       <version>${amazon.sqs.version}</version>
@@ -273,6 +285,13 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-model</artifactId>
       <version>3.9.3</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.icegreen</groupId>
+      <artifactId>greenmail-junit5</artifactId>
+      <version>2.0.0</version>
       <scope>test</scope>
     </dependency>
 

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/assembler/MetadataBuilderImpl.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/assembler/MetadataBuilderImpl.java
@@ -43,6 +43,13 @@ public class MetadataBuilderImpl implements MetadataBuilder {
     }
 
     @Override
+    public MetadataBuilder packageDepositStatusRef(String packageDepositStatusRef) {
+        checkState();
+        metadata.setPackageDepositStatusRef(packageDepositStatusRef);
+        return this;
+    }
+
+    @Override
     public MetadataBuilder mimeType(String mimeType) {
         checkState();
         metadata.setMimeType(mimeType);

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/assembler/SimpleMetadataImpl.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/assembler/SimpleMetadataImpl.java
@@ -54,6 +54,8 @@ public class SimpleMetadataImpl implements PackageStream.Metadata {
 
     private JsonObject submissionMeta = null;
 
+    private String packageDepositStatusRef;
+
     public SimpleMetadataImpl() {
 
     }
@@ -75,6 +77,11 @@ public class SimpleMetadataImpl implements PackageStream.Metadata {
     @Override
     public String spec() {
         return spec;
+    }
+
+    @Override
+    public String packageDepositStatusRef() {
+        return packageDepositStatusRef;
     }
 
     @Override
@@ -148,6 +155,10 @@ public class SimpleMetadataImpl implements PackageStream.Metadata {
 
     void setSpec(String spec) {
         this.spec = spec;
+    }
+
+    void setPackageDepositStatusRef(String packageDepositStatusRef) {
+        this.packageDepositStatusRef = packageDepositStatusRef;
     }
 
     String getMimeType() {

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/config/spring/NihmsMailReceiverConfiguration.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/config/spring/NihmsMailReceiverConfiguration.java
@@ -17,6 +17,7 @@ package org.eclipse.pass.deposit.config.spring;
 
 import java.util.Properties;
 
+import jakarta.mail.URLName;
 import jakarta.mail.internet.MimeMessage;
 import org.eclipse.pass.deposit.service.NihmsReceiveMailService;
 import org.springframework.beans.factory.annotation.Value;
@@ -51,7 +52,7 @@ public class NihmsMailReceiverConfiguration {
     private String nihmsImapHost;
 
     @Value("${nihms.mail.port}")
-    private String nihmsImapPort;
+    private Integer nihmsImapPort;
 
     private final NihmsReceiveMailService nihmsReceiveMailService;
 
@@ -82,8 +83,8 @@ public class NihmsMailReceiverConfiguration {
 
     @Bean
     public MailReceiver imapMailReceiver() {
-        String storeUrl = String.format("imaps://%s:%s@%s:%s/inbox",
-            nihmsMailUsername, nihmsMailPassword, nihmsImapHost, nihmsImapPort);
+        String storeUrl = new URLName("imaps", nihmsImapHost, nihmsImapPort, "inbox",
+            nihmsMailUsername, nihmsMailPassword).toString();
         ImapMailReceiver imapMailReceiver = new ImapMailReceiver(storeUrl);
         imapMailReceiver.setShouldMarkMessagesAsRead(true);
         imapMailReceiver.setShouldDeleteMessages(false);

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/config/spring/NihmsMailReceiverConfiguration.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/config/spring/NihmsMailReceiverConfiguration.java
@@ -1,0 +1,87 @@
+package org.eclipse.pass.deposit.config.spring;
+
+import java.util.Properties;
+
+import jakarta.mail.internet.MimeMessage;
+import org.eclipse.pass.deposit.service.NihmsReceiveMailService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.annotation.InboundChannelAdapter;
+import org.springframework.integration.annotation.Poller;
+import org.springframework.integration.annotation.ServiceActivator;
+import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.config.EnableIntegration;
+import org.springframework.integration.mail.ImapMailReceiver;
+import org.springframework.integration.mail.MailReceiver;
+import org.springframework.integration.mail.MailReceivingMessageSource;
+import org.springframework.messaging.Message;
+
+/**
+ * @author Russ Poetker (rpoetke1@jh.edu)
+ */
+@Configuration
+@EnableIntegration
+@ConditionalOnProperty(name = "pass.deposit.nihms.email.enabled", havingValue = "true")
+public class NihmsMailReceiverConfiguration {
+
+    @Value("${nihms.mail.username}")
+    private String nihmsMailUsername;
+
+    @Value("${nihms.mail.password}")
+    private String nihmsMailPassword;
+
+    @Value("${nihms.mail.host}")
+    private String nihmsImapHost;
+
+    @Value("${nihms.mail.port}")
+    private String nihmsImapPort;
+
+    private final NihmsReceiveMailService nihmsReceiveMailService;
+
+    public NihmsMailReceiverConfiguration(NihmsReceiveMailService nihmsReceiveMailService) {
+        this.nihmsReceiveMailService = nihmsReceiveMailService;
+    }
+
+    @ServiceActivator(inputChannel = "receiveEmailChannel")
+    public void receive(Message<?> message) {
+        nihmsReceiveMailService.handleReceivedMail((MimeMessage) message.getPayload());
+    }
+
+    @Bean("receiveEmailChannel")
+    public DirectChannel defaultChannel() {
+        DirectChannel directChannel = new DirectChannel();
+        directChannel.setDatatypes(jakarta.mail.internet.MimeMessage.class);
+        return directChannel;
+    }
+
+    @Bean()
+    @InboundChannelAdapter(
+        channel = "receiveEmailChannel",
+        poller = @Poller(fixedDelay = "${pass.deposit.nihms.email.delay}")
+    )
+    public MailReceivingMessageSource mailMessageSource(MailReceiver mailReceiver) {
+        return new MailReceivingMessageSource(mailReceiver);
+    }
+
+    @Bean
+    public MailReceiver imapMailReceiver() {
+        // TODO may be imaps, need to confirm with Jeff
+        String storeUrl = String.format("imap://%s:%s@%s:%s/inbox",
+            nihmsMailUsername, nihmsMailPassword, nihmsImapHost, nihmsImapPort);
+        ImapMailReceiver imapMailReceiver = new ImapMailReceiver(storeUrl);
+        imapMailReceiver.setShouldMarkMessagesAsRead(true);
+        imapMailReceiver.setShouldDeleteMessages(false);
+        imapMailReceiver.setMaxFetchSize(10);
+        Properties javaMailProperties = new Properties();
+        // TODO may be imaps, need to confirm with Jeff
+//        javaMailProperties.put("mail.imap.socketFactory.class", "javax.net.ssl.SSLSocketFactory");
+//        javaMailProperties.put("mail.imap.socketFactory.fallback", false);
+        javaMailProperties.put("mail.store.protocol", "imap");
+        javaMailProperties.put("mail.debug", true);
+        imapMailReceiver.setJavaMailProperties(javaMailProperties);
+        return imapMailReceiver;
+    }
+
+}

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/config/spring/NihmsMailReceiverConfiguration.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/config/spring/NihmsMailReceiverConfiguration.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.eclipse.pass.deposit.config.spring;
 
 import java.util.Properties;

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/config/spring/NihmsMailReceiverConfiguration.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/config/spring/NihmsMailReceiverConfiguration.java
@@ -88,13 +88,13 @@ public class NihmsMailReceiverConfiguration {
         ImapMailReceiver imapMailReceiver = new ImapMailReceiver(storeUrl);
         imapMailReceiver.setShouldMarkMessagesAsRead(true);
         imapMailReceiver.setShouldDeleteMessages(false);
+        imapMailReceiver.setSimpleContent(true);
         imapMailReceiver.setMaxFetchSize(10);
         Properties javaMailProperties = new Properties();
-        javaMailProperties.put("mail.imaps.socketFactory.class", "javax.net.ssl.SSLSocketFactory");
-        javaMailProperties.put("mail.imaps.socketFactory.fallback", false);
-        javaMailProperties.put("mail.imaps.ssl.trust", nihmsImapHost);
-        javaMailProperties.put("mail.store.protocol", "imaps");
-        javaMailProperties.put("mail.debug", true);
+        javaMailProperties.setProperty("mail.imaps.ssl.enable", "true");
+        javaMailProperties.setProperty("mail.imaps.ssl.trust", nihmsImapHost);
+        javaMailProperties.setProperty("mail.imaps.starttls.enable", "true");
+        javaMailProperties.setProperty("mail.imaps.auth.plain.disable", "true");
         imapMailReceiver.setJavaMailProperties(javaMailProperties);
         return imapMailReceiver;
     }

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/config/spring/NihmsMailReceiverConfiguration.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/config/spring/NihmsMailReceiverConfiguration.java
@@ -82,18 +82,17 @@ public class NihmsMailReceiverConfiguration {
 
     @Bean
     public MailReceiver imapMailReceiver() {
-        // TODO may be imaps, need to confirm with Jeff
-        String storeUrl = String.format("imap://%s:%s@%s:%s/inbox",
+        String storeUrl = String.format("imaps://%s:%s@%s:%s/inbox",
             nihmsMailUsername, nihmsMailPassword, nihmsImapHost, nihmsImapPort);
         ImapMailReceiver imapMailReceiver = new ImapMailReceiver(storeUrl);
         imapMailReceiver.setShouldMarkMessagesAsRead(true);
         imapMailReceiver.setShouldDeleteMessages(false);
         imapMailReceiver.setMaxFetchSize(10);
         Properties javaMailProperties = new Properties();
-        // TODO may be imaps, need to confirm with Jeff
-//        javaMailProperties.put("mail.imap.socketFactory.class", "javax.net.ssl.SSLSocketFactory");
-//        javaMailProperties.put("mail.imap.socketFactory.fallback", false);
-        javaMailProperties.put("mail.store.protocol", "imap");
+        javaMailProperties.put("mail.imaps.socketFactory.class", "javax.net.ssl.SSLSocketFactory");
+        javaMailProperties.put("mail.imaps.socketFactory.fallback", false);
+        javaMailProperties.put("mail.imaps.ssl.trust", nihmsImapHost);
+        javaMailProperties.put("mail.store.protocol", "imaps");
         javaMailProperties.put("mail.debug", true);
         imapMailReceiver.setJavaMailProperties(javaMailProperties);
         return imapMailReceiver;

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/config/spring/NihmsMailReceiverConfiguration.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/config/spring/NihmsMailReceiverConfiguration.java
@@ -20,6 +20,8 @@ import java.util.Properties;
 import jakarta.mail.URLName;
 import jakarta.mail.internet.MimeMessage;
 import org.eclipse.pass.deposit.service.NihmsReceiveMailService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -41,6 +43,8 @@ import org.springframework.messaging.Message;
 @EnableIntegration
 @ConditionalOnProperty(name = "pass.deposit.nihms.email.enabled", havingValue = "true")
 public class NihmsMailReceiverConfiguration {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DepositConfig.class);
 
     @Value("${nihms.mail.username}")
     private String nihmsMailUsername;
@@ -83,6 +87,7 @@ public class NihmsMailReceiverConfiguration {
 
     @Bean
     public MailReceiver imapMailReceiver() {
+        LOG.warn("Nihms Email Service is enabled, configuration is being executed");
         String storeUrl = new URLName("imaps", nihmsImapHost, nihmsImapPort, "inbox",
             nihmsMailUsername, nihmsMailPassword).toString();
         ImapMailReceiver imapMailReceiver = new ImapMailReceiver(storeUrl);

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/provider/nihms/NihmsAssembler.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/provider/nihms/NihmsAssembler.java
@@ -45,6 +45,8 @@ public class NihmsAssembler extends AbstractAssembler {
      */
     public static final String SPEC_NIHMS_NATIVE_2022_05 = "nihms-native-2022-05";
 
+    static final String NIHMS_PKG_DEP_REF_PREFIX = "nihms-package:";
+
     /**
      * Mime type of zip files.
      */
@@ -84,6 +86,7 @@ public class NihmsAssembler extends AbstractAssembler {
                                                ZonedDateTime.now()
                                                             .format(DateTimeFormatter.ofPattern("uuuu-MM-dd_HH-MM-ss")),
                                                submission.getId());
+        mb.packageDepositStatusRef(NIHMS_PKG_DEP_REF_PREFIX + packageFileName);
 
         StringBuilder ext = new StringBuilder(packageFileName);
         PackageStream.Metadata md = mb.build();
@@ -113,7 +116,8 @@ public class NihmsAssembler extends AbstractAssembler {
             }
         }
 
-        mb.name(sanitizeFilename(ext.toString()));
+        String filename = sanitizeFilename(ext.toString());
+        mb.name(filename);
     }
 
 }

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/provider/nihms/NihmsAssembler.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/provider/nihms/NihmsAssembler.java
@@ -44,8 +44,7 @@ public class NihmsAssembler extends AbstractAssembler {
      * bulk publishing pdf.
      */
     public static final String SPEC_NIHMS_NATIVE_2022_05 = "nihms-native-2022-05";
-
-    static final String NIHMS_PKG_DEP_REF_PREFIX = "nihms-package:";
+    public static final String NIHMS_PKG_DEP_REF_PREFIX = "nihms-package:";
 
     /**
      * Mime type of zip files.

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/provider/nihms/NihmsMetadataSerializer.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/provider/nihms/NihmsMetadataSerializer.java
@@ -33,7 +33,6 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
 import org.apache.commons.lang3.StringUtils;
-import org.eclipse.pass.deposit.assembler.PackageOptions;
 import org.eclipse.pass.deposit.assembler.SizedStream;
 import org.eclipse.pass.deposit.model.DepositMetadata;
 import org.eclipse.pass.deposit.model.JournalPublicationType;
@@ -56,7 +55,7 @@ public class NihmsMetadataSerializer implements StreamingSerializer {
 
     public NihmsMetadataSerializer(DepositMetadata metadata, Map<String, Object> packageOptions) {
         this.metadata = metadata;
-        Object funderMappingObj = packageOptions.get(PackageOptions.FunderMapping.KEY);
+        Object funderMappingObj = packageOptions.get(NihmsPackageProvider.FUNDER_MAPPING);
         if (funderMappingObj instanceof Map<?, ?>) {
             this.funderMapping = ((Map<?, ?>) funderMappingObj).entrySet().stream()
                     .collect(Collectors.toMap(

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/provider/nihms/NihmsPackageProvider.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/provider/nihms/NihmsPackageProvider.java
@@ -42,6 +42,11 @@ import org.springframework.core.io.Resource;
  */
 public class NihmsPackageProvider implements PackageProvider {
 
+    /**
+     * Package options key that contains the funder mapping to nihms funder code
+     */
+    static final String FUNDER_MAPPING = "funder-mapping";
+
     static final String REMEDIATED_FILE_PREFIX = "SUBMISSION-";
 
     private static final Logger LOG = LoggerFactory.getLogger(NihmsPackageProvider.class);

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/DepositTask.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/DepositTask.java
@@ -418,9 +418,9 @@ public class DepositTask {
          */
         static Function<Deposit, TransportResponse> performDeposit(DepositWorkerContext dc) {
             return (deposit) -> {
-                Packager packager = null;
-                PackageStream packageStream = null;
-                Map<String, String> packagerConfig = null;
+                Packager packager;
+                PackageStream packageStream;
+                Map<String, String> packagerConfig;
 
                 try {
                     packager = dc.packager();
@@ -436,6 +436,7 @@ public class DepositTask {
                 try (TransportSession transport = packager.getTransport().open(packagerConfig)) {
                     TransportResponse tr = transport.send(packageStream, packagerConfig);
                     deposit.setDepositStatus(DepositStatus.SUBMITTED);
+                    deposit.setDepositStatusRef(packageStream.metadata().packageDepositStatusRef());
                     return tr;
                 } catch (Exception e) {
                     throw new RuntimeException("Error closing transport session for deposit " +

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/MailUtil.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/MailUtil.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.deposit.service;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.Multipart;
+import jakarta.mail.Part;
+
+/**
+ * @author Russ Poetker (rpoetke1@jh.edu)
+ */
+public class MailUtil {
+
+    private MailUtil() {}
+
+    static String getHtmlText(Part part) throws MessagingException, IOException {
+        if (part.isMimeType("text/html")) {
+            return part.getContent().toString();
+        }
+
+        if (part.isMimeType("multipart/alternative")) {
+            Multipart multipart = (Multipart) part.getContent();
+            int count = multipart.getCount();
+            for (int i = 0; i < count; i++) {
+                Part bodyPart = multipart.getBodyPart(i);
+                if (bodyPart.isMimeType("text/html")) {
+                    return bodyPart.getContent().toString();
+                } else if (bodyPart.isMimeType("multipart/*")) {
+                    return getHtmlText(bodyPart);
+                }
+            }
+        } else if (part.isMimeType("multipart/*")) {
+            Multipart multipart = (Multipart) part.getContent();
+            int count = multipart.getCount();
+            for (int i = 0; i < count; i++) {
+                Part bodyPart = multipart.getBodyPart(i);
+                String content = getHtmlText(bodyPart);
+                if (Objects.nonNull(content)) {
+                    return content;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/NihmsReceiveMailService.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/NihmsReceiveMailService.java
@@ -47,15 +47,16 @@ public class NihmsReceiveMailService {
     private static final Logger LOG = LoggerFactory.getLogger(NihmsReceiveMailService.class);
 
     private final PassClient passClient;
-    private final String nihmsRepositoryKey;
+
+    @Value("${pass.deposit.pmc.repo.key}")
+    private String nihmsRepositoryKey;
+
     private final Address nihmsFromEmail;
 
     public NihmsReceiveMailService(PassClient passClient,
-                                   @Value("${pass.deposit.pmc.repo.key}") String nihmsRepositoryKey,
                                    @Value("${pass.deposit.nihms.email.from}") String nihmsFromEmail)
         throws AddressException {
         this.passClient = passClient;
-        this.nihmsRepositoryKey = nihmsRepositoryKey;
         this.nihmsFromEmail = new InternetAddress(nihmsFromEmail);
     }
 

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/NihmsReceiveMailService.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/NihmsReceiveMailService.java
@@ -46,6 +46,8 @@ import org.springframework.stereotype.Service;
 public class NihmsReceiveMailService {
     private static final Logger LOG = LoggerFactory.getLogger(NihmsReceiveMailService.class);
 
+    static final String NIHMS_DEP_STATUS_REF_PREFIX = "nihms-id:";
+
     private final PassClient passClient;
 
     @Value("${pass.deposit.pmc.repo.key}")
@@ -131,7 +133,7 @@ public class NihmsReceiveMailService {
     private void updateDepositAccepted(String submissionId, String nihmsId) throws IOException {
         getDeposits(submissionId).forEach(deposit -> {
             deposit.setDepositStatus(DepositStatus.ACCEPTED);
-            deposit.setDepositStatusRef(nihmsId);
+            deposit.setDepositStatusRef(NIHMS_DEP_STATUS_REF_PREFIX + nihmsId);
             updateDeposit(deposit);
         });
     }

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/NihmsReceiveMailService.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/NihmsReceiveMailService.java
@@ -15,7 +15,13 @@
  */
 package org.eclipse.pass.deposit.service;
 
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import jakarta.mail.internet.MimeMessage;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -27,14 +33,43 @@ import org.springframework.stereotype.Service;
 public class NihmsReceiveMailService {
     private static final Logger LOG = LoggerFactory.getLogger(NihmsReceiveMailService.class);
 
+    private final List<Pattern> depositFailurePatterns = List.of(
+        Pattern.compile("package id=(.*) failed because.*", Pattern.CASE_INSENSITIVE),
+        Pattern.compile("package id=(.*) was not submitted.*", Pattern.CASE_INSENSITIVE),
+        Pattern.compile("package id=(.*) is corrupt.*", Pattern.CASE_INSENSITIVE),
+        Pattern.compile("package id=(.*) was already used for Manuscript.*submission not created.*",
+            Pattern.CASE_INSENSITIVE),
+        Pattern.compile("package id=(.*) for Manuscript.*submitted with the following problem.*",
+            Pattern.CASE_INSENSITIVE),
+        Pattern.compile("package id=(.*) contains unrecognized.*", Pattern.CASE_INSENSITIVE)
+    );
+
+    private final Pattern depositSuccessPattern = Pattern.compile("package id=(.*) submitted successfully.*",
+        Pattern.CASE_INSENSITIVE);
+
     public void handleReceivedMail(MimeMessage receivedMessage) {
         try {
-            String subject = receivedMessage.getSubject();
+            // TODO only update if email subject is for `Bulk Submission`
+//            String subject = receivedMessage.getSubject();
             String content = receivedMessage.getContent().toString();
-            LOG.info(subject + "::" + content);
-            // TODO
-            // send content to be parsed for state transitions
-            // send deposit update message based on state transition
+            Document document = Jsoup.parse(content);
+            document.select(".message").forEach(element -> {
+                String elementText = element.text();
+                LOG.info("element message: " + elementText);
+                depositFailurePatterns.forEach(pattern -> {
+                    Matcher matcher = pattern.matcher(elementText);
+                    matcher.results().forEach(matchResult -> {
+                        LOG.info("Fail match result group 0: " + matchResult.group(0));
+                        LOG.info("Fail match result group 1: " + matchResult.group(1));
+                    });
+                });
+                Matcher successMatcher = depositSuccessPattern.matcher(elementText);
+                successMatcher.results().forEach(matchResult -> {
+                    LOG.info("Success match result group 0: " + matchResult.group(0));
+                    LOG.info("Success match result group 1: " + matchResult.group(1));
+                });
+            });
+
         } catch (Exception e) {
             LOG.error(e.getMessage(), e);
         }

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/NihmsReceiveMailService.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/NihmsReceiveMailService.java
@@ -1,0 +1,28 @@
+package org.eclipse.pass.deposit.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import jakarta.mail.internet.MimeMessage;
+
+/**
+ * @author Russ Poetker (rpoetke1@jh.edu)
+ */
+@Service
+public class NihmsReceiveMailService {
+    private static final Logger LOG = LoggerFactory.getLogger(NihmsReceiveMailService.class);
+
+    public void handleReceivedMail(MimeMessage receivedMessage) {
+        try {
+            String subject = receivedMessage.getSubject();
+            String content = receivedMessage.getContent().toString();
+            LOG.info(subject + "::" + content);
+            // TODO
+            // send content to be parsed for state transitions
+            // send deposit update message based on state transition
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
+        }
+    }
+}

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/NihmsReceiveMailService.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/NihmsReceiveMailService.java
@@ -1,10 +1,24 @@
+/*
+ * Copyright 2023 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.eclipse.pass.deposit.service;
 
+import jakarta.mail.internet.MimeMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-
-import jakarta.mail.internet.MimeMessage;
 
 /**
  * @author Russ Poetker (rpoetke1@jh.edu)

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/NihmsReceiveMailService.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/NihmsReceiveMailService.java
@@ -147,6 +147,7 @@ public class NihmsReceiveMailService {
         getDeposits(submissionId, packageId).forEach(deposit -> {
             deposit.setDepositStatus(DepositStatus.ACCEPTED);
             deposit.setDepositStatusRef(NIHMS_DEP_STATUS_REF_PREFIX + nihmsId);
+            deposit.setStatusMessage(null);
             updateDeposit(deposit);
         });
     }

--- a/pass-deposit-services/deposit-core/src/main/resources/application.properties
+++ b/pass-deposit-services/deposit-core/src/main/resources/application.properties
@@ -55,4 +55,3 @@ jscholarship.hack.sword.statement.uri-replacement=https://jscholarship.library.j
 pass.deposit.nihms.email.enabled=false
 pass.deposit.nihms.email.delay=30000
 pass.deposit.nihms.email.from=${PASS_DEPOSIT_NIHMS_EMAIL_FROM:nihms-help@ncbi.nlm.nih.gov}
-pass.deposit.pmc.repo.key=${PASS_DEPOSIT_PMC_REPO_KEY:pmc}

--- a/pass-deposit-services/deposit-core/src/main/resources/application.properties
+++ b/pass-deposit-services/deposit-core/src/main/resources/application.properties
@@ -54,3 +54,4 @@ jscholarship.hack.sword.statement.uri-replacement=https://jscholarship.library.j
 
 pass.deposit.nihms.email.enabled=false
 pass.deposit.nihms.email.delay=30000
+pass.deposit.pmc.repo.key=${PASS_DEPOSIT_PMC_REPO_KEY:pmc}

--- a/pass-deposit-services/deposit-core/src/main/resources/application.properties
+++ b/pass-deposit-services/deposit-core/src/main/resources/application.properties
@@ -53,5 +53,5 @@ jscholarship.hack.sword.statement.uri-prefix=http://dspace-prod.mse.jhu.edu:8080
 jscholarship.hack.sword.statement.uri-replacement=https://jscholarship.library.jhu.edu/swordv2/
 
 pass.deposit.nihms.email.enabled=false
-pass.deposit.nihms.email.delay=30000
+pass.deposit.nihms.email.delay=600000
 pass.deposit.nihms.email.from=${PASS_DEPOSIT_NIHMS_EMAIL_FROM:nihms-help@ncbi.nlm.nih.gov}

--- a/pass-deposit-services/deposit-core/src/main/resources/application.properties
+++ b/pass-deposit-services/deposit-core/src/main/resources/application.properties
@@ -52,6 +52,11 @@ pass.deposit.jobs.2.init.delay=10000
 jscholarship.hack.sword.statement.uri-prefix=http://dspace-prod.mse.jhu.edu:8080/swordv2/
 jscholarship.hack.sword.statement.uri-replacement=https://jscholarship.library.jhu.edu/swordv2/
 
+nihms.mail.host=${NIHMS_MAIL_HOST}
+nihms.mail.port=${NIHMS_MAIL_PORT}
+nihms.mail.username=${NIHMS_MAIL_USERNAME}
+nihms.mail.password=${NIHMS_MAIL_PASSWORD}
+
 pass.deposit.nihms.email.enabled=false
 pass.deposit.nihms.email.delay=600000
 pass.deposit.nihms.email.from=${PASS_DEPOSIT_NIHMS_EMAIL_FROM:nihms-help@ncbi.nlm.nih.gov}

--- a/pass-deposit-services/deposit-core/src/main/resources/application.properties
+++ b/pass-deposit-services/deposit-core/src/main/resources/application.properties
@@ -51,3 +51,6 @@ pass.deposit.jobs.2.init.delay=10000
 
 jscholarship.hack.sword.statement.uri-prefix=http://dspace-prod.mse.jhu.edu:8080/swordv2/
 jscholarship.hack.sword.statement.uri-replacement=https://jscholarship.library.jhu.edu/swordv2/
+
+pass.deposit.nihms.email.enabled=false
+pass.deposit.nihms.email.delay=30000

--- a/pass-deposit-services/deposit-core/src/main/resources/application.properties
+++ b/pass-deposit-services/deposit-core/src/main/resources/application.properties
@@ -54,4 +54,5 @@ jscholarship.hack.sword.statement.uri-replacement=https://jscholarship.library.j
 
 pass.deposit.nihms.email.enabled=false
 pass.deposit.nihms.email.delay=30000
+pass.deposit.nihms.email.from=${PASS_DEPOSIT_NIHMS_EMAIL_FROM:nihms-help@ncbi.nlm.nih.gov}
 pass.deposit.pmc.repo.key=${PASS_DEPOSIT_PMC_REPO_KEY:pmc}

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/assembler/PreassembledAssembler.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/assembler/PreassembledAssembler.java
@@ -210,6 +210,11 @@ public class PreassembledAssembler implements Assembler {
                     }
 
                     @Override
+                    public String packageDepositStatusRef() {
+                        return null;
+                    }
+
+                    @Override
                     public String mimeType() {
                         switch (compression()) {
                             case ZIP:

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/provider/j10p/AbstractDspaceMetsAssemblerIT.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/provider/j10p/AbstractDspaceMetsAssemblerIT.java
@@ -23,6 +23,7 @@ import static org.eclipse.pass.deposit.provider.j10p.XMLConstants.XLINK_HREF;
 import static org.eclipse.pass.deposit.provider.j10p.XMLConstants.XLINK_NS;
 import static org.eclipse.pass.deposit.util.DepositTestUtil.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
@@ -89,6 +90,7 @@ public abstract class AbstractDspaceMetsAssemblerIT extends AbstractAssemblerIT 
         assertTrue(metadata.archived());
         assertEquals(SPEC_DSPACE_METS, metadata.spec());
         assertEquals(APPLICATION_ZIP.toString(), metadata.mimeType());
+        assertNull(metadata.packageDepositStatusRef());
     }
 
     protected static void verifyPackageStructure(Document metsDoc, File extractedPackageDir, List<DepositFile>

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/provider/nihms/NihmsAssemblerIT.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/provider/nihms/NihmsAssemblerIT.java
@@ -51,7 +51,6 @@ import org.eclipse.pass.deposit.assembler.AbstractAssembler;
 import org.eclipse.pass.deposit.assembler.AbstractAssemblerIT;
 import org.eclipse.pass.deposit.assembler.PackageOptions.Archive;
 import org.eclipse.pass.deposit.assembler.PackageOptions.Compression;
-import org.eclipse.pass.deposit.assembler.PackageOptions.FunderMapping;
 import org.eclipse.pass.deposit.assembler.PackageOptions.Spec;
 import org.eclipse.pass.deposit.assembler.PackageStream;
 import org.eclipse.pass.deposit.model.DepositFile;
@@ -93,7 +92,7 @@ public class NihmsAssemblerIT extends AbstractAssemblerIT {
                 put(Spec.KEY, SPEC_NIHMS_NATIVE_2022_05);
                 put(Archive.KEY, Archive.OPTS.TAR);
                 put(Compression.KEY, Compression.OPTS.GZIP);
-                put(FunderMapping.KEY, funderMapping);
+                put(NihmsPackageProvider.FUNDER_MAPPING, funderMapping);
             }
         };
     }

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/provider/nihms/NihmsAssemblerIT.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/provider/nihms/NihmsAssemblerIT.java
@@ -116,6 +116,9 @@ public class NihmsAssemblerIT extends AbstractAssemblerIT {
         assertTrue(metadata.archived());
         assertEquals(SPEC_NIHMS_NATIVE_2022_05, metadata.spec());
         assertEquals(APPLICATION_GZIP, metadata.mimeType());
+        String expectedPkgDepStatusRef = (NihmsAssembler.NIHMS_PKG_DEP_REF_PREFIX + metadata.name())
+            .replace(".tar.gz", "");
+        assertEquals(expectedPkgDepStatusRef, metadata.packageDepositStatusRef());
     }
 
     /**

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/provider/nihms/NihmsMetadataSerializerTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/provider/nihms/NihmsMetadataSerializerTest.java
@@ -46,7 +46,6 @@ import javax.xml.transform.stream.StreamSource;
 
 import com.github.jknack.handlebars.internal.Files;
 import org.apache.commons.io.IOUtils;
-import org.eclipse.pass.deposit.assembler.PackageOptions;
 import org.eclipse.pass.deposit.assembler.SizedStream;
 import org.eclipse.pass.deposit.model.DepositMetadata;
 import org.eclipse.pass.deposit.model.JournalPublicationType;
@@ -177,7 +176,7 @@ public class NihmsMetadataSerializerTest {
                 Map.of("johnshopkins.edu:funder:300293", "cdc",
                         "johnshopkins.edu:funder:300484", "nih");
         packageOptions = new HashMap<>();
-        packageOptions.put(PackageOptions.FunderMapping.KEY, funderMapping);
+        packageOptions.put(NihmsPackageProvider.FUNDER_MAPPING, funderMapping);
 
         underTest = new NihmsMetadataSerializer(metadata, packageOptions);
     }

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/provider/nihms/NihmsThreadedAssemblyIT.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/provider/nihms/NihmsThreadedAssemblyIT.java
@@ -48,7 +48,7 @@ public class NihmsThreadedAssemblyIT extends AbstractThreadedAssemblyIT {
                 put(PackageOptions.Archive.KEY, PackageOptions.Archive.OPTS.TAR);
                 put(PackageOptions.Compression.KEY, PackageOptions.Compression.OPTS.GZIP);
                 put(PackageOptions.Checksum.KEY, singletonList(PackageOptions.Checksum.OPTS.SHA256));
-                put(PackageOptions.FunderMapping.KEY, funderMapping);
+                put(NihmsPackageProvider.FUNDER_MAPPING, funderMapping);
             }
         };
     }

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/DepositTaskTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/DepositTaskTest.java
@@ -182,6 +182,7 @@ public class DepositTaskTest {
 
         Assembler assembler = mock(Assembler.class);
         PackageStream stream = mock(PackageStream.class);
+        PackageStream.Metadata metadata = mock(PackageStream.Metadata.class);
         Packager packager = mock(Packager.class);
         Transport transport = mock(Transport.class);
         TransportSession session = mock(TransportSession.class);
@@ -190,6 +191,7 @@ public class DepositTaskTest {
         when(packager.getAssembler()).thenReturn(assembler);
         when(packager.getConfiguration()).thenReturn(packagerConfig);
         when(assembler.assemble(any(), anyMap())).thenReturn(stream);
+        when(stream.metadata()).thenReturn(metadata);
         when(packager.getTransport()).thenReturn(transport);
         when(transport.open(anyMap())).thenReturn(session);
         when(session.send(eq(stream), any())).thenReturn(tr);

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceIT.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceIT.java
@@ -89,17 +89,18 @@ public class NihmsReceiveMailServiceIT extends AbstractDepositSubmissionIT {
 
         // THEN
         // wait for email poller to run, every 2 seconds plus few seconds for processing
-        await().pollDelay(5, SECONDS).until(() -> true);
-        verify(nihmsReceiveMailService, times(1))
-            .handleReceivedMail(any());
-        PassClientSelector<Deposit> sel = new PassClientSelector<>(Deposit.class);
-        sel.setFilter(RSQL.equals("submission.id",  testSubmission.getId()));
-        List<Deposit> actualDeposits = passClient.selectObjects(sel).getObjects();
-        assertEquals(1, actualDeposits.size());
-        Deposit pmcDeposit = actualDeposits.get(0);
-        assertEquals(DepositStatus.ACCEPTED, pmcDeposit.getDepositStatus());
-        assertEquals(NIHMS_DEP_STATUS_REF_PREFIX + "test-nihms-id", pmcDeposit.getDepositStatusRef());
-        assertNull(pmcDeposit.getStatusMessage());
+        await().atMost(4, SECONDS).untilAsserted(() -> {
+            verify(nihmsReceiveMailService, times(1))
+                .handleReceivedMail(any());
+            PassClientSelector<Deposit> sel = new PassClientSelector<>(Deposit.class);
+            sel.setFilter(RSQL.equals("submission.id", testSubmission.getId()));
+            List<Deposit> actualDeposits = passClient.selectObjects(sel).getObjects();
+            assertEquals(1, actualDeposits.size());
+            Deposit pmcDeposit = actualDeposits.get(0);
+            assertEquals(DepositStatus.ACCEPTED, pmcDeposit.getDepositStatus());
+            assertEquals(NIHMS_DEP_STATUS_REF_PREFIX + "test-nihms-id", pmcDeposit.getDepositStatusRef());
+            assertNull(pmcDeposit.getStatusMessage());
+        });
     }
 
     private Submission initSubmissionDeposit() throws Exception {

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceIT.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceIT.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2023 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.deposit.service;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+import static org.eclipse.pass.deposit.service.NihmsReceiveMailService.NIHMS_DEP_STATUS_REF_PREFIX;
+import static org.eclipse.pass.deposit.util.ResourceTestUtil.findByNameAsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import com.icegreen.greenmail.configuration.GreenMailConfiguration;
+import com.icegreen.greenmail.junit5.GreenMailExtension;
+import com.icegreen.greenmail.user.GreenMailUser;
+import com.icegreen.greenmail.util.GreenMailUtil;
+import com.icegreen.greenmail.util.ServerSetupTest;
+import jakarta.mail.internet.MimeMessage;
+import org.eclipse.pass.deposit.AbstractDepositSubmissionIT;
+import org.eclipse.pass.deposit.DepositApp;
+import org.eclipse.pass.deposit.provider.nihms.NihmsAssembler;
+import org.eclipse.pass.deposit.util.ResourceTestUtil;
+import org.eclipse.pass.support.client.PassClientSelector;
+import org.eclipse.pass.support.client.RSQL;
+import org.eclipse.pass.support.client.model.Deposit;
+import org.eclipse.pass.support.client.model.DepositStatus;
+import org.eclipse.pass.support.client.model.Submission;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * @author Russ Poetker (rpoetke1@jh.edu)
+ */
+@SpringBootTest(classes = DepositApp.class)
+@TestPropertySource("classpath:test-application.properties")
+@TestPropertySource(properties = {
+    "pass.deposit.nihms.email.enabled=true",
+    "pass.deposit.nihms.email.delay=2000",
+    "pass.deposit.nihms.email.from=test-from@localhost",
+    "nihms.mail.host=localhost",
+    "nihms.mail.port=3993",
+    "nihms.mail.username=testnihms@localhost",
+    "nihms.mail.password=testnihmspassword"
+
+})
+public class NihmsReceiveMailServiceIT extends AbstractDepositSubmissionIT {
+
+    @RegisterExtension
+    static GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.IMAPS)
+        .withConfiguration(new GreenMailConfiguration().withUser("testnihms@localhost", "testnihmspassword"))
+        .withPerMethodLifecycle(false);
+
+    @SpyBean private NihmsReceiveMailService nihmsReceiveMailService;
+
+    @Test
+    void testHandleReceivedMail() throws Exception {
+        // GIVEN
+        Submission testSubmission = initSubmissionDeposit();
+        final String subject1 = "Bulk submission";
+        final String body1 = findByNameAsString("nihmsemail-success.html", this.getClass())
+            .replace("{test-submission-id}", testSubmission.getId());
+        MimeMessage message1 = GreenMailUtil.createTextEmail("testnihms@localhost", "test-from@localhost",
+            subject1, body1, greenMail.getImaps().getServerSetup());
+        GreenMailUser user = greenMail.setUser("testnihms@localhost", "testnihmspassword");
+
+        // WHEN
+        user.deliver(message1);
+
+        // THEN
+        // wait for email poller to run, every 2 seconds plus few seconds for processing
+        await().pollDelay(5, SECONDS).until(() -> true);
+        verify(nihmsReceiveMailService, times(1))
+            .handleReceivedMail(any());
+        PassClientSelector<Deposit> sel = new PassClientSelector<>(Deposit.class);
+        sel.setFilter(RSQL.equals("submission.id",  testSubmission.getId()));
+        List<Deposit> actualDeposits = passClient.selectObjects(sel).getObjects();
+        assertEquals(1, actualDeposits.size());
+        Deposit pmcDeposit = actualDeposits.get(0);
+        assertEquals(DepositStatus.ACCEPTED, pmcDeposit.getDepositStatus());
+        assertEquals(NIHMS_DEP_STATUS_REF_PREFIX + "test-nihms-id", pmcDeposit.getDepositStatusRef());
+        assertNull(pmcDeposit.getStatusMessage());
+    }
+
+    private Submission initSubmissionDeposit() throws Exception {
+        Submission submission = findSubmission(createSubmission(
+            ResourceTestUtil.readSubmissionJson("sample2")));
+        submission.setSubmittedDate(ZonedDateTime.now());
+        passClient.updateObject(submission);
+        triggerSubmission(submission);
+        final Submission actualSubmission = passClient.getObject(Submission.class, submission.getId());
+        Deposit pmcDeposit = new Deposit();
+        pmcDeposit.setSubmission(actualSubmission);
+        // There is only the pmc repo on this submission
+        pmcDeposit.setRepository(actualSubmission.getRepositories().get(0));
+        pmcDeposit.setDepositStatus(DepositStatus.SUBMITTED);
+        pmcDeposit.setDepositStatusRef(NihmsAssembler.NIHMS_PKG_DEP_REF_PREFIX +
+            "nihms-native-2017-07_2023-10-23_13-10-30_" + actualSubmission.getId());
+        passClient.createObject(pmcDeposit);
+        return actualSubmission;
+    }
+}

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceTest.java
@@ -22,6 +22,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import java.io.IOException;
+import java.util.List;
+
 import com.icegreen.greenmail.configuration.GreenMailConfiguration;
 import com.icegreen.greenmail.junit5.GreenMailExtension;
 import com.icegreen.greenmail.user.GreenMailUser;
@@ -37,9 +40,6 @@ import org.mockito.Captor;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.TestPropertySource;
-
-import java.io.IOException;
-import java.util.List;
 
 /**
  * @author Russ Poetker (rpoetke1@jh.edu)

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceTest.java
@@ -17,6 +17,7 @@ package org.eclipse.pass.deposit.service;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
+import static org.eclipse.pass.deposit.util.ResourceTestUtil.findByNameAsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
@@ -30,7 +31,9 @@ import com.icegreen.greenmail.junit5.GreenMailExtension;
 import com.icegreen.greenmail.user.GreenMailUser;
 import com.icegreen.greenmail.util.GreenMailUtil;
 import com.icegreen.greenmail.util.ServerSetupTest;
+import jakarta.mail.Message;
 import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
 import jakarta.mail.internet.MimeMessage;
 import org.eclipse.pass.deposit.DepositApp;
 import org.junit.jupiter.api.Test;
@@ -105,6 +108,24 @@ public class NihmsReceiveMailServiceTest {
         MimeMessage mimeMessage2 = mimeMessages.get(1);
         assertEquals(subject2, mimeMessage2.getSubject());
         assertEquals(body2, mimeMessage2.getContent());
+    }
 
+    @Test
+    void testHandleReceivedMail_MessageParsing() throws MessagingException {
+        // GIVEN
+        final String subject = "Bulk submission";
+        final String body = findByNameAsString("nihmsemail.html", this.getClass());
+        Session smtpSession = GreenMailUtil.getSession(greenMail.getImaps().getServerSetup());
+        MimeMessage mimeMessage = new MimeMessage(smtpSession);
+        mimeMessage.setRecipients(Message.RecipientType.TO, "testnihms@localhost");
+        mimeMessage.setFrom("from@localhost");
+        mimeMessage.setSubject(subject);
+        mimeMessage.setContent(body, "text/html; charset=\"utf-8\"");
+
+        // WHEN
+        nihmsReceiveMailService.handleReceivedMail(mimeMessage);
+
+        // THEN
+        // TODO verify deposits are updated
     }
 }

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceTest.java
@@ -47,7 +47,7 @@ import org.springframework.test.context.TestPropertySource;
     "pass.deposit.nihms.email.delay=2000",
     "nihms.mail.host=localhost",
     "nihms.mail.port=3993",
-    "nihms.mail.username=testnihms%40localhost",
+    "nihms.mail.username=testnihms@localhost",
     "nihms.mail.password=testnihmspassword"
 
 })

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceTest.java
@@ -81,7 +81,7 @@ public class NihmsReceiveMailServiceTest {
     @Captor ArgumentCaptor<Deposit> depositCaptor;
 
     @Test
-    void testHandleReceivedMail() throws MessagingException, IOException {
+    void testHandleReceivedMail() {
         // GIVEN
         final String subject1 = GreenMailUtil.random();
         final String body1 = GreenMailUtil.random();

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceTest.java
@@ -1,4 +1,26 @@
+/*
+ * Copyright 2023 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.eclipse.pass.deposit.service;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import com.icegreen.greenmail.configuration.GreenMailConfiguration;
 import com.icegreen.greenmail.junit5.GreenMailExtension;
@@ -9,19 +31,9 @@ import jakarta.mail.internet.MimeMessage;
 import org.eclipse.pass.deposit.DepositApp;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.TestPropertySource;
-
-import java.net.URI;
-
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.awaitility.Awaitility.await;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 /**
  * @author Russ Poetker (rpoetke1@jh.edu)

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceTest.java
@@ -162,6 +162,46 @@ public class NihmsReceiveMailServiceTest {
     }
 
     @Test
+    void testHandleReceivedMail_UnknownMessagePattern() throws MessagingException, IOException {
+        // GIVEN
+        final String subject = "Bulk submission (errors encountered)";
+        final String body = findByNameAsString("nihmsemail-unknown-message.html", this.getClass());
+        Session smtpSession = GreenMailUtil.getSession(greenMail.getImaps().getServerSetup());
+        MimeMessage mimeMessage = new MimeMessage(smtpSession);
+        mimeMessage.setRecipients(Message.RecipientType.TO, "testnihms@localhost");
+        mimeMessage.setFrom("test-from@localhost");
+        mimeMessage.setSubject(subject);
+        mimeMessage.setContent(body, "text/html; charset=\"utf-8\"");
+        mockPassClientStreams();
+
+        // WHEN
+        nihmsReceiveMailService.handleReceivedMail(mimeMessage);
+
+        // THEN
+        verifyNoInteractions(passClient);
+    }
+
+    @Test
+    void testHandleReceivedMail_NoMessage() throws MessagingException, IOException {
+        // GIVEN
+        final String subject = "Bulk submission (errors encountered)";
+        final String body = findByNameAsString("nihmsemail-no-messages.html", this.getClass());
+        Session smtpSession = GreenMailUtil.getSession(greenMail.getImaps().getServerSetup());
+        MimeMessage mimeMessage = new MimeMessage(smtpSession);
+        mimeMessage.setRecipients(Message.RecipientType.TO, "testnihms@localhost");
+        mimeMessage.setFrom("test-from@localhost");
+        mimeMessage.setSubject(subject);
+        mimeMessage.setContent(body, "text/html; charset=\"utf-8\"");
+        mockPassClientStreams();
+
+        // WHEN
+        nihmsReceiveMailService.handleReceivedMail(mimeMessage);
+
+        // THEN
+        verifyNoInteractions(passClient);
+    }
+
+    @Test
     void testHandleReceivedMail_SkipNonNihmsEmail() throws MessagingException, IOException {
         // GIVEN
         final String subject = "Bulk submission";

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceTest.java
@@ -157,7 +157,8 @@ public class NihmsReceiveMailServiceTest {
             .findFirst().get();
         assertEquals(DepositStatus.ACCEPTED, updatedDeposit3.getDepositStatus());
         assertNull(updatedDeposit3.getStatusMessage());
-        assertEquals("1502302", updatedDeposit3.getDepositStatusRef());
+        assertEquals(NihmsReceiveMailService.NIHMS_DEP_STATUS_REF_PREFIX + "1502302",
+            updatedDeposit3.getDepositStatusRef());
     }
 
     @Test

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceTest.java
@@ -62,7 +62,6 @@ import org.springframework.test.context.TestPropertySource;
     "pass.deposit.nihms.email.enabled=true",
     "pass.deposit.nihms.email.delay=2000",
     "pass.deposit.nihms.email.from=test-from@localhost",
-    "pass.deposit.pmc.repo.key=pmc",
     "nihms.mail.host=localhost",
     "nihms.mail.port=3993",
     "nihms.mail.username=testnihms@localhost",

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceTest.java
@@ -1,0 +1,64 @@
+package org.eclipse.pass.deposit.service;
+
+import com.icegreen.greenmail.configuration.GreenMailConfiguration;
+import com.icegreen.greenmail.junit5.GreenMailExtension;
+import com.icegreen.greenmail.user.GreenMailUser;
+import com.icegreen.greenmail.util.GreenMailUtil;
+import com.icegreen.greenmail.util.ServerSetupTest;
+import jakarta.mail.internet.MimeMessage;
+import org.eclipse.pass.deposit.DepositApp;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.context.TestPropertySource;
+
+import java.net.URI;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author Russ Poetker (rpoetke1@jh.edu)
+ */
+@SpringBootTest(classes = DepositApp.class)
+@TestPropertySource("classpath:test-application.properties")
+@TestPropertySource(properties = {
+    "pass.deposit.nihms.email.enabled=true",
+    "pass.deposit.nihms.email.delay=2000",
+    "nihms.mail.host=localhost",
+    "nihms.mail.port=3143",
+    "nihms.mail.username=testnihms%40localhost",
+    "nihms.mail.password=testnihmspassword"
+
+})
+public class NihmsReceiveMailServiceTest {
+
+    @RegisterExtension
+    static GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.IMAP)
+        .withConfiguration(new GreenMailConfiguration().withUser("testnihms@localhost", "testnihmspassword"))
+        .withPerMethodLifecycle(false);
+
+    @SpyBean private NihmsReceiveMailService nihmsReceiveMailService;
+
+    @Test
+    void testReceiveMail() {
+        final String subject = GreenMailUtil.random();
+        final String body = GreenMailUtil.random();
+        MimeMessage message = GreenMailUtil.createTextEmail("testnihms@localhost", "from@localhost",
+            subject, body, greenMail.getImap().getServerSetup());
+        GreenMailUser user = greenMail.setUser("testnihms@localhost", "testnihmspassword");
+        user.deliver(message);
+
+        await().atMost(30, SECONDS).untilAsserted(() -> {
+            assertEquals(1, greenMail.getReceivedMessages().length);
+            verify(nihmsReceiveMailService, times(1)).handleReceivedMail(any());
+        });
+
+    }
+}

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceTest.java
@@ -94,9 +94,10 @@ public class NihmsReceiveMailServiceTest {
 
         // THEN
         // wait for email poller to run, every 2 seconds
-        await().pollDelay(4, SECONDS).until(() -> true);
-        verify(nihmsReceiveMailService, times(1))
-            .handleReceivedMail(any());
+        await().atMost(4, SECONDS).untilAsserted(() ->
+            verify(nihmsReceiveMailService, times(1)).handleReceivedMail(any())
+        );
+
 
         // GIVEN
         final String subject2 = GreenMailUtil.random();
@@ -109,17 +110,18 @@ public class NihmsReceiveMailServiceTest {
 
         // THEN
         // wait for email poller to run, every 2 seconds
-        await().pollDelay(4, SECONDS).until(() -> true);
-        verify(nihmsReceiveMailService, times(2))
-            .handleReceivedMail(messageCaptor.capture());
-        List<MimeMessage> mimeMessages = messageCaptor.getAllValues();
-        assertEquals(2, mimeMessages.size());
-        MimeMessage mimeMessage1 = mimeMessages.get(0);
-        assertEquals(subject1, mimeMessage1.getSubject());
-        assertEquals(body1, mimeMessage1.getContent());
-        MimeMessage mimeMessage2 = mimeMessages.get(1);
-        assertEquals(subject2, mimeMessage2.getSubject());
-        assertEquals(body2, mimeMessage2.getContent());
+        await().atMost(4, SECONDS).untilAsserted(() -> {
+            verify(nihmsReceiveMailService, times(2))
+                .handleReceivedMail(messageCaptor.capture());
+            List<MimeMessage> mimeMessages = messageCaptor.getAllValues();
+            assertEquals(2, mimeMessages.size());
+            MimeMessage mimeMessage1 = mimeMessages.get(0);
+            assertEquals(subject1, mimeMessage1.getSubject());
+            assertEquals(body1, mimeMessage1.getContent());
+            MimeMessage mimeMessage2 = mimeMessages.get(1);
+            assertEquals(subject2, mimeMessage2.getSubject());
+            assertEquals(body2, mimeMessage2.getContent());
+        });
     }
 
     @Test

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceTest.java
@@ -98,7 +98,6 @@ public class NihmsReceiveMailServiceTest {
             verify(nihmsReceiveMailService, times(1)).handleReceivedMail(any())
         );
 
-
         // GIVEN
         final String subject2 = GreenMailUtil.random();
         final String body2 = GreenMailUtil.random();

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceTest.java
@@ -261,10 +261,16 @@ public class NihmsReceiveMailServiceTest {
     private void mockPassClientStreams() throws IOException {
         Deposit deposit1 = new Deposit();
         deposit1.setId("1");
+        deposit1.setDepositStatus(DepositStatus.SUBMITTED);
+        deposit1.setStatusMessage("init-submitted");
         Deposit deposit2 = new Deposit();
         deposit2.setId("2");
+        deposit2.setDepositStatus(DepositStatus.SUBMITTED);
+        deposit2.setStatusMessage("init-submitted");
         Deposit deposit3 = new Deposit();
         deposit3.setId("3");
+        deposit3.setDepositStatus(DepositStatus.SUBMITTED);
+        deposit3.setStatusMessage("init-submitted");
         when(passClient.streamObjects(any())).thenAnswer(input -> {
             PassClientSelector<Deposit> selector = input.getArgument(0);
             if (selector.getFilter().contains("submission.id=='229935'")) {

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/util/ResourceTestUtil.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/util/ResourceTestUtil.java
@@ -15,10 +15,17 @@
  */
 package org.eclipse.pass.deposit.util;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.UncheckedIOException;
 
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.util.FileCopyUtils;
 
 /**
  * Provides access to test resources found on the classpath.
@@ -43,5 +50,14 @@ public class ResourceTestUtil {
      */
     public static InputStream findByName(String resourceName, Class<?> baseClass) throws IOException {
         return new ClassPathResource(resourceName, baseClass).getInputStream();
+    }
+
+    public static String findByNameAsString(String resourceName, Class<?> baseClass) {
+        Resource resource = new ClassPathResource(resourceName, baseClass);
+        try (Reader reader = new InputStreamReader(resource.getInputStream(), UTF_8)) {
+            return FileCopyUtils.copyToString(reader);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 }

--- a/pass-deposit-services/deposit-core/src/test/resources/full-test-repositories.json
+++ b/pass-deposit-services/deposit-core/src/test/resources/full-test-repositories.json
@@ -1,0 +1,101 @@
+{
+  "JScholarship": {
+    "assembler": {
+      "specification": "simple",
+      "beanName": "simpleAssembler",
+      "options": {
+        "archive": "ZIP",
+        "compression": "NONE",
+        "algorithms": [
+          "sha512",
+          "md5"
+        ]
+      }
+    },
+    "transport-config": {
+      "protocol-binding": {
+        "protocol": "filesystem",
+        "baseDir": "target/packages",
+        "createIfMissing": "true",
+        "overwrite": "true"
+      }
+    }
+  },
+  "PubMed Central": {
+    "deposit-config": {
+      "processing": {
+      },
+      "mapping": {
+        "INFO": "accepted",
+        "ERROR": "rejected",
+        "WARN": "rejected",
+        "default-mapping": "submitted"
+      }
+    },
+    "assembler": {
+      "specification": "nihms-native-2017-07",
+      "beanName": "nihmsAssembler",
+      "options": {
+        "archive": "TAR",
+        "compression": "GZIP",
+        "algorithms": [
+          "sha512",
+          "md5"
+        ]
+      }
+    },
+    "transport-config": {
+      "protocol-binding": {
+        "protocol": "filesystem",
+        "baseDir": "target/packages",
+        "createIfMissing": "true",
+        "overwrite": "true"
+      }
+    }
+  },
+  "BagIt": {
+    "assembler": {
+      "specification": "simple",
+      "beanName": "simpleAssembler",
+      "options": {
+        "archive": "ZIP",
+        "compression": "NONE",
+        "algorithms": [
+          "sha512",
+          "md5"
+        ],
+        "baginfo-template-resource": "/bag-info.hbm"
+      }
+    },
+    "transport-config": {
+      "protocol-binding": {
+        "protocol": "filesystem",
+        "baseDir": "target/packages",
+        "createIfMissing": "true",
+        "overwrite": "true"
+      }
+    }
+  },
+  "dash": {
+    "assembler": {
+      "specification": "simple",
+      "beanName": "simpleAssembler",
+      "options": {
+        "archive": "ZIP",
+        "compression": "NONE",
+        "algorithms": [
+          "sha512",
+          "md5"
+        ]
+      }
+    },
+    "transport-config": {
+      "protocol-binding": {
+        "protocol": "filesystem",
+        "baseDir": "target/packages",
+        "createIfMissing": "true",
+        "overwrite": "true"
+      }
+    }
+  }
+}

--- a/pass-deposit-services/deposit-core/src/test/resources/full-test-repositories.json
+++ b/pass-deposit-services/deposit-core/src/test/resources/full-test-repositories.json
@@ -41,7 +41,44 @@
         "algorithms": [
           "sha512",
           "md5"
-        ]
+        ],
+        "funder-mapping": {
+          "johnshopkins.edu:funder:300032": "ahqr",
+          "johnshopkins.edu:funder:300293": "cdc",
+          "johnshopkins.edu:funder:300859": "cdc",
+          "johnshopkins.edu:funder:301459": "va",
+          "johnshopkins.edu:funder:300453": "epa",
+          "johnshopkins.edu:funder:303444": "hhmi",
+          "johnshopkins.edu:funder:300484": "nih",
+          "johnshopkins.edu:funder:300865": "nih",
+          "johnshopkins.edu:funder:300869": "nih",
+          "johnshopkins.edu:funder:300866": "nih",
+          "johnshopkins.edu:funder:308302": "nih",
+          "johnshopkins.edu:funder:305950": "nih",
+          "johnshopkins.edu:funder:302727": "nih",
+          "johnshopkins.edu:funder:300863": "nih",
+          "johnshopkins.edu:funder:300874": "nih",
+          "johnshopkins.edu:funder:300861": "nih",
+          "johnshopkins.edu:funder:300842": "nih",
+          "johnshopkins.edu:funder:303587": "nih",
+          "johnshopkins.edu:funder:303586": "nih",
+          "johnshopkins.edu:funder:306099": "nih",
+          "johnshopkins.edu:funder:300858": "nih",
+          "johnshopkins.edu:funder:301479": "nih",
+          "johnshopkins.edu:funder:300870": "nih",
+          "johnshopkins.edu:funder:303589": "nih",
+          "johnshopkins.edu:funder:300860": "nih",
+          "johnshopkins.edu:funder:300852": "nih",
+          "johnshopkins.edu:funder:302822": "nih",
+          "johnshopkins.edu:funder:302592": "nih",
+          "johnshopkins.edu:funder:303585": "nih",
+          "johnshopkins.edu:funder:303574": "nih",
+          "johnshopkins.edu:funder:300867": "nih",
+          "johnshopkins.edu:funder:303580": "nih",
+          "johnshopkins.edu:funder:301978": "nih",
+          "johnshopkins.edu:funder:305204": "aspr",
+          "johnshopkins.edu:funder:303395": "fda"
+        }
       }
     },
     "transport-config": {

--- a/pass-deposit-services/deposit-core/src/test/resources/org/eclipse/pass/deposit/service/nihmsemail-no-messages.html
+++ b/pass-deposit-services/deposit-core/src/test/resources/org/eclipse/pass/deposit/service/nihmsemail-no-messages.html
@@ -1,0 +1,16 @@
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=9; IE=8; IE=7; IE=EDGE">
+    <title>Bulk submission (errors encountered)</title>
+    </head>
+<body style='font-family:"Helvetica Neue", Helvetica, Arial, sans-serif'>
+  <table class="table" style="background-color:transparent; margin-bottom:20px; max-width:100%; width:100%; border-collapse:collapse" width="100%">
+    <colgroup>
+          <col span="1" style="width:50px">
+          <col span="1">
+    </colgroup>
+    <p>This is a test with no messages in the email</p>
+    </table>
+</body>
+</html>

--- a/pass-deposit-services/deposit-core/src/test/resources/org/eclipse/pass/deposit/service/nihmsemail-noclass.html
+++ b/pass-deposit-services/deposit-core/src/test/resources/org/eclipse/pass/deposit/service/nihmsemail-noclass.html
@@ -1,0 +1,29 @@
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=9; IE=8; IE=7; IE=EDGE">
+    <title>Bulk submission (errors encountered)</title>
+    </head>
+<body style='font-family:"Helvetica Neue", Helvetica, Arial, sans-serif'>
+  <table class="table" style="background-color:transparent; margin-bottom:20px; max-width:100%; width:100%; border-collapse:collapse" width="100%">
+    <colgroup>
+          <col span="1" style="width:50px">
+          <col span="1">
+    </colgroup>
+    <tbody>
+        <tr style="page-break-inside:avoid">
+              <td style="border:0 solid #000; border-radius:0.25em; color:#fff; font-size:75%; font-weight:bold; line-height:1.428571; padding:8px; text-align:center; vertical-align:top; white-space:nowrap; background-color:#d9534f; border-top:1px solid #ddd" align="center" valign="top" bgcolor="#d9534f">ERROR</td>
+              <td style="border-top:1px solid #ddd; line-height:1.428571; padding:8px; vertical-align:top" valign="top">Package ID=nihms-native-2017-07_2023-10-23_13-10-12_229935 failed because all manuscripts from this journal should be submitted directly to PMC.</td>
+            </tr>
+        <tr style="page-break-inside:avoid">
+              <td style="border:0 solid #000; border-radius:0.25em; color:#fff; font-size:75%; font-weight:bold; line-height:1.428571; padding:8px; text-align:center; vertical-align:top; white-space:nowrap; background-color:#d9534f; border-top:1px solid #ddd" align="center" valign="top" bgcolor="#d9534f">ERROR</td>
+              <td style="border-top:1px solid #ddd; line-height:1.428571; padding:8px; vertical-align:top" valign="top">Package ID=nihms-native-2017-07_2023-10-23_13-10-38_229941 failed because all manuscripts from this journal should be submitted directly to PMC.</td>
+            </tr>
+        <tr style="page-break-inside:avoid">
+              <td style="border:0 solid #000; border-radius:0.25em; color:#fff; font-size:75%; font-weight:bold; line-height:1.428571; padding:8px; text-align:center; vertical-align:top; white-space:nowrap; background-color:#5bc0de; border-top:1px solid #ddd" align="center" valign="top" bgcolor="#5bc0de">INFO</td>
+              <td style="border-top:1px solid #ddd; line-height:1.428571; padding:8px; vertical-align:top" valign="top">Package ID=nihms-native-2017-07_2023-10-23_13-10-30_229947 for Manuscript ID 1502302 was submitted successfully.</td>
+            </tr>
+      </tbody>
+    </table>
+</body>
+</html>

--- a/pass-deposit-services/deposit-core/src/test/resources/org/eclipse/pass/deposit/service/nihmsemail-success.html
+++ b/pass-deposit-services/deposit-core/src/test/resources/org/eclipse/pass/deposit/service/nihmsemail-success.html
@@ -1,0 +1,21 @@
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=9; IE=8; IE=7; IE=EDGE">
+    <title>Bulk submission (errors encountered)</title>
+    </head>
+<body style='font-family:"Helvetica Neue", Helvetica, Arial, sans-serif'>
+  <table class="table" style="background-color:transparent; margin-bottom:20px; max-width:100%; width:100%; border-collapse:collapse" width="100%">
+    <colgroup>
+          <col span="1" style="width:50px">
+          <col span="1">
+    </colgroup>
+    <tbody>
+        <tr style="page-break-inside:avoid">
+              <td class="label label-info" style="border:0 solid #000; border-radius:0.25em; color:#fff; font-size:75%; font-weight:bold; line-height:1.428571; padding:8px; text-align:center; vertical-align:top; white-space:nowrap; background-color:#5bc0de; border-top:1px solid #ddd" align="center" valign="top" bgcolor="#5bc0de">INFO</td>
+              <td class="message" style="border-top:1px solid #ddd; line-height:1.428571; padding:8px; vertical-align:top" valign="top">Package ID=nihms-native-2017-07_2023-10-23_13-10-30_{test-submission-id} for Manuscript ID test-nihms-id was submitted successfully.</td>
+            </tr>
+      </tbody>
+    </table>
+</body>
+</html>

--- a/pass-deposit-services/deposit-core/src/test/resources/org/eclipse/pass/deposit/service/nihmsemail-unknown-message.html
+++ b/pass-deposit-services/deposit-core/src/test/resources/org/eclipse/pass/deposit/service/nihmsemail-unknown-message.html
@@ -1,0 +1,21 @@
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=9; IE=8; IE=7; IE=EDGE">
+    <title>Bulk submission (errors encountered)</title>
+    </head>
+<body style='font-family:"Helvetica Neue", Helvetica, Arial, sans-serif'>
+  <table class="table" style="background-color:transparent; margin-bottom:20px; max-width:100%; width:100%; border-collapse:collapse" width="100%">
+    <colgroup>
+          <col span="1" style="width:50px">
+          <col span="1">
+    </colgroup>
+    <tbody>
+        <tr style="page-break-inside:avoid">
+              <td class="label label-info" style="border:0 solid #000; border-radius:0.25em; color:#fff; font-size:75%; font-weight:bold; line-height:1.428571; padding:8px; text-align:center; vertical-align:top; white-space:nowrap; background-color:#5bc0de; border-top:1px solid #ddd" align="center" valign="top" bgcolor="#5bc0de">INFO</td>
+              <td class="message" style="border-top:1px solid #ddd; line-height:1.428571; padding:8px; vertical-align:top" valign="top">Warning: NIH-funded manuscripts from this journal should be submitted directly to PMC.</td>
+            </tr>
+      </tbody>
+    </table>
+</body>
+</html>

--- a/pass-deposit-services/deposit-core/src/test/resources/org/eclipse/pass/deposit/service/nihmsemail.html
+++ b/pass-deposit-services/deposit-core/src/test/resources/org/eclipse/pass/deposit/service/nihmsemail.html
@@ -1,0 +1,29 @@
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=9; IE=8; IE=7; IE=EDGE">
+    <title>Bulk submission (errors encountered)</title>
+    </head>
+<body style='font-family:"Helvetica Neue", Helvetica, Arial, sans-serif'>
+  <table class="table" style="background-color:transparent; margin-bottom:20px; max-width:100%; width:100%; border-collapse:collapse" width="100%">
+    <colgroup>
+          <col span="1" style="width:50px">
+          <col span="1">
+    </colgroup>
+    <tbody>
+        <tr style="page-break-inside:avoid">
+              <td class="label label-error" style="border:0 solid #000; border-radius:0.25em; color:#fff; font-size:75%; font-weight:bold; line-height:1.428571; padding:8px; text-align:center; vertical-align:top; white-space:nowrap; background-color:#d9534f; border-top:1px solid #ddd" align="center" valign="top" bgcolor="#d9534f">ERROR</td>
+              <td class="message" style="border-top:1px solid #ddd; line-height:1.428571; padding:8px; vertical-align:top" valign="top">Package ID=nihms-native-2017-07_2023-10-23_13-10-12_229935 failed because all manuscripts from this journal should be submitted directly to PMC.</td>
+            </tr>
+        <tr style="page-break-inside:avoid">
+              <td class="label label-error" style="border:0 solid #000; border-radius:0.25em; color:#fff; font-size:75%; font-weight:bold; line-height:1.428571; padding:8px; text-align:center; vertical-align:top; white-space:nowrap; background-color:#d9534f; border-top:1px solid #ddd" align="center" valign="top" bgcolor="#d9534f">ERROR</td>
+              <td class="message" style="border-top:1px solid #ddd; line-height:1.428571; padding:8px; vertical-align:top" valign="top">Package ID=nihms-native-2017-07_2023-10-23_13-10-38_229941 failed because all manuscripts from this journal should be submitted directly to PMC.</td>
+            </tr>
+        <tr style="page-break-inside:avoid">
+              <td class="label label-info" style="border:0 solid #000; border-radius:0.25em; color:#fff; font-size:75%; font-weight:bold; line-height:1.428571; padding:8px; text-align:center; vertical-align:top; white-space:nowrap; background-color:#5bc0de; border-top:1px solid #ddd" align="center" valign="top" bgcolor="#5bc0de">INFO</td>
+              <td class="message" style="border-top:1px solid #ddd; line-height:1.428571; padding:8px; vertical-align:top" valign="top">Package ID=nihms-native-2017-07_2023-10-23_13-10-30_229947 for Manuscript ID 1502302 was submitted successfully.</td>
+            </tr>
+      </tbody>
+    </table>
+</body>
+</html>

--- a/pass-deposit-services/deposit-core/src/test/resources/repositories.json
+++ b/pass-deposit-services/deposit-core/src/test/resources/repositories.json
@@ -31,44 +31,7 @@
         "algorithms": [
           "sha512",
           "md5"
-        ],
-        "funder-mapping": {
-          "johnshopkins.edu:funder:300032": "ahqr",
-          "johnshopkins.edu:funder:300293": "cdc",
-          "johnshopkins.edu:funder:300859": "cdc",
-          "johnshopkins.edu:funder:301459": "va",
-          "johnshopkins.edu:funder:300453": "epa",
-          "johnshopkins.edu:funder:303444": "hhmi",
-          "johnshopkins.edu:funder:300484": "nih",
-          "johnshopkins.edu:funder:300865": "nih",
-          "johnshopkins.edu:funder:300869": "nih",
-          "johnshopkins.edu:funder:300866": "nih",
-          "johnshopkins.edu:funder:308302": "nih",
-          "johnshopkins.edu:funder:305950": "nih",
-          "johnshopkins.edu:funder:302727": "nih",
-          "johnshopkins.edu:funder:300863": "nih",
-          "johnshopkins.edu:funder:300874": "nih",
-          "johnshopkins.edu:funder:300861": "nih",
-          "johnshopkins.edu:funder:300842": "nih",
-          "johnshopkins.edu:funder:303587": "nih",
-          "johnshopkins.edu:funder:303586": "nih",
-          "johnshopkins.edu:funder:306099": "nih",
-          "johnshopkins.edu:funder:300858": "nih",
-          "johnshopkins.edu:funder:301479": "nih",
-          "johnshopkins.edu:funder:300870": "nih",
-          "johnshopkins.edu:funder:303589": "nih",
-          "johnshopkins.edu:funder:300860": "nih",
-          "johnshopkins.edu:funder:300852": "nih",
-          "johnshopkins.edu:funder:302822": "nih",
-          "johnshopkins.edu:funder:302592": "nih",
-          "johnshopkins.edu:funder:303585": "nih",
-          "johnshopkins.edu:funder:303574": "nih",
-          "johnshopkins.edu:funder:300867": "nih",
-          "johnshopkins.edu:funder:303580": "nih",
-          "johnshopkins.edu:funder:301978": "nih",
-          "johnshopkins.edu:funder:305204": "aspr",
-          "johnshopkins.edu:funder:303395": "fda"
-        }
+        ]
       }
     },
     "transport-config": {

--- a/pass-deposit-services/pom.xml
+++ b/pass-deposit-services/pom.xml
@@ -136,12 +136,6 @@
 
       <dependency>
         <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-quartz</artifactId>
-        <version>${spring-boot-maven-plugin.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-json</artifactId>
         <version>${spring-boot-maven-plugin.version}</version>
       </dependency>

--- a/pass-deposit-services/pom.xml
+++ b/pass-deposit-services/pom.xml
@@ -240,6 +240,10 @@
             <groupId>xerces</groupId>
             <artifactId>xmlParserAPIs</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-javamail_1.4_spec</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
 


### PR DESCRIPTION
This PR adds an email integration to read `Bulk submission` emails from nihms.  

The PR contains the following:
- Add Deposit.statusMessage attribute in pass-data-client model
- Set Deposit.depositStatusRef to `nihms-package:<nihms_package_name>` when the submission deposit is sent to nihms SFTP server.
- Read the nihms emails every 10 minutes and use the contents of the emails to update the submission's deposit status.  A success email will result in the deposit status being set to `ACCEPTED` and the deposit.depositStatusRef being set to `nihms-id:<manuscript_id from success email>`.  A failure email will result in the deposit status being set to `REJECTED` and the deposit.statusMessage set to failure message in the email.  The Deposit is updated in PASS.

I have a couple manual tests I want to perform:

- Run the email integration locally and attach to actual inbox of `pass-nihms@jh.edu` to read email and verify it comes in as expected
   - This has a pending action to determine if this is possible with the JHU inbox. I will test with a gmail account to move this along.
- Run integration test in stage with actual nihms deposits

I will be doing these tests over the next couple days, but the code should be stable enough to review now.

