### PR TITLE
Delete SubmissionEvent for test submissions

### DIFF
--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/DeploymentTestDataService.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/DeploymentTestDataService.java
@@ -32,6 +32,7 @@ import org.eclipse.pass.support.client.model.Journal;
 import org.eclipse.pass.support.client.model.PassEntity;
 import org.eclipse.pass.support.client.model.Policy;
 import org.eclipse.pass.support.client.model.Submission;
+import org.eclipse.pass.support.client.model.SubmissionEvent;
 import org.eclipse.pass.support.client.model.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -92,6 +93,10 @@ public class DeploymentTestDataService {
                 testFileSelector.setFilter(RSQL.equals("submission.id", testSubmission.getId()));
                 List<File> testFiles = passClient.streamObjects(testFileSelector).toList();
                 testFiles.forEach(this::deleteFile);
+                PassClientSelector<SubmissionEvent> subEventSelector = new PassClientSelector<>(SubmissionEvent.class);
+                subEventSelector.setFilter(RSQL.equals("submission.id", testSubmission.getId()));
+                List<SubmissionEvent> testSubmissionEvents = passClient.streamObjects(subEventSelector).toList();
+                testSubmissionEvents.forEach(this::deleteObject);
                 deleteObject(testSubmission);
                 deleteObject(testSubmission.getPublication());
             } catch (IOException e) {

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/DeploymentTestDataServiceIT.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/DeploymentTestDataServiceIT.java
@@ -34,6 +34,7 @@ import org.eclipse.pass.support.client.RSQL;
 import org.eclipse.pass.support.client.model.AwardStatus;
 import org.eclipse.pass.support.client.model.Deposit;
 import org.eclipse.pass.support.client.model.DepositStatus;
+import org.eclipse.pass.support.client.model.EventType;
 import org.eclipse.pass.support.client.model.File;
 import org.eclipse.pass.support.client.model.Grant;
 import org.eclipse.pass.support.client.model.PassEntity;
@@ -42,6 +43,7 @@ import org.eclipse.pass.support.client.model.Publication;
 import org.eclipse.pass.support.client.model.Repository;
 import org.eclipse.pass.support.client.model.RepositoryCopy;
 import org.eclipse.pass.support.client.model.Submission;
+import org.eclipse.pass.support.client.model.SubmissionEvent;
 import org.eclipse.pass.support.client.model.User;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -93,6 +95,9 @@ public class DeploymentTestDataServiceIT extends AbstractDepositIT {
         PassClientSelector<File> fileSelector = new PassClientSelector<>(File.class);
         List<File> testFiles = passClient.streamObjects(fileSelector).toList();
         testFiles.forEach(this::deleteFile);
+        PassClientSelector<SubmissionEvent> subEventSelector = new PassClientSelector<>(SubmissionEvent.class);
+        List<SubmissionEvent> testSubEvents = passClient.streamObjects(subEventSelector).toList();
+        testSubEvents.forEach(this::deleteObject);
         PassClientSelector<Submission> submissionSelector = new PassClientSelector<>(Submission.class);
         List<Submission> testSubmissions = passClient.streamObjects(submissionSelector).toList();
         testSubmissions.forEach(this::deleteObject);
@@ -195,6 +200,9 @@ public class DeploymentTestDataServiceIT extends AbstractDepositIT {
         PassClientSelector<File> fileSelector = new PassClientSelector<>(File.class);
         List<File> testFiles = passClient.streamObjects(fileSelector).toList();
         assertTrue(testFiles.isEmpty());
+        PassClientSelector<SubmissionEvent> subEventSelector = new PassClientSelector<>(SubmissionEvent.class);
+        List<SubmissionEvent> testSubEvents = passClient.streamObjects(subEventSelector).toList();
+        assertTrue(testSubEvents.isEmpty());
     }
 
     @Test
@@ -255,6 +263,12 @@ public class DeploymentTestDataServiceIT extends AbstractDepositIT {
         assertEquals(1, testFiles.size());
         File actualFile = testFiles.get(0);
         assertEquals(actualSubmission.getId(), actualFile.getSubmission().getId());
+
+        PassClientSelector<SubmissionEvent> subEventSelector = new PassClientSelector<>(SubmissionEvent.class);
+        List<SubmissionEvent> testSubEvents = passClient.streamObjects(subEventSelector).toList();
+        assertEquals(1, testSubEvents.size());
+        SubmissionEvent actualSubEvent = testSubEvents.get(0);
+        assertEquals(actualSubmission.getId(), actualSubEvent.getSubmission().getId());
     }
 
     private Submission initSubmissionAndDeposits(Grant testGrant) throws Exception {
@@ -293,6 +307,16 @@ public class DeploymentTestDataServiceIT extends AbstractDepositIT {
         file.setUri(data_uri);
         file.setSubmission(submission);
         passClient.createObject(file);
+
+        PassClientSelector<User> selectorUser = new PassClientSelector<>(User.class);
+        selectorUser.setFilter(RSQL.equals("email", "test-user-email@foo"));
+        User testUser = passClient.streamObjects(selectorUser).toList().get(0);
+
+        SubmissionEvent submissionEvent = new SubmissionEvent();
+        submissionEvent.setSubmission(submission);
+        submissionEvent.setEventType(EventType.SUBMITTED);
+        submissionEvent.setPerformedBy(testUser);
+        passClient.createObject(submissionEvent);
 
         return submission;
     }


### PR DESCRIPTION
For deleting test submissions from deployment tests, need to delete SubmissionEvents to resolve FK violations on submission delete.