### PR TITLE
Modify pass-core test container to use basic auth in wait strategy.

### DIFF
--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/AbstractDepositSubmissionIT.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/AbstractDepositSubmissionIT.java
@@ -95,7 +95,7 @@ public abstract class AbstractDepositSubmissionIT {
         .withEnv("PASS_CORE_BASE_URL", "http://localhost:8080")
         .withEnv("PASS_CORE_BACKEND_USER", "backend")
         .withEnv("PASS_CORE_BACKEND_PASSWORD", "backend")
-        .waitingFor(Wait.forHttp("/data/grant").forStatusCode(401))
+        .waitingFor(Wait.forHttp("/data/grant").forStatusCode(200).withBasicCredentials("backend", "backend"))
         .withExposedPorts(8080);
 
     @Autowired protected SubmissionTestUtil submissionTestUtil;

--- a/pass-grant-loader/src/test/java/org/eclipse/pass/support/grant/AbstractIntegrationTest.java
+++ b/pass-grant-loader/src/test/java/org/eclipse/pass/support/grant/AbstractIntegrationTest.java
@@ -62,7 +62,7 @@ public abstract class AbstractIntegrationTest {
         .withEnv("PASS_CORE_BASE_URL", "http://localhost:8080")
         .withEnv("PASS_CORE_BACKEND_USER", "backend")
         .withEnv("PASS_CORE_BACKEND_PASSWORD", "backend")
-        .waitingFor(Wait.forHttp("/data/grant").forStatusCode(401))
+        .waitingFor(Wait.forHttp("/data/grant").forStatusCode(200).withBasicCredentials("backend", "backend"))
         .withExposedPorts(8080);
 
     @SpyBean protected PassClient passClient;

--- a/pass-nihms-loader/nihms-data-transform-load/src/test/java/org/eclipse/pass/loader/nihms/NihmsSubmissionEtlITBase.java
+++ b/pass-nihms-loader/nihms-data-transform-load/src/test/java/org/eclipse/pass/loader/nihms/NihmsSubmissionEtlITBase.java
@@ -91,7 +91,7 @@ public abstract class NihmsSubmissionEtlITBase {
         .withEnv("PASS_CORE_BASE_URL", "http://localhost:8080")
         .withEnv("PASS_CORE_BACKEND_USER", "backend")
         .withEnv("PASS_CORE_BACKEND_PASSWORD", "backend")
-        .waitingFor(Wait.forHttp("/data/grant").forStatusCode(401))
+        .waitingFor(Wait.forHttp("/data/grant").forStatusCode(200).withBasicCredentials("backend", "backend"))
         .withExposedPorts(8080);
 
     @DynamicPropertySource

--- a/pass-notification-service/src/test/java/org/eclipse/pass/notification/service/NotificationServiceIT.java
+++ b/pass-notification-service/src/test/java/org/eclipse/pass/notification/service/NotificationServiceIT.java
@@ -91,7 +91,7 @@ public class NotificationServiceIT extends AbstractNotificationSpringIntegration
         .withEnv("PASS_CORE_BASE_URL", "http://localhost:8080")
         .withEnv("PASS_CORE_BACKEND_USER", "backend")
         .withEnv("PASS_CORE_BACKEND_PASSWORD", "backend")
-        .waitingFor(Wait.forHttp("/data/grant").forStatusCode(401))
+        .waitingFor(Wait.forHttp("/data/grant").forStatusCode(200).withBasicCredentials("backend", "backend"))
         .withExposedPorts(8080);
 
     @RegisterExtension


### PR DESCRIPTION
This is needed for new version of pass-core which takes over the reverse proxy role.