### PR TITLE
Disable acceptance tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,3 +5,5 @@ jobs:
   test:
     name: "Run Unit & Integration Tests"
     uses: eclipse-pass/main/.github/workflows/ci.yml@main
+    with:
+      run_acceptance_tests: false


### PR DESCRIPTION
Current tests don't touch pass-support code, so there isn't much point in running them. Can be toggled later if tests are changed