### PR TITLE
Change nihms success email processing

### DIFF
--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/NihmsReceiveMailService.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/NihmsReceiveMailService.java
@@ -144,7 +144,7 @@ public class NihmsReceiveMailService {
                 String submissionId = parseSubmissionId(packageId);
                 String nihmsId =  matchResult.group(2);
                 try {
-                    updateDepositAccepted(submissionId, packageId, nihmsId);
+                    updateDepositSuccess(submissionId, packageId, nihmsId);
                 } catch (Exception e) {
                     LOG.error("Error updating nihms deposit for submission ID " + submissionId, e);
                 }
@@ -168,11 +168,11 @@ public class NihmsReceiveMailService {
         });
     }
 
-    private void updateDepositAccepted(String submissionId, String packageId, String nihmsId) throws IOException {
+    private void updateDepositSuccess(String submissionId, String packageId, String nihmsId) throws IOException {
         getDeposits(submissionId, packageId).forEach(deposit -> {
-            deposit.setDepositStatus(DepositStatus.ACCEPTED);
+            deposit.setDepositStatus(DepositStatus.SUBMITTED);
             deposit.setDepositStatusRef(NIHMS_DEP_STATUS_REF_PREFIX + nihmsId);
-            deposit.setStatusMessage(null);
+            deposit.setStatusMessage("Accepted by the NIHMS workflow. NIHMS-ID: " + nihmsId);
             updateDeposit(deposit);
         });
     }

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceIT.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceIT.java
@@ -20,7 +20,6 @@ import static org.awaitility.Awaitility.await;
 import static org.eclipse.pass.deposit.service.NihmsReceiveMailService.NIHMS_DEP_STATUS_REF_PREFIX;
 import static org.eclipse.pass.deposit.util.ResourceTestUtil.findByNameAsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -107,10 +106,10 @@ public class NihmsReceiveMailServiceIT extends AbstractDepositSubmissionIT {
             List<Deposit> actualDeposits = passClient.selectObjects(sel).getObjects();
             assertEquals(1, actualDeposits.size());
             Deposit pmcDeposit = actualDeposits.get(0);
-            assertEquals(DepositStatus.ACCEPTED, pmcDeposit.getDepositStatus());
-            assertEquals(CopyStatus.COMPLETE, pmcDeposit.getRepositoryCopy().getCopyStatus());
+            assertEquals(DepositStatus.SUBMITTED, pmcDeposit.getDepositStatus());
+            assertEquals(CopyStatus.IN_PROGRESS, pmcDeposit.getRepositoryCopy().getCopyStatus());
             assertEquals(NIHMS_DEP_STATUS_REF_PREFIX + "test-nihms-id", pmcDeposit.getDepositStatusRef());
-            assertNull(pmcDeposit.getStatusMessage());
+            assertEquals("Accepted by the NIHMS workflow. NIHMS-ID: test-nihms-id", pmcDeposit.getStatusMessage());
         });
     }
 

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceTest.java
@@ -203,7 +203,7 @@ public class NihmsReceiveMailServiceTest {
     }
 
     private void verifyDepositUpdates() throws IOException {
-        verify(passClient, times(6)).updateObject(passEntityCaptor.capture());
+        verify(passClient, times(5)).updateObject(passEntityCaptor.capture());
         List<Deposit> updatedDeposits = passEntityCaptor.getAllValues().stream()
             .filter(passEntity -> passEntity instanceof Deposit)
             .map(passEntity -> (Deposit) passEntity)
@@ -213,7 +213,7 @@ public class NihmsReceiveMailServiceTest {
             .filter(passEntity -> passEntity instanceof RepositoryCopy)
             .map(passEntity -> (RepositoryCopy) passEntity)
             .toList();
-        assertEquals(3, updatedRepoCopies.size());
+        assertEquals(2, updatedRepoCopies.size());
         Deposit updatedDeposit1 = updatedDeposits.stream()
             .filter(deposit -> deposit.getId().equals("1"))
             .findFirst().get();
@@ -241,15 +241,12 @@ public class NihmsReceiveMailServiceTest {
         Deposit updatedDeposit3 = updatedDeposits.stream()
             .filter(deposit -> deposit.getId().equals("3"))
             .findFirst().get();
-        assertEquals(DepositStatus.ACCEPTED, updatedDeposit3.getDepositStatus());
-        assertEquals(CopyStatus.COMPLETE, updatedDeposit3.getRepositoryCopy().getCopyStatus());
-        assertNull(updatedDeposit3.getStatusMessage());
+        assertEquals(DepositStatus.SUBMITTED, updatedDeposit3.getDepositStatus());
+        assertEquals(CopyStatus.IN_PROGRESS, updatedDeposit3.getRepositoryCopy().getCopyStatus());
+        assertEquals("Accepted by the NIHMS workflow. NIHMS-ID: 1502302", updatedDeposit3.getStatusMessage());
         assertEquals(NihmsReceiveMailService.NIHMS_DEP_STATUS_REF_PREFIX + "1502302",
             updatedDeposit3.getDepositStatusRef());
-        RepositoryCopy updatedRepoCopy3 = updatedRepoCopies.stream()
-            .filter(repositoryCopy -> repositoryCopy.getId().equals("rc-3"))
-            .findFirst().get();
-        assertEquals(CopyStatus.COMPLETE, updatedRepoCopy3.getCopyStatus());
+        assertEquals(CopyStatus.IN_PROGRESS, updatedDeposit3.getRepositoryCopy().getCopyStatus());
     }
 
     @Test


### PR DESCRIPTION
Now the nihms email service will process a success email as follows:

- Set deposit status to Submitted
- Set Deposit.depositStatusRef to `nihms-id:<nihms-id>`
- Set Deposit.statusMessage to `Accepted by the NIHMS workflow. NIHMS-ID: <nihms-id>`