### PR TITLE
Submission status job filters by submission date

### DIFF
--- a/pass-deposit-services/README.md
+++ b/pass-deposit-services/README.md
@@ -163,7 +163,7 @@ any messages relating to the resource. Failed `Deposit` resources will be retrie
 A resource will be considered as failed when errors occur during the processing of `Submission` and `Deposit` resources.
 Some errors may be caused by transient network issues, or a server being rebooted.  In the case of such failures,
 Deposit Services will retry for n number of days after the `Submission` is created. The number of days
-is set in an application property named `pass.deposit.update.window.days`.
+is set in an application property named `pass.status.update.window.days`.
 
 `Submission` resources are failed when:
 
@@ -187,7 +187,7 @@ the user interface, and resubmit it.
 See `DepositTask` for details. Deposits fail for transient reasons; a server being down, an interruption in network
 communication, or invalid credentials for the downstream repository are just a few examples. As stated, DS will retry
 failed `Deposit` resources for n number of days after the creation of the associated `Submission`.  The number of days
-is set in an application property named `pass.deposit.update.window.days`.
+is set in an application property named `pass.status.update.window.days`.
 
 ## Build and Deployment
 

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/DepositUpdater.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/DepositUpdater.java
@@ -18,12 +18,12 @@ package org.eclipse.pass.deposit.service;
 import java.io.IOException;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Objects;
 
 import org.eclipse.pass.deposit.config.repository.Repositories;
 import org.eclipse.pass.deposit.config.repository.RepositoryConfig;
+import org.eclipse.pass.support.client.ModelUtil;
 import org.eclipse.pass.support.client.PassClient;
 import org.eclipse.pass.support.client.PassClientSelector;
 import org.eclipse.pass.support.client.RSQL;
@@ -37,10 +37,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class DepositUpdater {
-
     private static final Logger LOG = LoggerFactory.getLogger(DepositUpdater.class);
-    private static final DateTimeFormatter DATE_TIME_FORMATTER =
-        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
 
     private final PassClient passClient;
     private final DepositTaskHelper depositHelper;
@@ -49,7 +46,7 @@ public class DepositUpdater {
 
     private final List<String> repoKeysWithDepositProcessors;
 
-    @Value("${pass.deposit.update.window.days}")
+    @Value("${pass.status.update.window.days}")
     private long updateWindowDays;
 
     @Autowired
@@ -73,7 +70,7 @@ public class DepositUpdater {
         failedDepositsSelector.setFilter(
             RSQL.and(
                 RSQL.equals("depositStatus", DepositStatus.FAILED.getValue()),
-                RSQL.gte("submission.submittedDate", DATE_TIME_FORMATTER.format(submissionFromDate))
+                RSQL.gte("submission.submittedDate", ModelUtil.dateTimeFormatter().format(submissionFromDate))
             )
         );
         List<Deposit> failedDeposits = passClient.streamObjects(failedDepositsSelector).toList();
@@ -96,7 +93,7 @@ public class DepositUpdater {
         submittedDepositsSelector.setFilter(
             RSQL.and(
                 RSQL.equals("depositStatus", DepositStatus.SUBMITTED.getValue()),
-                RSQL.gte("submission.submittedDate", DATE_TIME_FORMATTER.format(submissionFromDate)),
+                RSQL.gte("submission.submittedDate", ModelUtil.dateTimeFormatter().format(submissionFromDate)),
                 RSQL.in("repository.repositoryKey", repoKeysWithDepositProcessors.toArray(new String[0]))
             )
         );

--- a/pass-deposit-services/deposit-core/src/main/resources/application.properties
+++ b/pass-deposit-services/deposit-core/src/main/resources/application.properties
@@ -41,7 +41,7 @@ pass.deposit.queue.submission.name=${PASS_DEPOSIT_QUEUE_SUBMISSION_NAME:submissi
 pass.deposit.transport.swordv2.sleep-time-ms=10000
 pass.deposit.transport.swordv2.followRedirects=false
 
-pass.deposit.update.window.days=10
+pass.status.update.window.days=10
 
 pass.deposit.jobs.disabled=false
 # By default run all jobs every 10 minutes

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/AbstractDepositSubmissionIT.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/AbstractDepositSubmissionIT.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.ZonedDateTime;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
@@ -138,6 +139,8 @@ public abstract class AbstractDepositSubmissionIT {
     public void triggerSubmission(Submission submission) throws IOException {
         submission.setSubmitted(true);
         submission.setSubmissionStatus(SubmissionStatus.SUBMITTED);
+        submission.setSubmittedDate(ZonedDateTime.now());
+
         passClient.updateObject(submission);
     }
 

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/SubmissionStatusUpdaterIT.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/SubmissionStatusUpdaterIT.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 import org.eclipse.pass.support.client.PassClientSelector;
@@ -70,6 +71,7 @@ public class SubmissionStatusUpdaterIT extends AbstractSubmissionIT {
         // GIVEN
         submission.setSubmissionStatus(SubmissionStatus.SUBMITTED);
         submission.setSubmitted(true);
+        submission.setSubmittedDate(ZonedDateTime.now());
         passClient.updateObject(submission);
         when(statusService.calculateSubmissionStatus(any(Submission.class))).thenReturn(SubmissionStatus.COMPLETE);
         Mockito.clearInvocations(passClient);
@@ -91,6 +93,7 @@ public class SubmissionStatusUpdaterIT extends AbstractSubmissionIT {
         // GIVEN
         submission.setSubmissionStatus(SubmissionStatus.SUBMITTED);
         submission.setSubmitted(true);
+        submission.setSubmittedDate(ZonedDateTime.now());
         passClient.updateObject(submission);
         when(statusService.calculateSubmissionStatus(any(Submission.class))).thenReturn(SubmissionStatus.SUBMITTED);
         Mockito.clearInvocations(passClient);
@@ -107,6 +110,7 @@ public class SubmissionStatusUpdaterIT extends AbstractSubmissionIT {
         // GIVEN
         submission.setSubmissionStatus(null);
         submission.setSubmitted(true);
+        submission.setSubmittedDate(ZonedDateTime.now());
         passClient.updateObject(submission);
         when(statusService.calculateSubmissionStatus(any(Submission.class))).thenReturn(SubmissionStatus.SUBMITTED);
         Mockito.clearInvocations(passClient);
@@ -123,6 +127,7 @@ public class SubmissionStatusUpdaterIT extends AbstractSubmissionIT {
         // GIVEN
         submission.setSubmissionStatus(SubmissionStatus.SUBMITTED);
         submission.setSubmitted(false);
+        submission.setSubmittedDate(ZonedDateTime.now());
         passClient.updateObject(submission);
         Mockito.clearInvocations(passClient);
 


### PR DESCRIPTION
The submission status job now like the deposit status job only updates submissions within a certain window of days of submitted date. They both use the same property.

Changes:
 * Rename property pass.deposit.update.window.days to pass.status.update.window.days.
  * Change submission status job to only check submissions within pass.status.update.window.days days.
  * Minor cleanups