### PR TITLE
Fix deposit status update bug

### DIFF
--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/DepositProcessor.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/DepositProcessor.java
@@ -70,7 +70,7 @@ public class DepositProcessor implements Consumer<Deposit> {
             // if result is still intermediate, add Deposit to queue for processing?
 
             // Determine the logical success or failure of the Deposit, and persist the Deposit and RepositoryCopy
-            depositHelper.processDepositStatus(deposit.getId());
+            depositHelper.processDepositStatus(deposit);
         }
     }
 

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/DepositUpdater.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/DepositUpdater.java
@@ -105,7 +105,7 @@ public class DepositUpdater {
         submittedDeposits.forEach(deposit -> {
             try {
                 LOG.info("Updating Deposit.depositStatus for {}", deposit.getId());
-                depositHelper.processDepositStatus(deposit.getId());
+                depositHelper.processDepositStatus(deposit);
             } catch (Exception e) {
                 LOG.warn("Failed to update Deposit {}: {}", deposit.getId(), e.getMessage(), e);
             }

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/DepositProcessorTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/DepositProcessorTest.java
@@ -183,7 +183,7 @@ public class DepositProcessorTest {
 
         verify(intermediateDeposit).getDepositStatus();
         verifyNoInteractions(cri);
-        verify(depositTaskHelper).processDepositStatus(depositId);
+        verify(depositTaskHelper).processDepositStatus(intermediateDeposit);
     }
 
     private void prepareCriFuncCriticalSuccess(DepositStatus depositStatus) throws IOException {

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/DepositUpdaterTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/DepositUpdaterTest.java
@@ -77,8 +77,8 @@ public class DepositUpdaterTest {
         depositUpdater.doUpdate();
 
         // THEN
-        verify(depositTaskHelper).processDepositStatus("dp-1");
-        verify(depositTaskHelper).processDepositStatus("dp-2");
+        verify(depositTaskHelper).processDepositStatus(deposit1);
+        verify(depositTaskHelper).processDepositStatus(deposit2);
 
         ArgumentCaptor<PassClientSelector<Deposit>> argument = ArgumentCaptor.forClass(PassClientSelector.class);
         verify(passClient, times(2)).streamObjects(argument.capture());

--- a/pass-deposit-services/deposit-core/src/test/resources/full-test-repositories.json
+++ b/pass-deposit-services/deposit-core/src/test/resources/full-test-repositories.json
@@ -3,6 +3,11 @@
     "deposit-config": {
       "processing": {
         "beanName": "org.eclipse.pass.deposit.status.DefaultDepositStatusProcessor"
+      },
+      "mapping": {
+        "http://dspace.org/state/archived": "accepted",
+        "http://dspace.org/state/withdrawn": "rejected",
+        "default-mapping": "submitted"
       }
     },
     "assembler": {


### PR DESCRIPTION
There was an exception being thrown when deposit services received a message to update a Deposit that does not have a deposit status processor configured in the repository configuration.  This didn't cause any issue in processing currently because it would only happen to a nihms deposit, but it would be confusing and noisy when looking at the logs.