### PR TITLE
Add deployment test data job

### DIFF
--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/JsonApiPassClient.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/JsonApiPassClient.java
@@ -675,6 +675,23 @@ public class JsonApiPassClient implements PassClient {
     }
 
     @Override
+    public void deleteFile(File file) throws IOException {
+        // Transform File URI to use baseUrl in order to avoid authentication issues
+        HttpUrl urlFileBin = HttpUrl.parse(baseUrl).newBuilder()
+            .addEncodedPathSegments(file.getUri().getRawPath().substring(1)).build();
+
+        Request requestFileBin = new Request.Builder().url(urlFileBin).delete().build();
+        Response responseFileBin = client.newCall(requestFileBin).execute();
+
+        if (!responseFileBin.isSuccessful() && responseFileBin.code() != 404) {
+            throw new IOException(String.format("Failed to delete for File: %s, URL: %s, Status code: %d",
+                file.getId(), urlFileBin, responseFileBin.code()));
+        }
+
+        deleteObject(file);
+    }
+
+    @Override
     public URI uploadBinary(String name, byte[] data) throws IOException {
         HttpUrl url = HttpUrl.parse(baseUrl).newBuilder()
                 .addEncodedPathSegment("file").build();

--- a/pass-data-client/src/main/java/org/eclipse/pass/support/client/PassClient.java
+++ b/pass-data-client/src/main/java/org/eclipse/pass/support/client/PassClient.java
@@ -212,6 +212,13 @@ public interface PassClient {
     InputStream downloadFile(File file) throws IOException;
 
     /**
+     * Deletes the binary data associated to the File parameter and the File entity.
+     * @param file the File to delete
+     * @throws IOException if operation fails
+     */
+    void deleteFile(File file) throws IOException;
+
+    /**
      * @param id of File
      * @return InputStream of bytes
      * @throws IOException if operation fails

--- a/pass-data-client/src/test/java/org/eclipse/pass/support/client/JsonApiPassClientIT.java
+++ b/pass-data-client/src/test/java/org/eclipse/pass/support/client/JsonApiPassClientIT.java
@@ -3,6 +3,7 @@ package org.eclipse.pass.support.client;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -736,5 +737,30 @@ public class JsonApiPassClientIT {
         String test_data = new String(is.readAllBytes(), StandardCharsets.UTF_8);
 
         assertEquals(data, test_data);
+    }
+
+    @Test
+    public void testDeleteFile() throws IOException {
+        // GIVEN
+        File file = new File();
+        String data = "What's in a name?";
+        file.setName("rose.txt");
+        URI data_uri = client.uploadBinary(file.getName(), data.getBytes(StandardCharsets.UTF_8));
+        assertNotNull(data_uri);
+        file.setUri(data_uri);
+        client.createObject(file);
+
+        // WHEN
+        client.deleteFile(file);
+
+        // THEN
+        IOException ioExBin = assertThrows(IOException.class, () -> {
+            client.downloadFile(file);
+        });
+        assertEquals("Failed to retrieve binary for File: " + file.getId() + ", URL: "
+            + file.getUri().toString() + ", Status code: 404", ioExBin.getMessage());
+
+        File actualFile = client.getObject(File.class, file.getId());
+        assertNull(actualFile);
     }
 }

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/DeploymentTestDataService.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/DeploymentTestDataService.java
@@ -42,6 +42,8 @@ import org.springframework.stereotype.Component;
 public class DeploymentTestDataService {
     private static final Logger LOG = LoggerFactory.getLogger(DeploymentTestDataService.class);
 
+    static final String PASS_E2E_TEST_GRANT = "PASS_E2E_TEST_GRANT";
+
     private final PassClient passClient;
 
     @Value("${pass.test.data.policy.title}")
@@ -58,7 +60,7 @@ public class DeploymentTestDataService {
     public void processTestData() throws IOException {
         LOG.warn("Deployment Test Data Service running...");
         PassClientSelector<Grant> grantSelector = new PassClientSelector<>(Grant.class);
-        grantSelector.setFilter(RSQL.equals("projectName", "PASS_E2E_TEST_GRANT"));
+        grantSelector.setFilter(RSQL.equals("projectName", PASS_E2E_TEST_GRANT));
         List<Grant> testGrants = passClient.streamObjects(grantSelector).toList();
         Grant testGrant = testGrants.isEmpty() ? createTestGrantData() : testGrants.get(0);
         deleteTestSubmissions(testGrant);
@@ -121,7 +123,7 @@ public class DeploymentTestDataService {
         passClient.createObject(testFunder);
 
         Grant testGrant = new Grant();
-        testGrant.setProjectName("PASS_E2E_TEST_GRANT");
+        testGrant.setProjectName(PASS_E2E_TEST_GRANT);
         testGrant.setAwardNumber("TEST_E2E_AWD_NUM");
         testGrant.setLocalKey("PASS_E2E_TEST_GRANT_LK");
         testGrant.setAwardDate(ZonedDateTime.parse("2020-02-01T00:00:00Z"));

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/DeploymentTestDataService.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/DeploymentTestDataService.java
@@ -25,6 +25,7 @@ import org.eclipse.pass.support.client.PassClientSelector;
 import org.eclipse.pass.support.client.RSQL;
 import org.eclipse.pass.support.client.model.AwardStatus;
 import org.eclipse.pass.support.client.model.Deposit;
+import org.eclipse.pass.support.client.model.File;
 import org.eclipse.pass.support.client.model.Funder;
 import org.eclipse.pass.support.client.model.Grant;
 import org.eclipse.pass.support.client.model.Journal;
@@ -87,6 +88,10 @@ public class DeploymentTestDataService {
                     deleteObject(testDeposit);
                     deleteObject(testDeposit.getRepositoryCopy());
                 });
+                PassClientSelector<File> testFileSelector = new PassClientSelector<>(File.class);
+                testFileSelector.setFilter(RSQL.equals("submission.id", testSubmission.getId()));
+                List<File> testFiles = passClient.streamObjects(testFileSelector).toList();
+                testFiles.forEach(this::deleteFile);
                 deleteObject(testSubmission);
                 deleteObject(testSubmission.getPublication());
             } catch (IOException e) {
@@ -99,6 +104,14 @@ public class DeploymentTestDataService {
     private void deleteObject(PassEntity entity) {
         try {
             passClient.deleteObject(entity);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void deleteFile(File file) {
+        try {
+            passClient.deleteFile(file);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/DeploymentTestDataService.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/DeploymentTestDataService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Johns Hopkins University
+ * Copyright 2024 Johns Hopkins University
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/DeploymentTestDataService.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/DeploymentTestDataService.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.deposit.service;
+
+import java.io.IOException;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import org.eclipse.pass.support.client.ModelUtil;
+import org.eclipse.pass.support.client.PassClient;
+import org.eclipse.pass.support.client.PassClientSelector;
+import org.eclipse.pass.support.client.RSQL;
+import org.eclipse.pass.support.client.model.AwardStatus;
+import org.eclipse.pass.support.client.model.Deposit;
+import org.eclipse.pass.support.client.model.Funder;
+import org.eclipse.pass.support.client.model.Grant;
+import org.eclipse.pass.support.client.model.Journal;
+import org.eclipse.pass.support.client.model.PassEntity;
+import org.eclipse.pass.support.client.model.Policy;
+import org.eclipse.pass.support.client.model.Submission;
+import org.eclipse.pass.support.client.model.User;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DeploymentTestDataService {
+    private static final Logger LOG = LoggerFactory.getLogger(DeploymentTestDataService.class);
+
+    private final PassClient passClient;
+
+    @Value("${pass.test.data.policy.title}")
+    private String testPolicyTitle;
+
+    @Value("${pass.test.data.user.email}")
+    private String testUserEmail;
+
+    @Autowired
+    public DeploymentTestDataService(PassClient passClient) {
+        this.passClient = passClient;
+    }
+
+    public void processTestData() throws IOException {
+        LOG.warn("Deployment Test Data Service running...");
+        PassClientSelector<Grant> grantSelector = new PassClientSelector<>(Grant.class);
+        grantSelector.setFilter(RSQL.equals("projectName", "PASS_E2E_TEST_GRANT"));
+        List<Grant> testGrants = passClient.streamObjects(grantSelector).toList();
+        Grant testGrant = testGrants.isEmpty() ? createTestGrantData() : testGrants.get(0);
+        deleteTestSubmissions(testGrant);
+    }
+
+    private void deleteTestSubmissions(Grant testGrant) throws IOException {
+        LOG.warn("Deleting Test Submissions");
+        ZonedDateTime submissionToDate = ZonedDateTime.now().minusDays(1);
+        PassClientSelector<Submission> testSubmissionSelector = new PassClientSelector<>(Submission.class);
+        testSubmissionSelector.setFilter(RSQL.and(
+            RSQL.equals("grants.id",  testGrant.getId()),
+            RSQL.lte("submittedDate", ModelUtil.dateTimeFormatter().format(submissionToDate))
+        ));
+        testSubmissionSelector.setInclude("publication");
+        List<Submission> testSubmissions = passClient.streamObjects(testSubmissionSelector).toList();
+        testSubmissions.forEach(testSubmission -> {
+            try {
+                PassClientSelector<Deposit> testDepositSelector = new PassClientSelector<>(Deposit.class);
+                testDepositSelector.setFilter(RSQL.equals("submission.id", testSubmission.getId()));
+                testDepositSelector.setInclude("repositoryCopy");
+                List<Deposit> testDeposits = passClient.streamObjects(testDepositSelector).toList();
+                testDeposits.forEach(testDeposit -> {
+                    deleteObject(testDeposit);
+                    deleteObject(testDeposit.getRepositoryCopy());
+                });
+                deleteObject(testSubmission);
+                deleteObject(testSubmission.getPublication());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        LOG.warn("Deleted {} Test Submissions", testSubmissions.size());
+    }
+
+    private void deleteObject(PassEntity entity) {
+        try {
+            passClient.deleteObject(entity);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Grant createTestGrantData() throws IOException {
+        LOG.warn("Creating Test Grant Data");
+        Journal testJournal = new Journal();
+        testJournal.setJournalName("PASS_E2E_TEST_JOURNAL");
+        testJournal.setIssns(List.of("Print:test-fake"));
+        passClient.createObject(testJournal);
+
+        PassClientSelector<Policy> policySelector = new PassClientSelector<>(Policy.class);
+        policySelector.setFilter(RSQL.equals("title", testPolicyTitle));
+        List<Policy> testPolicies = passClient.streamObjects(policySelector).toList();
+        Policy testPolicy = testPolicies.get(0);
+
+        Funder testFunder = new Funder();
+        testFunder.setLocalKey("E2E_TEST_FUNDER_LK");
+        testFunder.setName("PASS_E2E_TEST_FUNDER");
+        testFunder.setPolicy(testPolicy);
+        passClient.createObject(testFunder);
+
+        Grant testGrant = new Grant();
+        testGrant.setProjectName("PASS_E2E_TEST_GRANT");
+        testGrant.setAwardNumber("TEST_E2E_AWD_NUM");
+        testGrant.setLocalKey("PASS_E2E_TEST_GRANT_LK");
+        testGrant.setAwardDate(ZonedDateTime.parse("2020-02-01T00:00:00Z"));
+        testGrant.setStartDate(ZonedDateTime.parse("2020-01-01T00:00:00Z"));
+        testGrant.setEndDate(ZonedDateTime.parse("2088-01-01T00:00:00Z"));
+        testGrant.setAwardStatus(AwardStatus.ACTIVE);
+        testGrant.setDirectFunder(testFunder);
+        testGrant.setPrimaryFunder(testFunder);
+
+        PassClientSelector<User> userSelector = new PassClientSelector<>(User.class);
+        userSelector.setFilter(RSQL.equals("email", testUserEmail));
+        List<User> testUsers = passClient.streamObjects(userSelector).toList();
+        User testUser = testUsers.get(0);
+        testGrant.setPi(testUser);
+
+        passClient.createObject(testGrant);
+        return testGrant;
+    }
+
+}

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/DeploymentTestDataService.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/DeploymentTestDataService.java
@@ -62,6 +62,7 @@ public class DeploymentTestDataService {
         List<Grant> testGrants = passClient.streamObjects(grantSelector).toList();
         Grant testGrant = testGrants.isEmpty() ? createTestGrantData() : testGrants.get(0);
         deleteTestSubmissions(testGrant);
+        LOG.warn("Done running Deployment Test Data Service");
     }
 
     private void deleteTestSubmissions(Grant testGrant) throws IOException {

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/support/jobs/DeploymentTestDataJob.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/support/jobs/DeploymentTestDataJob.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.deposit.support.jobs;
+
+import org.eclipse.pass.deposit.service.DeploymentTestDataService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@ConditionalOnExpression(
+    "'${pass.test.data.job.enabled}'=='true' and '${pass.deposit.jobs.disabled}'=='false'"
+)
+@Component
+public class DeploymentTestDataJob {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DeploymentTestDataJob.class);
+
+    private final DeploymentTestDataService deploymentTestDataService;
+
+    public DeploymentTestDataJob(DeploymentTestDataService deploymentTestDataService) {
+        this.deploymentTestDataService = deploymentTestDataService;
+    }
+
+    @Scheduled(
+        fixedDelayString = "${pass.test.data.job.interval-ms}",
+        initialDelayString = "${pass.deposit.jobs.3.init.delay}"
+    )
+    public void processDeploymentTestData() {
+        LOG.warn("Starting {}", this.getClass().getSimpleName());
+        try {
+            deploymentTestDataService.processTestData();
+        } catch (Exception e) {
+            LOG.error("DeploymentTestDataJob execution failed: {}", e.getMessage(), e);
+        }
+        LOG.warn("Finished {}", this.getClass().getSimpleName());
+    }
+
+}

--- a/pass-deposit-services/deposit-core/src/main/resources/application.properties
+++ b/pass-deposit-services/deposit-core/src/main/resources/application.properties
@@ -48,6 +48,7 @@ pass.deposit.jobs.disabled=false
 pass.deposit.jobs.default-interval-ms=600000
 pass.deposit.jobs.1.init.delay=5000
 pass.deposit.jobs.2.init.delay=10000
+pass.deposit.jobs.3.init.delay=20000
 
 jscholarship.hack.sword.statement.uri-prefix=http://dspace-prod.mse.jhu.edu:8080/swordv2/
 jscholarship.hack.sword.statement.uri-replacement=https://jscholarship.library.jhu.edu/swordv2/
@@ -67,5 +68,8 @@ pass.deposit.nihms.email.delay=720000
 pass.deposit.nihms.email.auth=${NIHMS_MAIL_AUTH:LOGIN}
 pass.deposit.nihms.email.from=${PASS_DEPOSIT_NIHMS_EMAIL_FROM:nihms-help@ncbi.nlm.nih.gov}
 
+pass.test.data.job.enabled=false
+# Run every 12 hours
+pass.test.data.job.interval-ms=43200000
 pass.test.data.policy.title=${TEST_DATA_POLICY_TITLE:}
 pass.test.data.user.email=${TEST_DATA_USER_EMAIL:}

--- a/pass-deposit-services/deposit-core/src/main/resources/application.properties
+++ b/pass-deposit-services/deposit-core/src/main/resources/application.properties
@@ -66,3 +66,6 @@ pass.deposit.nihms.email.enabled=false
 pass.deposit.nihms.email.delay=720000
 pass.deposit.nihms.email.auth=${NIHMS_MAIL_AUTH:LOGIN}
 pass.deposit.nihms.email.from=${PASS_DEPOSIT_NIHMS_EMAIL_FROM:nihms-help@ncbi.nlm.nih.gov}
+
+pass.test.data.policy.title=${TEST_DATA_POLICY_TITLE:}
+pass.test.data.user.email=${TEST_DATA_USER_EMAIL:}

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/DeploymentTestDataServiceIT.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/DeploymentTestDataServiceIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Johns Hopkins University
+ * Copyright 2024 Johns Hopkins University
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/DeploymentTestDataServiceIT.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/DeploymentTestDataServiceIT.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2023 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.deposit.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import org.eclipse.pass.support.client.PassClientSelector;
+import org.eclipse.pass.support.client.RSQL;
+import org.eclipse.pass.support.client.model.AwardStatus;
+import org.eclipse.pass.support.client.model.Deposit;
+import org.eclipse.pass.support.client.model.DepositStatus;
+import org.eclipse.pass.support.client.model.Grant;
+import org.eclipse.pass.support.client.model.PassEntity;
+import org.eclipse.pass.support.client.model.Policy;
+import org.eclipse.pass.support.client.model.Publication;
+import org.eclipse.pass.support.client.model.Repository;
+import org.eclipse.pass.support.client.model.RepositoryCopy;
+import org.eclipse.pass.support.client.model.Submission;
+import org.eclipse.pass.support.client.model.User;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * @author Russ Poetker (rpoetke1@jh.edu)
+ */
+@TestPropertySource(properties = {
+    "pass.test.data.policy.title=test-policy-title",
+    "pass.test.data.user.email=test-user-email@foo"
+})
+public class DeploymentTestDataServiceIT extends AbstractDepositIT {
+
+    @Autowired private DeploymentTestDataService deploymentTestDataService;
+
+    @BeforeEach
+    public void initPolicyAndUser() throws IOException {
+        PassClientSelector<Policy> selector = new PassClientSelector<>(Policy.class);
+        selector.setFilter(RSQL.equals("title", "test-policy-title"));
+        List<Policy> testPolicies = passClient.streamObjects(selector).toList();
+        if (testPolicies.isEmpty()) {
+            Policy policy = new Policy();
+            policy.setTitle("test-policy-title");
+            passClient.createObject(policy);
+            User testUser = new User();
+            testUser.setFirstName("test");
+            testUser.setLastName("user");
+            testUser.setEmail("test-user-email@foo");
+            passClient.createObject(testUser);
+        }
+    }
+
+    @AfterEach
+    public void cleanUp() throws IOException {
+        PassClientSelector<Grant> grantSelector = new PassClientSelector<>(Grant.class);
+        grantSelector.setFilter(RSQL.equals("projectName", "PASS_E2E_TEST_GRANT"));
+        List<Grant> testGrants = passClient.streamObjects(grantSelector).toList();
+        testGrants.forEach(this::deleteObject);
+        PassClientSelector<Deposit> depositSelector = new PassClientSelector<>(Deposit.class);
+        List<Deposit> testDeposits = passClient.streamObjects(depositSelector).toList();
+        testDeposits.forEach(this::deleteObject);
+        PassClientSelector<RepositoryCopy> repoCopySelector = new PassClientSelector<>(RepositoryCopy.class);
+        List<RepositoryCopy> testRepoCopies = passClient.streamObjects(repoCopySelector).toList();
+        testRepoCopies.forEach(this::deleteObject);
+        PassClientSelector<Submission> submissionSelector = new PassClientSelector<>(Submission.class);
+        List<Submission> testSubmissions = passClient.streamObjects(submissionSelector).toList();
+        testSubmissions.forEach(this::deleteObject);
+        PassClientSelector<Publication> publicationSelector = new PassClientSelector<>(Publication.class);
+        List<Publication> testPublications = passClient.streamObjects(publicationSelector).toList();
+        testPublications.forEach(this::deleteObject);
+    }
+
+    private void deleteObject(PassEntity entity) {
+        try {
+            passClient.deleteObject(entity);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testProcessData_TestGrantDataCreatedIfNotExist() throws Exception {
+        // WHEN
+        deploymentTestDataService.processTestData();
+
+        // THEN
+        PassClientSelector<Grant> grantSelector = new PassClientSelector<>(Grant.class);
+        grantSelector.setFilter(RSQL.equals("projectName", "PASS_E2E_TEST_GRANT"));
+        grantSelector.setInclude("pi", "directFunder", "primaryFunder");
+        List<Grant> testGrants = passClient.streamObjects(grantSelector).toList();
+        assertEquals(1, testGrants.size());
+        Grant actualTestGrant = testGrants.get(0);
+        assertEquals("PASS_E2E_TEST_GRANT", actualTestGrant.getProjectName());
+        assertEquals(AwardStatus.ACTIVE, actualTestGrant.getAwardStatus());
+        assertEquals("test-user-email@foo", actualTestGrant.getPi().getEmail());
+        assertEquals("PASS_E2E_TEST_FUNDER", actualTestGrant.getDirectFunder().getName());
+        assertEquals("PASS_E2E_TEST_FUNDER", actualTestGrant.getPrimaryFunder().getName());
+    }
+
+    @Test
+    public void testProcessData_DoesNotTestGrantDataCreatedIfExist() throws Exception {
+        // GIVEN
+        Grant testGrant = new Grant();
+        testGrant.setProjectName("PASS_E2E_TEST_GRANT");
+        testGrant.setAwardStatus(AwardStatus.ACTIVE);
+        passClient.createObject(testGrant);
+        Mockito.reset(passClient);
+
+        // WHEN
+        deploymentTestDataService.processTestData();
+
+        // THEN
+        PassClientSelector<Grant> grantSelector = new PassClientSelector<>(Grant.class);
+        grantSelector.setFilter(RSQL.equals("projectName", "PASS_E2E_TEST_GRANT"));
+        List<Grant> testGrants = passClient.streamObjects(grantSelector).toList();
+        assertEquals(1, testGrants.size());
+        Grant actualTestGrant = testGrants.get(0);
+        assertEquals(testGrant.getId(), actualTestGrant.getId());
+        assertEquals("PASS_E2E_TEST_GRANT", actualTestGrant.getProjectName());
+        assertEquals(AwardStatus.ACTIVE, actualTestGrant.getAwardStatus());
+        verify(passClient, times(0)).createObject(any());
+    }
+
+    @Test
+    public void testProcessData_DeleteTestSubmissionsForTestGrant() throws Exception {
+        // GIVEN
+        Grant testGrant = new Grant();
+        testGrant.setProjectName("PASS_E2E_TEST_GRANT");
+        testGrant.setAwardStatus(AwardStatus.ACTIVE);
+        passClient.createObject(testGrant);
+        initSubmissionAndDeposits(testGrant);
+
+        // WHEN
+        deploymentTestDataService.processTestData();
+
+        // THEN
+        PassClientSelector<Grant> grantSelector = new PassClientSelector<>(Grant.class);
+        grantSelector.setFilter(RSQL.equals("projectName", "PASS_E2E_TEST_GRANT"));
+        List<Grant> testGrants = passClient.streamObjects(grantSelector).toList();
+        assertEquals(1, testGrants.size());
+        Grant actualTestGrant = testGrants.get(0);
+        assertEquals("PASS_E2E_TEST_GRANT", actualTestGrant.getProjectName());
+        assertEquals(AwardStatus.ACTIVE, actualTestGrant.getAwardStatus());
+        PassClientSelector<Deposit> depositSelector = new PassClientSelector<>(Deposit.class);
+        List<Deposit> testDeposits = passClient.streamObjects(depositSelector).toList();
+        assertTrue(testDeposits.isEmpty());
+        PassClientSelector<RepositoryCopy> repoCopySelector = new PassClientSelector<>(RepositoryCopy.class);
+        List<RepositoryCopy> testRepoCopies = passClient.streamObjects(repoCopySelector).toList();
+        assertTrue(testRepoCopies.isEmpty());
+        PassClientSelector<Submission> submissionSelector = new PassClientSelector<>(Submission.class);
+        List<Submission> testSubmissions = passClient.streamObjects(submissionSelector).toList();
+        assertTrue(testSubmissions.isEmpty());
+        PassClientSelector<Publication> publicationSelector = new PassClientSelector<>(Publication.class);
+        List<Publication> testPublications = passClient.streamObjects(publicationSelector).toList();
+        assertTrue(testPublications.isEmpty());
+    }
+
+    @Test
+    public void testProcessData_DoesNotDeleteTestSubmissionsForOtherGrant() throws Exception {
+        // GIVEN
+        Grant testGrant = new Grant();
+        testGrant.setProjectName("Some Other Grant");
+        testGrant.setAwardStatus(AwardStatus.ACTIVE);
+        passClient.createObject(testGrant);
+        Submission testSubmission = initSubmissionAndDeposits(testGrant);
+
+        // WHEN
+        deploymentTestDataService.processTestData();
+
+        // THEN
+        PassClientSelector<Grant> grantSelector = new PassClientSelector<>(Grant.class);
+        grantSelector.setFilter(RSQL.equals("projectName", "PASS_E2E_TEST_GRANT"));
+        List<Grant> testGrants = passClient.streamObjects(grantSelector).toList();
+        assertEquals(1, testGrants.size());
+        Grant actualTestGrant = testGrants.get(0);
+        assertEquals("PASS_E2E_TEST_GRANT", actualTestGrant.getProjectName());
+        assertEquals(AwardStatus.ACTIVE, actualTestGrant.getAwardStatus());
+        PassClientSelector<Deposit> depositSelector = new PassClientSelector<>(Deposit.class);
+        List<Deposit> testDeposits = passClient.streamObjects(depositSelector).toList();
+        assertFalse(testDeposits.isEmpty());
+        PassClientSelector<RepositoryCopy> repoCopySelector = new PassClientSelector<>(RepositoryCopy.class);
+        List<RepositoryCopy> testRepoCopies = passClient.streamObjects(repoCopySelector).toList();
+        assertFalse(testRepoCopies.isEmpty());
+        PassClientSelector<Publication> publicationSelector = new PassClientSelector<>(Publication.class);
+        List<Publication> testPublications = passClient.streamObjects(publicationSelector).toList();
+        assertFalse(testPublications.isEmpty());
+        PassClientSelector<Submission> submissionSelector = new PassClientSelector<>(Submission.class);
+        submissionSelector.setInclude("grants");
+        List<Submission> testSubmissions = passClient.streamObjects(submissionSelector).toList();
+        assertFalse(testSubmissions.isEmpty());
+        Submission actualSubmission = testSubmissions.get(0);
+        assertEquals(testSubmission.getId(), actualSubmission.getId());
+    }
+
+    private Submission initSubmissionAndDeposits(Grant testGrant) throws Exception {
+        Submission submission = new Submission();
+        submission.setGrants(List.of(testGrant));
+        submission.setSubmittedDate(ZonedDateTime.now().minusDays(2));
+        passClient.createObject(submission);
+
+        Repository repository = new Repository();
+        repository.setName("test-repository");
+        passClient.createObject(repository);
+
+        Publication publication = new Publication();
+        publication.setTitle("test-publication");
+        passClient.createObject(publication);
+
+        RepositoryCopy repositoryCopy = new RepositoryCopy();
+        repositoryCopy.setRepository(repository);
+        repositoryCopy.setPublication(publication);
+        passClient.createObject(repositoryCopy);
+
+        Deposit j10pDeposit = new Deposit();
+        j10pDeposit.setSubmission(submission);
+        j10pDeposit.setDepositStatus(DepositStatus.SUBMITTED);
+        j10pDeposit.setRepositoryCopy(repositoryCopy);
+        passClient.createObject(j10pDeposit);
+
+        submission.setPublication(publication);
+        passClient.updateObject(submission);
+
+        return submission;
+    }
+
+}

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/DeploymentTestDataServiceIT.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/DeploymentTestDataServiceIT.java
@@ -15,6 +15,7 @@
  */
 package org.eclipse.pass.deposit.service;
 
+import static org.eclipse.pass.deposit.service.DeploymentTestDataService.PASS_E2E_TEST_GRANT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -76,7 +77,7 @@ public class DeploymentTestDataServiceIT extends AbstractDepositIT {
     @AfterEach
     public void cleanUp() throws IOException {
         PassClientSelector<Grant> grantSelector = new PassClientSelector<>(Grant.class);
-        grantSelector.setFilter(RSQL.equals("projectName", "PASS_E2E_TEST_GRANT"));
+        grantSelector.setFilter(RSQL.equals("projectName", PASS_E2E_TEST_GRANT));
         List<Grant> testGrants = passClient.streamObjects(grantSelector).toList();
         testGrants.forEach(this::deleteObject);
         PassClientSelector<Deposit> depositSelector = new PassClientSelector<>(Deposit.class);
@@ -108,12 +109,12 @@ public class DeploymentTestDataServiceIT extends AbstractDepositIT {
 
         // THEN
         PassClientSelector<Grant> grantSelector = new PassClientSelector<>(Grant.class);
-        grantSelector.setFilter(RSQL.equals("projectName", "PASS_E2E_TEST_GRANT"));
+        grantSelector.setFilter(RSQL.equals("projectName", PASS_E2E_TEST_GRANT));
         grantSelector.setInclude("pi", "directFunder", "primaryFunder");
         List<Grant> testGrants = passClient.streamObjects(grantSelector).toList();
         assertEquals(1, testGrants.size());
         Grant actualTestGrant = testGrants.get(0);
-        assertEquals("PASS_E2E_TEST_GRANT", actualTestGrant.getProjectName());
+        assertEquals(PASS_E2E_TEST_GRANT, actualTestGrant.getProjectName());
         assertEquals(AwardStatus.ACTIVE, actualTestGrant.getAwardStatus());
         assertEquals("test-user-email@foo", actualTestGrant.getPi().getEmail());
         assertEquals("PASS_E2E_TEST_FUNDER", actualTestGrant.getDirectFunder().getName());
@@ -124,7 +125,7 @@ public class DeploymentTestDataServiceIT extends AbstractDepositIT {
     public void testProcessData_DoesNotTestGrantDataCreatedIfExist() throws Exception {
         // GIVEN
         Grant testGrant = new Grant();
-        testGrant.setProjectName("PASS_E2E_TEST_GRANT");
+        testGrant.setProjectName(PASS_E2E_TEST_GRANT);
         testGrant.setAwardStatus(AwardStatus.ACTIVE);
         passClient.createObject(testGrant);
         Mockito.reset(passClient);
@@ -134,12 +135,12 @@ public class DeploymentTestDataServiceIT extends AbstractDepositIT {
 
         // THEN
         PassClientSelector<Grant> grantSelector = new PassClientSelector<>(Grant.class);
-        grantSelector.setFilter(RSQL.equals("projectName", "PASS_E2E_TEST_GRANT"));
+        grantSelector.setFilter(RSQL.equals("projectName", PASS_E2E_TEST_GRANT));
         List<Grant> testGrants = passClient.streamObjects(grantSelector).toList();
         assertEquals(1, testGrants.size());
         Grant actualTestGrant = testGrants.get(0);
         assertEquals(testGrant.getId(), actualTestGrant.getId());
-        assertEquals("PASS_E2E_TEST_GRANT", actualTestGrant.getProjectName());
+        assertEquals(PASS_E2E_TEST_GRANT, actualTestGrant.getProjectName());
         assertEquals(AwardStatus.ACTIVE, actualTestGrant.getAwardStatus());
         verify(passClient, times(0)).createObject(any());
     }
@@ -148,7 +149,7 @@ public class DeploymentTestDataServiceIT extends AbstractDepositIT {
     public void testProcessData_DeleteTestSubmissionsForTestGrant() throws Exception {
         // GIVEN
         Grant testGrant = new Grant();
-        testGrant.setProjectName("PASS_E2E_TEST_GRANT");
+        testGrant.setProjectName(PASS_E2E_TEST_GRANT);
         testGrant.setAwardStatus(AwardStatus.ACTIVE);
         passClient.createObject(testGrant);
         initSubmissionAndDeposits(testGrant);
@@ -158,11 +159,11 @@ public class DeploymentTestDataServiceIT extends AbstractDepositIT {
 
         // THEN
         PassClientSelector<Grant> grantSelector = new PassClientSelector<>(Grant.class);
-        grantSelector.setFilter(RSQL.equals("projectName", "PASS_E2E_TEST_GRANT"));
+        grantSelector.setFilter(RSQL.equals("projectName", PASS_E2E_TEST_GRANT));
         List<Grant> testGrants = passClient.streamObjects(grantSelector).toList();
         assertEquals(1, testGrants.size());
         Grant actualTestGrant = testGrants.get(0);
-        assertEquals("PASS_E2E_TEST_GRANT", actualTestGrant.getProjectName());
+        assertEquals(PASS_E2E_TEST_GRANT, actualTestGrant.getProjectName());
         assertEquals(AwardStatus.ACTIVE, actualTestGrant.getAwardStatus());
         PassClientSelector<Deposit> depositSelector = new PassClientSelector<>(Deposit.class);
         List<Deposit> testDeposits = passClient.streamObjects(depositSelector).toList();
@@ -182,7 +183,7 @@ public class DeploymentTestDataServiceIT extends AbstractDepositIT {
     public void testProcessData_DoesNotDeleteTestSubmissionsForOtherGrant() throws Exception {
         // GIVEN
         Grant deploymentGrant = new Grant();
-        deploymentGrant.setProjectName("PASS_E2E_TEST_GRANT");
+        deploymentGrant.setProjectName(PASS_E2E_TEST_GRANT);
         deploymentGrant.setAwardStatus(AwardStatus.ACTIVE);
         passClient.createObject(deploymentGrant);
         initSubmissionAndDeposits(deploymentGrant);
@@ -198,11 +199,11 @@ public class DeploymentTestDataServiceIT extends AbstractDepositIT {
 
         // THEN
         final PassClientSelector<Grant> grantSelector = new PassClientSelector<>(Grant.class);
-        grantSelector.setFilter(RSQL.equals("projectName", "PASS_E2E_TEST_GRANT"));
+        grantSelector.setFilter(RSQL.equals("projectName", PASS_E2E_TEST_GRANT));
         List<Grant> actualTestGrants = passClient.streamObjects(grantSelector).toList();
         assertEquals(1, actualTestGrants.size());
         Grant actualTestGrant = actualTestGrants.get(0);
-        assertEquals("PASS_E2E_TEST_GRANT", actualTestGrant.getProjectName());
+        assertEquals(PASS_E2E_TEST_GRANT, actualTestGrant.getProjectName());
         assertEquals(AwardStatus.ACTIVE, actualTestGrant.getAwardStatus());
 
         PassClientSelector<Submission> submissionSelector = new PassClientSelector<>(Submission.class);

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/support/jobs/ScheduledJobsTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/support/jobs/ScheduledJobsTest.java
@@ -20,6 +20,7 @@ import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.verify;
 
 import org.eclipse.pass.deposit.DepositApp;
+import org.eclipse.pass.deposit.service.DeploymentTestDataService;
 import org.eclipse.pass.deposit.service.DepositUpdater;
 import org.eclipse.pass.deposit.service.SubmissionStatusUpdater;
 import org.junit.jupiter.api.Test;
@@ -34,14 +35,18 @@ import org.springframework.test.context.TestPropertySource;
 @TestPropertySource("classpath:test-application.properties")
 @TestPropertySource(properties = {
     "pass.deposit.jobs.disabled=false",
+    "pass.test.data.job.enabled=true",
     "pass.deposit.jobs.default-interval-ms=1500",
+    "pass.test.data.job.interval-ms=1500",
     "pass.deposit.jobs.1.init.delay=50",
-    "pass.deposit.jobs.2.init.delay=100"
+    "pass.deposit.jobs.2.init.delay=100",
+    "pass.deposit.jobs.3.init.delay=120"
 })
 public class ScheduledJobsTest {
 
     @MockBean private SubmissionStatusUpdater submissionStatusUpdater;
     @MockBean private DepositUpdater depositUpdater;
+    @MockBean private DeploymentTestDataService deploymentTestDataService;
 
     @Test
     void testDepositUpdaterJob() {
@@ -58,6 +63,15 @@ public class ScheduledJobsTest {
         // submissionStatusUpdater.doUpdate() will be called from Scheduled method in job
         await().atMost(3, SECONDS).untilAsserted(() -> {
             verify(submissionStatusUpdater).doUpdate();
+        });
+    }
+
+    @Test
+    void testDeploymentTestDataJob() {
+        // GIVEN/WHEN
+        // deploymentTestDataService.processTestData() will be called from Scheduled method in job
+        await().atMost(3, SECONDS).untilAsserted(() -> {
+            verify(deploymentTestDataService).processTestData();
         });
     }
 


### PR DESCRIPTION
This PR adds a new job to the deposit service's jobs.  The Job is responsible for managing the deployment test data in live environments.  The job will create the deployment test grant data if it doesn't exist, and it will delete submissions (and all related data) related to the test grant after 24 hours.  The job will run every 12 hours and should only be enabled when running in a live environment (stage or prod).

This is needed to support the deployment tests PR: https://github.com/eclipse-pass/pass-acceptance-testing/pull/17