### PR TITLE
Fix couple issues with deposit status update

### DIFF
--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/config/spring/DepositConfig.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/config/spring/DepositConfig.java
@@ -202,7 +202,7 @@ public class DepositConfig {
 
     @Bean({
         "defaultDepositStatusProcessor",
-        "org.eclipse.pass.deposit.messaging.status.DefaultDepositStatusProcessor"
+        "org.eclipse.pass.deposit.status.DefaultDepositStatusProcessor"
     })
     public DefaultDepositStatusProcessor defaultDepositStatusProcessor(DepositStatusResolver<URI, URI> statusResolver) {
         return new DefaultDepositStatusProcessor(statusResolver);

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/DepositUpdater.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/DepositUpdater.java
@@ -89,6 +89,9 @@ public class DepositUpdater {
     }
 
     private void updateSubmittedDeposits(ZonedDateTime submissionFromDate) throws IOException {
+        if (repoKeysWithDepositProcessors.isEmpty()) {
+            return;
+        }
         PassClientSelector<Deposit> submittedDepositsSelector = new PassClientSelector<>(Deposit.class);
         submittedDepositsSelector.setFilter(
             RSQL.and(
@@ -114,7 +117,8 @@ public class DepositUpdater {
             .filter(repositoryConfig ->
                 Objects.nonNull(repositoryConfig.getRepositoryDepositConfig())
                     && Objects.nonNull(repositoryConfig.getRepositoryDepositConfig().getDepositProcessing())
-                    && Objects.nonNull(repositoryConfig.getRepositoryDepositConfig().getDepositProcessing().getProcessor())
+                    && Objects.nonNull(repositoryConfig.getRepositoryDepositConfig().getDepositProcessing()
+                        .getProcessor())
             ).map(RepositoryConfig::getRepositoryKey)
             .toList();
     }

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/DepositUpdater.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/DepositUpdater.java
@@ -20,7 +20,10 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Objects;
 
+import org.eclipse.pass.deposit.config.repository.Repositories;
+import org.eclipse.pass.deposit.config.repository.RepositoryConfig;
 import org.eclipse.pass.support.client.PassClient;
 import org.eclipse.pass.support.client.PassClientSelector;
 import org.eclipse.pass.support.client.RSQL;
@@ -42,42 +45,77 @@ public class DepositUpdater {
     private final PassClient passClient;
     private final DepositTaskHelper depositHelper;
     private final FailedDepositRetry failedDepositRetry;
+    private final Repositories repositories;
+
+    private final List<String> repoKeysWithDepositProcessors;
 
     @Value("${pass.deposit.update.window.days}")
     private long updateWindowDays;
 
     @Autowired
     public DepositUpdater(PassClient passClient, DepositTaskHelper depositHelper,
-                          FailedDepositRetry failedDepositRetry) {
+                          FailedDepositRetry failedDepositRetry, Repositories repositories) {
         this.passClient = passClient;
         this.depositHelper = depositHelper;
         this.failedDepositRetry = failedDepositRetry;
+        this.repositories = repositories;
+        this.repoKeysWithDepositProcessors = getReposWithDepositProcessors();
     }
 
     public void doUpdate() throws IOException {
         ZonedDateTime submissionFromDate = ZonedDateTime.now(ZoneOffset.UTC).minusDays(updateWindowDays);
-        PassClientSelector<Deposit> sel = new PassClientSelector<>(Deposit.class);
-        sel.setFilter(
+        retryFailedDeposits(submissionFromDate);
+        updateSubmittedDeposits(submissionFromDate);
+    }
+
+    private void retryFailedDeposits(ZonedDateTime submissionFromDate) throws IOException {
+        PassClientSelector<Deposit> failedDepositsSelector = new PassClientSelector<>(Deposit.class);
+        failedDepositsSelector.setFilter(
             RSQL.and(
-                RSQL.in("depositStatus", DepositStatus.SUBMITTED.getValue(), DepositStatus.FAILED.getValue()),
+                RSQL.equals("depositStatus", DepositStatus.FAILED.getValue()),
                 RSQL.gte("submission.submittedDate", DATE_TIME_FORMATTER.format(submissionFromDate))
             )
         );
-        List<Deposit> deposits = passClient.streamObjects(sel).toList();
-        LOG.warn("Deposit Count for updating: " + deposits.size());
-
-        deposits.forEach(deposit -> {
+        List<Deposit> failedDeposits = passClient.streamObjects(failedDepositsSelector).toList();
+        LOG.warn("Failed Deposit Count for updating: " + failedDeposits.size());
+        failedDeposits.forEach(deposit -> {
             try {
-                if (deposit.getDepositStatus() == DepositStatus.FAILED) {
-                    LOG.info("Retrying FAILED Deposit for {}", deposit.getId());
-                    failedDepositRetry.retryFailedDeposit(deposit);
-                } else {
-                    LOG.info("Updating Deposit.depositStatus for {}", deposit.getId());
-                    depositHelper.processDepositStatus(deposit.getId());
-                }
+                LOG.info("Retrying FAILED Deposit for {}", deposit.getId());
+                failedDepositRetry.retryFailedDeposit(deposit);
+            } catch (Exception e) {
+                LOG.warn("Failed to retry Failed Deposit {}: {}", deposit.getId(), e.getMessage(), e);
+            }
+        });
+    }
+
+    private void updateSubmittedDeposits(ZonedDateTime submissionFromDate) throws IOException {
+        PassClientSelector<Deposit> submittedDepositsSelector = new PassClientSelector<>(Deposit.class);
+        submittedDepositsSelector.setFilter(
+            RSQL.and(
+                RSQL.equals("depositStatus", DepositStatus.SUBMITTED.getValue()),
+                RSQL.gte("submission.submittedDate", DATE_TIME_FORMATTER.format(submissionFromDate)),
+                RSQL.in("repository.repositoryKey", repoKeysWithDepositProcessors.toArray(new String[0]))
+            )
+        );
+        List<Deposit> submittedDeposits = passClient.streamObjects(submittedDepositsSelector).toList();
+        LOG.warn("Deposit Count for updating: " + submittedDeposits.size());
+        submittedDeposits.forEach(deposit -> {
+            try {
+                LOG.info("Updating Deposit.depositStatus for {}", deposit.getId());
+                depositHelper.processDepositStatus(deposit.getId());
             } catch (Exception e) {
                 LOG.warn("Failed to update Deposit {}: {}", deposit.getId(), e.getMessage(), e);
             }
         });
+    }
+
+    private List<String> getReposWithDepositProcessors() {
+        return repositories.getAllConfigs().stream()
+            .filter(repositoryConfig ->
+                Objects.nonNull(repositoryConfig.getRepositoryDepositConfig())
+                    && Objects.nonNull(repositoryConfig.getRepositoryDepositConfig().getDepositProcessing())
+                    && Objects.nonNull(repositoryConfig.getRepositoryDepositConfig().getDepositProcessing().getProcessor())
+            ).map(RepositoryConfig::getRepositoryKey)
+            .toList();
     }
 }

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/NihmsReceiveMailService.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/NihmsReceiveMailService.java
@@ -91,10 +91,13 @@ public class NihmsReceiveMailService {
 
     public void handleReceivedMail(MimeMessage receivedMessage) {
         try {
+            LOG.warn("Email received: " + receivedMessage.getSubject());
             if (isEmailNotNihms(receivedMessage)) {
                 return;
             }
+            LOG.warn("Email is from Nihms");
             String content = getHtmlText(receivedMessage);
+            LOG.warn("Nihms Email content:" + content);
             if (Objects.isNull(content)) {
                 LOG.error("No HTML content found in nihms email: " + receivedMessage.getSubject());
                 return;

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/NihmsReceiveMailService.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/NihmsReceiveMailService.java
@@ -35,6 +35,7 @@ import org.eclipse.pass.deposit.provider.nihms.NihmsAssembler;
 import org.eclipse.pass.support.client.PassClient;
 import org.eclipse.pass.support.client.PassClientSelector;
 import org.eclipse.pass.support.client.RSQL;
+import org.eclipse.pass.support.client.model.CopyStatus;
 import org.eclipse.pass.support.client.model.Deposit;
 import org.eclipse.pass.support.client.model.DepositStatus;
 import org.jsoup.Jsoup;
@@ -150,6 +151,7 @@ public class NihmsReceiveMailService {
     private void updateDepositRejected(String submissionId, String packageId, String message) throws IOException {
         getDeposits(submissionId, packageId).forEach(deposit -> {
             deposit.setDepositStatus(DepositStatus.REJECTED);
+            deposit.getRepositoryCopy().setCopyStatus(CopyStatus.REJECTED);
             deposit.setStatusMessage(message);
             updateDeposit(deposit);
         });
@@ -158,6 +160,7 @@ public class NihmsReceiveMailService {
     private void updateDepositAccepted(String submissionId, String packageId, String nihmsId) throws IOException {
         getDeposits(submissionId, packageId).forEach(deposit -> {
             deposit.setDepositStatus(DepositStatus.ACCEPTED);
+            deposit.getRepositoryCopy().setCopyStatus(CopyStatus.ACCEPTED);
             deposit.setDepositStatusRef(NIHMS_DEP_STATUS_REF_PREFIX + nihmsId);
             deposit.setStatusMessage(null);
             updateDeposit(deposit);
@@ -175,6 +178,7 @@ public class NihmsReceiveMailService {
 
     private void updateDeposit(Deposit deposit) {
         try {
+            passClient.updateObject(deposit.getRepositoryCopy());
             passClient.updateObject(deposit);
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/pass-deposit-services/deposit-core/src/main/resources/application.properties
+++ b/pass-deposit-services/deposit-core/src/main/resources/application.properties
@@ -58,5 +58,5 @@ nihms.mail.username=${NIHMS_MAIL_USERNAME}
 nihms.mail.password=${NIHMS_MAIL_PASSWORD}
 
 pass.deposit.nihms.email.enabled=false
-pass.deposit.nihms.email.delay=600000
+pass.deposit.nihms.email.delay=720000
 pass.deposit.nihms.email.from=${PASS_DEPOSIT_NIHMS_EMAIL_FROM:nihms-help@ncbi.nlm.nih.gov}

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/DepositUpdaterIT.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/DepositUpdaterIT.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2023 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.deposit.service;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.time.ZonedDateTime;
+
+import org.eclipse.pass.deposit.util.ResourceTestUtil;
+import org.eclipse.pass.support.client.PassClientResult;
+import org.eclipse.pass.support.client.PassClientSelector;
+import org.eclipse.pass.support.client.RSQL;
+import org.eclipse.pass.support.client.model.Deposit;
+import org.eclipse.pass.support.client.model.DepositStatus;
+import org.eclipse.pass.support.client.model.Repository;
+import org.eclipse.pass.support.client.model.Submission;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * @author Russ Poetker (rpoetke1@jh.edu)
+ */
+@TestPropertySource(properties = {
+    "pass.deposit.repository.configuration=classpath:/full-test-repositories.json"
+})
+public class DepositUpdaterIT extends AbstractDepositIT {
+
+    @Autowired private DepositUpdater depositUpdater;
+    @MockBean private DepositTaskHelper depositTaskHelper;
+
+    @Test
+    public void testDoUpdate_SkipNoDepositStatusProcessorRepos() throws Exception {
+        // GIVEN
+        Submission submission = initSubmissionAndDeposits();
+        mockSword();
+
+        // WHEN
+        try {
+            depositUpdater.doUpdate();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        // THEN
+        PassClientSelector<Deposit> depositSelector = new PassClientSelector<>(Deposit.class);
+        depositSelector.setFilter(RSQL.equals("submission.id", submission.getId()));
+        depositSelector.setInclude("repository");
+        PassClientResult<Deposit> actualDeposits = passClient.selectObjects(depositSelector);
+        Deposit pmcDeposit = actualDeposits.getObjects().stream()
+            .filter(deposit -> deposit.getRepository().getRepositoryKey().equals("PubMed Central"))
+            .findFirst().get();
+        Deposit j10pDeposit = actualDeposits.getObjects().stream()
+            .filter(deposit -> deposit.getRepository().getRepositoryKey().equals("JScholarship"))
+            .findFirst().get();
+        verify(depositTaskHelper, times(0)).processDepositStatus(eq(pmcDeposit.getId()));
+        verify(depositTaskHelper, times(1)).processDepositStatus(eq(j10pDeposit.getId()));
+    }
+
+    private Submission initSubmissionAndDeposits() throws Exception {
+        Submission submission = findSubmission(createSubmission(
+            ResourceTestUtil.readSubmissionJson("sample1")));
+        submission.setSubmittedDate(ZonedDateTime.now());
+        passClient.updateObject(submission);
+        Repository pmcRepo = submission.getRepositories().stream()
+            .filter(repository -> repository.getRepositoryKey().equals("PubMed Central"))
+            .findFirst().get();
+        Deposit pmcDeposit = new Deposit();
+        pmcDeposit.setSubmission(submission);
+        pmcDeposit.setRepository(pmcRepo);
+        pmcDeposit.setDepositStatus(DepositStatus.SUBMITTED);
+        pmcDeposit.setDepositStatusRef("test-pmc-package");
+        passClient.createObject(pmcDeposit);
+        Repository j10pRepo = submission.getRepositories().stream()
+            .filter(repository -> repository.getRepositoryKey().equals("JScholarship"))
+            .findFirst().get();
+        Deposit j10pDeposit = new Deposit();
+        j10pDeposit.setSubmission(submission);
+        j10pDeposit.setRepository(j10pRepo);
+        j10pDeposit.setDepositStatus(DepositStatus.SUBMITTED);
+        j10pDeposit.setDepositStatusRef("test-j10p-ref");
+        passClient.createObject(j10pDeposit);
+        return submission;
+    }
+
+}

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/DepositUpdaterTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/DepositUpdaterTest.java
@@ -24,10 +24,12 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.util.stream.Stream;
 
+import org.eclipse.pass.deposit.config.repository.Repositories;
 import org.eclipse.pass.support.client.PassClient;
 import org.eclipse.pass.support.client.PassClientSelector;
 import org.eclipse.pass.support.client.model.Deposit;
 import org.eclipse.pass.support.client.model.DepositStatus;
+import org.eclipse.pass.support.client.model.Repository;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -43,7 +45,9 @@ public class DepositUpdaterTest {
         final PassClient passClient = mock(PassClient.class);
         final DepositTaskHelper depositTaskHelper = mock(DepositTaskHelper.class);
         final FailedDepositRetry failedDepositRetry = mock(FailedDepositRetry.class);
-        final DepositUpdater depositUpdater = new DepositUpdater(passClient, depositTaskHelper, failedDepositRetry);
+        final Repositories repositories = mock(Repositories.class);
+        final DepositUpdater depositUpdater = new DepositUpdater(passClient, depositTaskHelper, failedDepositRetry,
+            repositories);
         Deposit deposit1 = new Deposit();
         deposit1.setId("dp-1");
         deposit1.setDepositStatus(DepositStatus.SUBMITTED);

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceIT.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceIT.java
@@ -61,7 +61,7 @@ import org.springframework.test.context.TestPropertySource;
 @TestPropertySource(properties = {
     "pass.deposit.nihms.email.enabled=true",
     "pass.deposit.nihms.email.delay=2000",
-    "pass.deposit.nihms.email.from=test-from@localhost",
+    "pass.deposit.nihms.email.from=test-from-2@localhost,test-from@localhost",
     "nihms.mail.host=localhost",
     "nihms.mail.port=3993",
     "nihms.mail.username=testnihms@localhost",

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceIT.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceIT.java
@@ -108,7 +108,7 @@ public class NihmsReceiveMailServiceIT extends AbstractDepositSubmissionIT {
             assertEquals(1, actualDeposits.size());
             Deposit pmcDeposit = actualDeposits.get(0);
             assertEquals(DepositStatus.ACCEPTED, pmcDeposit.getDepositStatus());
-            assertEquals(CopyStatus.ACCEPTED, pmcDeposit.getRepositoryCopy().getCopyStatus());
+            assertEquals(CopyStatus.COMPLETE, pmcDeposit.getRepositoryCopy().getCopyStatus());
             assertEquals(NIHMS_DEP_STATUS_REF_PREFIX + "test-nihms-id", pmcDeposit.getDepositStatusRef());
             assertNull(pmcDeposit.getStatusMessage());
         });

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceTest.java
@@ -68,7 +68,7 @@ import org.springframework.test.context.TestPropertySource;
 @TestPropertySource(properties = {
     "pass.deposit.nihms.email.enabled=true",
     "pass.deposit.nihms.email.delay=2000",
-    "pass.deposit.nihms.email.from=test-from@localhost",
+    "pass.deposit.nihms.email.from=test-from-2@localhost,test-from@localhost",
     "nihms.mail.host=localhost",
     "nihms.mail.port=3993",
     "nihms.mail.username=testnihms@localhost",
@@ -108,7 +108,7 @@ public class NihmsReceiveMailServiceTest {
         // GIVEN
         final String subject2 = GreenMailUtil.random();
         final String body2 = GreenMailUtil.random();
-        MimeMessage message2 = GreenMailUtil.createTextEmail("testnihms@localhost", "test-from@localhost",
+        MimeMessage message2 = GreenMailUtil.createTextEmail("testnihms@localhost", "test-from-2@localhost",
             subject2, body2, greenMail.getImaps().getServerSetup());
 
         // WHEN

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceTest.java
@@ -46,8 +46,10 @@ import jakarta.mail.internet.MimeMultipart;
 import org.eclipse.pass.deposit.DepositApp;
 import org.eclipse.pass.support.client.PassClient;
 import org.eclipse.pass.support.client.PassClientSelector;
+import org.eclipse.pass.support.client.model.CopyStatus;
 import org.eclipse.pass.support.client.model.Deposit;
 import org.eclipse.pass.support.client.model.DepositStatus;
+import org.eclipse.pass.support.client.model.RepositoryCopy;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.ArgumentCaptor;
@@ -204,18 +206,21 @@ public class NihmsReceiveMailServiceTest {
         Deposit updatedDeposit1 = depositCaptor.getAllValues().stream().filter(deposit -> deposit.getId().equals("1"))
             .findFirst().get();
         assertEquals(DepositStatus.REJECTED, updatedDeposit1.getDepositStatus());
+        assertEquals(CopyStatus.REJECTED, updatedDeposit1.getRepositoryCopy().getCopyStatus());
         assertEquals("Package ID=nihms-native-2017-07_2023-10-23_13-10-12_229935 failed because all " +
             "manuscripts from this journal should be submitted directly to PMC.", updatedDeposit1.getStatusMessage());
         assertNull(updatedDeposit1.getDepositStatusRef());
         Deposit updatedDeposit2 = depositCaptor.getAllValues().stream().filter(deposit -> deposit.getId().equals("2"))
             .findFirst().get();
         assertEquals(DepositStatus.REJECTED, updatedDeposit2.getDepositStatus());
+        assertEquals(CopyStatus.REJECTED, updatedDeposit2.getRepositoryCopy().getCopyStatus());
         assertEquals("Package ID=nihms-native-2017-07_2023-10-23_13-10-38_229941 failed because all " +
             "manuscripts from this journal should be submitted directly to PMC.", updatedDeposit2.getStatusMessage());
         assertNull(updatedDeposit2.getDepositStatusRef());
         Deposit updatedDeposit3 = depositCaptor.getAllValues().stream().filter(deposit -> deposit.getId().equals("3"))
             .findFirst().get();
         assertEquals(DepositStatus.ACCEPTED, updatedDeposit3.getDepositStatus());
+        assertEquals(CopyStatus.ACCEPTED, updatedDeposit3.getRepositoryCopy().getCopyStatus());
         assertNull(updatedDeposit3.getStatusMessage());
         assertEquals(NihmsReceiveMailService.NIHMS_DEP_STATUS_REF_PREFIX + "1502302",
             updatedDeposit3.getDepositStatusRef());
@@ -328,14 +333,17 @@ public class NihmsReceiveMailServiceTest {
         deposit1.setId("1");
         deposit1.setDepositStatus(DepositStatus.SUBMITTED);
         deposit1.setStatusMessage("init-submitted");
+        deposit1.setRepositoryCopy(new RepositoryCopy());
         Deposit deposit2 = new Deposit();
         deposit2.setId("2");
         deposit2.setDepositStatus(DepositStatus.SUBMITTED);
         deposit2.setStatusMessage("init-submitted");
+        deposit2.setRepositoryCopy(new RepositoryCopy());
         Deposit deposit3 = new Deposit();
         deposit3.setId("3");
         deposit3.setDepositStatus(DepositStatus.SUBMITTED);
         deposit3.setStatusMessage("init-submitted");
+        deposit3.setRepositoryCopy(new RepositoryCopy());
         when(passClient.streamObjects(any())).thenAnswer(input -> {
             PassClientSelector<Deposit> selector = input.getArgument(0);
             if (selector.getFilter().contains("submission.id=='229935'")) {

--- a/pass-deposit-services/deposit-core/src/test/resources/full-test-repositories.json
+++ b/pass-deposit-services/deposit-core/src/test/resources/full-test-repositories.json
@@ -1,5 +1,10 @@
 {
   "JScholarship": {
+    "deposit-config": {
+      "processing": {
+        "beanName": "org.eclipse.pass.deposit.status.DefaultDepositStatusProcessor"
+      }
+    },
     "assembler": {
       "specification": "simple",
       "beanName": "simpleAssembler",
@@ -22,16 +27,6 @@
     }
   },
   "PubMed Central": {
-    "deposit-config": {
-      "processing": {
-      },
-      "mapping": {
-        "INFO": "accepted",
-        "ERROR": "rejected",
-        "WARN": "rejected",
-        "default-mapping": "submitted"
-      }
-    },
     "assembler": {
       "specification": "nihms-native-2017-07",
       "beanName": "nihmsAssembler",

--- a/pass-deposit-services/deposit-core/src/test/resources/org/eclipse/pass/deposit/messaging/status/DepositTaskIT.json
+++ b/pass-deposit-services/deposit-core/src/test/resources/org/eclipse/pass/deposit/messaging/status/DepositTaskIT.json
@@ -2,7 +2,7 @@
   "Pmc": {
     "deposit-config": {
       "processing": {
-        "beanName": "org.eclipse.pass.deposit.messaging.status.DefaultDepositStatusProcessor"
+        "beanName": "org.eclipse.pass.deposit.status.DefaultDepositStatusProcessor"
       },
       "mapping": {
         "http://dspace.org/state/archived": "accepted",


### PR DESCRIPTION
This PR fixes a couple issues seen during nihms email integration testing in stage:

- Fix NPE on deposit status update job on nihms deposits.  Change deposit status updater logic to only process deposits with a repo config that has a deposit status processor configured.
- Refactor RepositoryCopy status update to be reusable.
- Update nihms email processing to update RepositoryCopy status when associated Deposit status is changing.