### PR TITLE
Update NIHMS loader to check for potentials deposits from PASS using the deposit status ref

### DIFF
--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/CopyStatus.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/model/CopyStatus.java
@@ -35,10 +35,9 @@ public enum CopyStatus {
      */
     STALLED("stalled"),
     /**
-     * The target Repository has rejected the Deposit
+     * The target Repository has accepted the files, and publication is pending if not already complete
      */
     COMPLETE("complete"),
-
     /**
      * The RepositoryCopy has been rejected by the remote Repository.
      */

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/DepositTaskHelperTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/DepositTaskHelperTest.java
@@ -61,7 +61,6 @@ public class DepositTaskHelperTest {
     private Repositories repositories;
 
     @BeforeEach
-    @SuppressWarnings("unchecked")
     public void setUp() throws Exception {
         passClient = mock(PassClient.class);
         repositories = mock(Repositories.class);

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/DepositTaskTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/DepositTaskTest.java
@@ -61,7 +61,6 @@ public class DepositTaskTest {
     private DepositTask depositTask;
 
     @BeforeEach
-    @SuppressWarnings("unchecked")
     public void setUp() throws Exception {
         DepositUtil.DepositWorkerContext dwc = new DepositUtil.DepositWorkerContext();
         dc = Mockito.spy(dwc);
@@ -71,7 +70,6 @@ public class DepositTaskTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void j10sStatementUrlHack() throws Exception {
         String prefix = "http://moo";
         String replacement = "http://foo";

--- a/pass-nihms-loader/nihms-data-harvest/src/test/java/org/eclipse/pass/loader/nihms/UrlBuilderTest.java
+++ b/pass-nihms-loader/nihms-data-harvest/src/test/java/org/eclipse/pass/loader/nihms/UrlBuilderTest.java
@@ -147,7 +147,7 @@ public class UrlBuilderTest {
 
     @AfterEach
     public void tearDown() {
-        System.err.println(generatedUrl.toString());
+        // System.err.println(generatedUrl.toString());
     }
 
     @Test

--- a/pass-nihms-loader/nihms-data-transform-load/pom.xml
+++ b/pass-nihms-loader/nihms-data-transform-load/pom.xml
@@ -114,6 +114,19 @@
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>${commons-io.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -162,19 +175,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>standard</id>
-      <properties>
-      </properties>
-    </profile>
-    <profile>
-      <id>local-context</id>
-      <properties>
-        <COMPACTION_PRELOAD_FILE_PASS_STATIC>/mnt/context.jsonld</COMPACTION_PRELOAD_FILE_PASS_STATIC>
-      </properties>
-    </profile>
-  </profiles>
-
 </project>

--- a/pass-nihms-loader/nihms-data-transform-load/src/main/java/org/eclipse/pass/loader/nihms/CompletedPublicationsCache.java
+++ b/pass-nihms-loader/nihms-data-transform-load/src/main/java/org/eclipse/pass/loader/nihms/CompletedPublicationsCache.java
@@ -18,10 +18,10 @@ package org.eclipse.pass.loader.nihms;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.PrintWriter;
+import java.nio.file.Files;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.pass.loader.nihms.util.ConfigUtil;
 import org.eclipse.pass.loader.nihms.util.FileUtil;
@@ -125,7 +125,6 @@ public class CompletedPublicationsCache {
     /**
      * Load contents of cache file into memory from file
      */
-    @SuppressWarnings("unchecked")
     public synchronized void loadFromFile() {
         try {
             if (!cacheFile.exists()) {
@@ -133,7 +132,7 @@ public class CompletedPublicationsCache {
                 cacheFile.createNewFile();
             }
             // read in cached values
-            completedPubsCache = new HashSet<String>(FileUtils.readLines(cacheFile));
+            completedPubsCache = new HashSet<>(Files.readAllLines(cacheFile.toPath()));
         } catch (Exception ex) {
             throw new RuntimeException(
                 "Could not create cache file to hold compliant records at path " + cacheFile.getAbsolutePath(), ex);

--- a/pass-nihms-loader/nihms-data-transform-load/src/main/java/org/eclipse/pass/loader/nihms/SubmissionDTO.java
+++ b/pass-nihms-loader/nihms-data-transform-load/src/main/java/org/eclipse/pass/loader/nihms/SubmissionDTO.java
@@ -15,6 +15,7 @@
  */
 package org.eclipse.pass.loader.nihms;
 
+import org.eclipse.pass.support.client.model.Deposit;
 import org.eclipse.pass.support.client.model.Publication;
 import org.eclipse.pass.support.client.model.RepositoryCopy;
 import org.eclipse.pass.support.client.model.Submission;
@@ -33,11 +34,15 @@ public class SubmissionDTO {
 
     private RepositoryCopy repositoryCopy = null;
 
+    private Deposit deposit = null;
+
     private boolean updatePublication = false;
 
     private boolean updateSubmission = false;
 
     private boolean updateRepositoryCopy = false;
+
+    private boolean updateDeposit = false;
 
     private String grantId = null;
 
@@ -81,6 +86,20 @@ public class SubmissionDTO {
      */
     public void setRepositoryCopy(RepositoryCopy repositoryCopy) {
         this.repositoryCopy = repositoryCopy;
+    }
+
+    /**
+     * @return the deposit
+     */
+    public Deposit getDeposit() {
+        return deposit;
+    }
+
+    /**
+     * @param deposit the deposit to set
+     */
+    public void setDeposit(Deposit deposit) {
+        this.deposit = deposit;
     }
 
     /**
@@ -136,7 +155,7 @@ public class SubmissionDTO {
      * @return updateRepositoryCopy true if update should be performed
      */
     public boolean doUpdate() {
-        return (updateRepositoryCopy || updateSubmission || updatePublication);
+        return (updateRepositoryCopy || updateSubmission || updatePublication || updateDeposit);
     }
 
     /**
@@ -146,4 +165,17 @@ public class SubmissionDTO {
         this.updateRepositoryCopy = updateRepositoryCopy;
     }
 
+    /**
+     * @param updateDeposit the updateDeposit to set
+     */
+    public void setUpdateDeposoit(boolean updateDeposit) {
+        this.updateDeposit = updateDeposit;
+    }
+
+    /**
+     * @return updateDeposit true if update should be performed
+     */
+    public boolean doUpdateDeposit() {
+        return updateDeposit;
+    }
 }

--- a/pass-nihms-loader/nihms-data-transform-load/src/main/java/org/eclipse/pass/loader/nihms/SubmissionLoader.java
+++ b/pass-nihms-loader/nihms-data-transform-load/src/main/java/org/eclipse/pass/loader/nihms/SubmissionLoader.java
@@ -103,7 +103,7 @@ public class SubmissionLoader {
                 deposit.setRepositoryCopy(repositoryCopy);
                 deposit.setDepositStatus(DepositStatus.ACCEPTED);
                 clientService.updateDeposit(deposit);
-            } else if (deposit != null && !deposit.getRepositoryCopy().equals(repositoryCopy.getId())) {
+            } else if (deposit != null && !deposit.getRepositoryCopy().getId().equals(repositoryCopy.getId())) {
                 //this shouldn't happen in principle, but if it does it should be checked.
                 LOG.warn(
                     "A NIHMS Deposit with id {} was found for the Submission but it is associated with a different " +
@@ -111,6 +111,10 @@ public class SubmissionLoader {
                     + "This may indicate a data error, please verify the RepositoryCopy association for this Deposit",
                     deposit.getId(), deposit.getRepositoryCopy(), repositoryCopy.getId());
             }
+        }
+
+        if (dto.doUpdateDeposit() && dto.getDeposit() != null) {
+            clientService.updateDeposit(dto.getDeposit());
         }
 
         //before moving on do one last check to see if SubmissionStatus has been affected by the changes

--- a/pass-nihms-loader/nihms-data-transform-load/src/test/java/org/eclipse/pass/loader/nihms/CompletedPublicationsCacheTest.java
+++ b/pass-nihms-loader/nihms-data-transform-load/src/test/java/org/eclipse/pass/loader/nihms/CompletedPublicationsCacheTest.java
@@ -19,11 +19,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.File;
-import java.util.ArrayList;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.List;
 
-import org.apache.commons.io.FileUtils;
 import org.eclipse.pass.loader.nihms.util.FileUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -123,8 +122,7 @@ public class CompletedPublicationsCacheTest {
         assertTrue(completedPubsCache.contains(pmid1, awardNum1));
         assertTrue(completedPubsCache.contains(pmid2, awardNum2));
 
-        @SuppressWarnings("unchecked")
-        List<String> processed = new ArrayList<String>(FileUtils.readLines(new File(cachepath)));
+        List<String> processed = Files.readAllLines(Paths.get(cachepath));
         assertEquals(2, processed.size());
     }
 

--- a/pass-nihms-loader/nihms-data-transform-load/src/test/java/org/eclipse/pass/loader/nihms/SubmissionLoaderTest.java
+++ b/pass-nihms-loader/nihms-data-transform-load/src/test/java/org/eclipse/pass/loader/nihms/SubmissionLoaderTest.java
@@ -54,7 +54,6 @@ public class SubmissionLoaderTest {
     private SubmissionStatusService statusServiceMock;
 
     private static final String submissionId = "1";
-    private static final String repositoryCopyId = "1";
     private static final String depositId = "1";
     private static final String publicationId = "1";
     private static final String userId = "1";

--- a/pass-nihms-loader/nihms-data-transform-load/src/test/java/org/eclipse/pass/loader/nihms/TransformAndLoadSmokeIT.java
+++ b/pass-nihms-loader/nihms-data-transform-load/src/test/java/org/eclipse/pass/loader/nihms/TransformAndLoadSmokeIT.java
@@ -53,25 +53,22 @@ public class TransformAndLoadSmokeIT extends NihmsSubmissionEtlITBase {
         stubFor(get(urlMatching("/entrez/eutils/esummary.fcgi\\?db=pubmed&retmode=json&rettype=abstract&id=([0-9]*)"))
                 .willReturn(ok(jsonErrorResponse)));
 
-        NihmsTransformLoadApp app = new NihmsTransformLoadApp(null);
-
-        app.run();
-
         PassClientSelector<RepositoryCopy> repoCopySelector = new PassClientSelector<>(RepositoryCopy.class);
         PassClientSelector<Publication> publicationSelector = new PassClientSelector<>(Publication.class);
         PassClientSelector<Submission> submissionSelector = new PassClientSelector<>(Submission.class);
 
+        NihmsTransformLoadApp app = new NihmsTransformLoadApp(null);
+
+        app.run();
+
         //now that it has run lets do some basic tallys to make sure they are as expected:
         //make sure RepositoryCopies are all in before moving on so we can be sure the counts are done.
-        repoCopySelector.setFilter(RSQL.notEquals("id", "-1"));
         List<RepositoryCopy> repositoryCopies = passClient.selectObjects(repoCopySelector).getObjects();
         assertEquals(23, repositoryCopies.size());
 
-        publicationSelector.setFilter(RSQL.notEquals("id", "-1"));
         List<Publication> publications = passClient.selectObjects(publicationSelector).getObjects();
         assertEquals(32, publications.size());
 
-        submissionSelector.setFilter(RSQL.notEquals("id", "-1"));
         List<Submission> submissions = passClient.selectObjects(submissionSelector).getObjects();
         assertEquals(32, submissions.size());
 
@@ -168,11 +165,11 @@ public class TransformAndLoadSmokeIT extends NihmsSubmissionEtlITBase {
         createGrant("R01 HD086026", user);
 
         String checkableAwardNumber = "R01 AAAAAA";
-        String checkableGrantId = createGrant(checkableAwardNumber, user);
+        Grant checkableGrant = createGrant(checkableAwardNumber, user);
 
         grantSelector.setFilter(RSQL.equals("awardNumber", checkableAwardNumber));
         String testGrantId = passClient.streamObjects(grantSelector).findFirst().orElseThrow().getId();
-        assertEquals(checkableGrantId, testGrantId);
+        assertEquals(checkableGrant.getId(), testGrantId);
 
     }
 

--- a/pass-nihms-loader/nihms-etl-model/src/main/java/org/eclipse/pass/loader/nihms/model/NihmsPublication.java
+++ b/pass-nihms-loader/nihms-etl-model/src/main/java/org/eclipse/pass/loader/nihms/model/NihmsPublication.java
@@ -207,6 +207,17 @@ public class NihmsPublication {
     }
 
     /**
+     * @return the nihmsId without the prefix
+     */
+    public String getRawNihmsId() {
+        if (nihmsId != null && nihmsId.startsWith(NIHMSID_PREFIX)) {
+            return nihmsId.substring(NIHMSID_PREFIX.length());
+        }
+
+        return nihmsId;
+    }
+
+    /**
      * Sets the NIHMSID, will add the NIHMS prefix if missing
      *
      * @param nihmsId the nihmsId to set

--- a/pass-notification-service/src/main/java/org/eclipse/pass/notification/service/LinksUtil.java
+++ b/pass-notification-service/src/main/java/org/eclipse/pass/notification/service/LinksUtil.java
@@ -169,7 +169,6 @@ public class LinksUtil {
      * @param json Serialized JSON
      * @return collection of links.
      */
-    @SuppressWarnings("unchecked")
     public static Collection<Link> deserialize(String json) {
         try {
             return asList(mapper.readValue(json, Link[].class));


### PR DESCRIPTION
Deposits to NIHMS from the UI will have status reference property identifying a NIHMS id if they get accepted for processing. With this pr, the loader will update the status of the deposits (and submissions) which match NIHMS ids of records instead of creating new objects.

Compliant records update the Deposit status to accepted, in process becomes submitted, and non-compliant goes to failed.

There are a bunch of small cleanups to reduce IDE warnings. The testings from the nihms loading has been refactored just a bit to be reduce the number of redundant API calls.