### PR TITLE
Handle case of Medline journal data missing parenthesis

### DIFF
--- a/pass-journal-loader/pass-journal-loader-nih/src/main/java/org/eclipse/pass/loader/journal/nih/MedlineReader.java
+++ b/pass-journal-loader/pass-journal-loader-nih/src/main/java/org/eclipse/pass/loader/journal/nih/MedlineReader.java
@@ -82,7 +82,8 @@ public class MedlineReader implements JournalReader {
                     } else if (line.startsWith(ISSN_FIELD)) {
                         final String issn = extract(line);
                         final String type = extractType(line);
-                        if (issn.length() > 0) {
+
+                        if (issn.length() > 0 && type != null) {
                             j.getIssns().add(String.join(":", type, issn));
                         }
                     } else if (line.startsWith(ABBR_FIELD)) {
@@ -104,7 +105,14 @@ public class MedlineReader implements JournalReader {
     }
 
     private String extractType(String line) {
-        return line.substring(line.indexOf("(") + 1, line.indexOf(")")).trim();
+        int open = line.indexOf("(");
+        int close = line.indexOf(")");
+
+        if (open == -1 || close == -1) {
+            return null;
+        }
+
+        return line.substring(open + 1, close).trim();
     }
 
     @Override

--- a/pass-journal-loader/pass-journal-loader-nih/src/test/java/org/eclipse/pass/loader/journal/nih/DepositIT.java
+++ b/pass-journal-loader/pass-journal-loader-nih/src/test/java/org/eclipse/pass/loader/journal/nih/DepositIT.java
@@ -63,7 +63,7 @@ public class DepositIT {
         Main.main(new String[] {});
 
         // We expect three journals, but no PMC A journals
-        assertEquals(3, listJournals().size());
+        assertEquals(4, listJournals().size());
         assertEquals(0, typeA(listJournals()).size());
 
         System.setProperty("medline", "");
@@ -71,7 +71,7 @@ public class DepositIT {
         Main.main(new String[] {});
 
         // We still expect three journals in the repository, but now two are PMC A
-        assertEquals(3, listJournals().size());
+        assertEquals(4, listJournals().size());
         assertEquals(2, typeA(listJournals()).size());
 
         System.setProperty("medline", "");
@@ -79,7 +79,7 @@ public class DepositIT {
         Main.main(new String[] {});
 
         // The last dataset removed a type A journal, so now we expect only one
-        assertEquals(3, listJournals().size());
+        assertEquals(4, listJournals().size());
         assertEquals(1, typeA(listJournals()).size());
     }
 

--- a/pass-journal-loader/pass-journal-loader-nih/src/test/java/org/eclipse/pass/loader/journal/nih/MedlineReaderTest.java
+++ b/pass-journal-loader/pass-journal-loader-nih/src/test/java/org/eclipse/pass/loader/journal/nih/MedlineReaderTest.java
@@ -41,11 +41,12 @@ public class MedlineReaderTest {
 
             final List<Journal> records = toTest.readJournals(in, UTF_8).collect(Collectors.toList());
 
-            assertEquals(3, records.size());
+            assertEquals(4, records.size());
 
             assertEquals(records.get(0).getIssns(), Collections.singletonList("Print:0000-0001"));
             assertEquals(records.get(1).getIssns(), Collections.singletonList("Online:0000-0002"));
             assertEquals(records.get(2).getIssns(), Arrays.asList("Print:0000-0003", "Online:0000-0004"));
+            assertEquals(records.get(3).getIssns(), Collections.EMPTY_LIST);
         }
     }
 
@@ -57,15 +58,17 @@ public class MedlineReaderTest {
 
             final List<Journal> records = toTest.readJournals(in, UTF_8).collect(Collectors.toList());
 
-            assertEquals(3, records.size());
+            assertEquals(4, records.size());
 
             assertEquals("First Journal", records.get(0).getJournalName());
             assertEquals("Second Journal", records.get(1).getJournalName());
             assertEquals("Third Journal", records.get(2).getJournalName());
+            assertEquals("Fourth Journal", records.get(3).getJournalName());
 
             assertEquals("1jr", records.get(0).getNlmta());
             assertEquals("2jr", records.get(1).getNlmta());
             assertEquals("3jr", records.get(2).getNlmta());
+            assertEquals("4jr", records.get(3).getNlmta());
         }
     }
 

--- a/pass-journal-loader/pass-journal-loader-nih/src/test/resources/medline.txt
+++ b/pass-journal-loader/pass-journal-loader-nih/src/test/resources/medline.txt
@@ -23,3 +23,10 @@ ISSN (Online): 0000-0004
 IsoAbbr: 3jr
 NlmId: abc1232
 --------------------------------------------------------
+JrId: 4
+JournalTitle: Fourth Journal
+MedAbbr: 4jr
+ISSN: 0000-0005
+IsoAbbr: 3jr
+NlmId: abc1233
+--------------------------------------------------------


### PR DESCRIPTION
A journal load failed trying to find () around the ISSN type in Medline journal data. Oddly testing on the latest Medline doesn't show the problem. See the ticket for the log.

This pr handles the case of those missing () by skipping such ISSNs.

