### PR TITLE
Add S3 support for grant loader file operations

### DIFF
--- a/pass-grant-loader/README.md
+++ b/pass-grant-loader/README.md
@@ -51,7 +51,7 @@ is a spring boot application, so use the standard Spring Boot configuration func
 
 Here is an example using Java system properties `-D`.
 ```
-    java -Dapp.home-/my/home/path -jar jhu-grant-loader-0.6.0-SNAPSHOT.jar -startDateTime "<yyyy-mm-dd hh:mm:ss.m{mm}>" -awardEndDate <MM/dd/yyyy>
+    java -jar jhu-grant-loader-0.6.0-SNAPSHOT.jar -a load file:./grant-data.csv
 ```
 
 ### Arguments

--- a/pass-grant-loader/pom.xml
+++ b/pass-grant-loader/pom.xml
@@ -275,6 +275,7 @@
                 <ignoredDependencies>
                   <!-- These come from bundled jars -->
                   <ignoredDependency>org.springframework*::</ignoredDependency>
+                  <ignoredDependency>io.awspring.cloud::</ignoredDependency>
                 </ignoredDependencies>
                 <ignoredUsedUndeclaredDependencies>
                   <!-- These come from junit-jupiter, so version is tied to that direct dependency -->
@@ -289,8 +290,6 @@
                   <ignoredUnusedDeclaredDependency>ch.qos.logback:logback-classic:</ignoredUnusedDeclaredDependency>
                   <!-- slf4j is the API used in the code, jcl is used by a transitive dep -->
                   <ignoredUnusedDeclaredDependency>org.slf4j:jcl-over-slf4j:</ignoredUnusedDeclaredDependency>
-                  <!-- This is used for resources in S3 -->
-                  <ignoredUnusedDeclaredDependency>io.awspring.cloud:spring-cloud-aws-starter-s3:</ignoredUnusedDeclaredDependency>
                   <!-- Deficiency of analyzer bytecode -->
                   <ignoredUnusedDeclaredDependency>org.projectlombok:lombok:</ignoredUnusedDeclaredDependency>
                   <ignoredUnusedDeclaredDependency>org.mockito:mockito-inline:</ignoredUnusedDeclaredDependency>

--- a/pass-grant-loader/src/main/java/org/eclipse/pass/support/grant/GrantLoaderApp.java
+++ b/pass-grant-loader/src/main/java/org/eclipse/pass/support/grant/GrantLoaderApp.java
@@ -40,7 +40,6 @@ import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.util.List;
 
-import org.apache.commons.lang3.StringUtils;
 import org.eclipse.pass.support.grant.data.GrantConnector;
 import org.eclipse.pass.support.grant.data.GrantIngestRecord;
 import org.eclipse.pass.support.grant.data.PassUpdater;
@@ -248,7 +247,7 @@ public class GrantLoaderApp {
         try (InputStream inputStream = grantUpdateTimestamps.getInputStream()) {
             content = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
         }
-        content += StringUtils.isNotEmpty(content) ? "\n" + updateString : updateString;
+        content += updateString;
         try (
             OutputStream outputStream = grantUpdateTimestamps.getOutputStream();
             OutputStreamWriter writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8);

--- a/pass-grant-loader/src/main/resources/application.properties
+++ b/pass-grant-loader/src/main/resources/application.properties
@@ -3,8 +3,8 @@ spring.cloud.aws.s3.enabled=false
 
 spring.profiles.active=jhu
 
-app.home=${APP_HOME_ENV:/data/grantloader}
-pass.policy.prop.path=${POLICY_PROP_PATH:${app.home}/policy.properties}
+pass.policy.prop.path=${POLICY_PROP_PATH:/data/grantloader/policy.properties}
+pass.grant.update.ts.path=${GRANT_UPDATE_TS_PATH:/data/grantloader/grant_update_timestamps}
 
 grant.db.url=${GRANT_DB_URL:}
 grant.db.username=${GRANT_DB_USER:}

--- a/pass-grant-loader/src/main/resources/application.properties
+++ b/pass-grant-loader/src/main/resources/application.properties
@@ -3,8 +3,8 @@ spring.cloud.aws.s3.enabled=false
 
 spring.profiles.active=jhu
 
-pass.policy.prop.path=${POLICY_PROP_PATH:/data/grantloader/policy.properties}
-pass.grant.update.ts.path=${GRANT_UPDATE_TS_PATH:/data/grantloader/grant_update_timestamps}
+pass.policy.prop.path=${POLICY_PROP_PATH:file:///data/grantloader/policy.properties}
+pass.grant.update.ts.path=${GRANT_UPDATE_TS_PATH:file:///data/grantloader/grant_update_timestamps}
 
 grant.db.url=${GRANT_DB_URL:}
 grant.db.username=${GRANT_DB_USER:}

--- a/pass-grant-loader/src/test/java/org/eclipse/pass/support/grant/AbstractRoundTripTest.java
+++ b/pass-grant-loader/src/test/java/org/eclipse/pass/support/grant/AbstractRoundTripTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2024 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.grant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.eclipse.pass.support.client.PassClientResult;
+import org.eclipse.pass.support.client.PassClientSelector;
+import org.eclipse.pass.support.client.RSQL;
+import org.eclipse.pass.support.client.model.AwardStatus;
+import org.eclipse.pass.support.client.model.Funder;
+import org.eclipse.pass.support.client.model.Grant;
+import org.eclipse.pass.support.grant.data.GrantIngestRecord;
+
+/**
+ * @author Russ Poetker (rpoetke1@jh.edu)
+ */
+public class AbstractRoundTripTest extends AbstractIntegrationTest {
+
+    protected List<GrantIngestRecord> getTestIngestRecords() {
+        GrantIngestRecord piRecord1 = TestUtil.makeGrantIngestRecord(0, 0, "P");
+        GrantIngestRecord coPiRecord1 = TestUtil.makeGrantIngestRecord(0, 1, "C");
+        GrantIngestRecord piRecord2 = TestUtil.makeGrantIngestRecord(3, 1, "P");
+        return List.of(piRecord1, coPiRecord1, piRecord2);
+    }
+
+    protected void verifyGrantOne() throws IOException {
+        PassClientSelector<Grant> grantSelector = new PassClientSelector<>(Grant.class);
+        grantSelector.setFilter(RSQL.equals("localKey", "johnshopkins.edu:grant:10000001"));
+        grantSelector.setInclude("primaryFunder", "directFunder", "pi", "coPis");
+        PassClientResult<Grant> resultGrant = passClient.selectObjects(grantSelector);
+        assertEquals(1, resultGrant.getTotal());
+        Grant passGrant = resultGrant.getObjects().get(0);
+        assertNotNull(passGrant.getId());
+        assertEquals("johnshopkins.edu:grant:10000001", passGrant.getLocalKey());
+        assertEquals("B10000000", passGrant.getAwardNumber());
+        assertEquals("Stupendous \"Research Project\" I",
+            passGrant.getProjectName());
+        assertEquals(AwardStatus.ACTIVE, passGrant.getAwardStatus());
+        assertEquals("1999-01-01T00:00Z", passGrant.getAwardDate().toString());
+        assertEquals("2000-07-01T00:00Z", passGrant.getStartDate().toString());
+        assertEquals("2004-06-30T00:00Z", passGrant.getEndDate().toString());
+
+        Funder primaryFunder = passClient.getObject(passGrant.getPrimaryFunder(), "policy");
+        assertEquals("johnshopkins.edu:funder:20000001", primaryFunder.getLocalKey());
+        assertEquals("J L Gotrocks Foundation", primaryFunder.getName());
+        assertEquals("1", primaryFunder.getPolicy().getId());
+
+        Funder directFunder = passClient.getObject(passGrant.getDirectFunder(), "policy");
+        assertEquals("johnshopkins.edu:funder:20000000", directFunder.getLocalKey());
+        assertEquals("Enormous State University",directFunder.getName());
+        assertEquals("1", directFunder.getPolicy().getId());
+
+        assertEquals("Amanda", passGrant.getPi().getFirstName());
+        assertEquals("Bea", passGrant.getPi().getMiddleName());
+        assertEquals("Reckondwith", passGrant.getPi().getLastName());
+        assertEquals("arecko1@jhu.edu", passGrant.getPi().getEmail());
+        assertEquals(List.of("johnshopkins.edu:employeeid:31000000", "johnshopkins.edu:eppn:arecko1"),
+            passGrant.getPi().getLocatorIds());
+
+        assertEquals(1, passGrant.getCoPis().size());
+        assertEquals("Skip", passGrant.getCoPis().get(0).getFirstName());
+        assertEquals("Avery", passGrant.getCoPis().get(0).getMiddleName());
+        assertEquals("Class", passGrant.getCoPis().get(0).getLastName());
+        assertEquals("sclass1@jhu.edu", passGrant.getCoPis().get(0).getEmail());
+        assertEquals(List.of("johnshopkins.edu:employeeid:31000001", "johnshopkins.edu:eppn:sclass1"),
+            passGrant.getCoPis().get(0).getLocatorIds());
+    }
+
+    protected void verifyGrantTwo() throws IOException {
+        PassClientSelector<Grant> grantSelector = new PassClientSelector<>(Grant.class);
+        grantSelector.setFilter(RSQL.equals("localKey", "johnshopkins.edu:grant:10000002"));
+        grantSelector.setInclude("primaryFunder", "directFunder", "pi", "coPis");
+        PassClientResult<Grant> resultGrant1 = passClient.selectObjects(grantSelector);
+        assertEquals(1, resultGrant1.getTotal());
+        Grant passGrant = resultGrant1.getObjects().get(0);
+        assertNotNull(passGrant.getId());
+        assertEquals("johnshopkins.edu:grant:10000002", passGrant.getLocalKey());
+        assertEquals("B10000003", passGrant.getAwardNumber());
+        assertEquals("Stupendous Research ProjectIV", passGrant.getProjectName());
+        assertEquals(AwardStatus.ACTIVE, passGrant.getAwardStatus());
+        assertEquals("2004-01-01T00:00Z", passGrant.getAwardDate().toString());
+        assertEquals("2004-07-01T00:00Z", passGrant.getStartDate().toString());
+        assertEquals("2007-06-30T00:00Z", passGrant.getEndDate().toString());
+
+        Funder primaryFunder = passClient.getObject(passGrant.getPrimaryFunder(), "policy");
+        assertEquals("johnshopkins.edu:funder:20000001", primaryFunder.getLocalKey());
+        assertEquals("J L Gotrocks Foundation", primaryFunder.getName());
+        assertEquals("1", primaryFunder.getPolicy().getId());
+
+        Funder directFunder = passClient.getObject(passGrant.getDirectFunder(), "policy");
+        assertEquals("johnshopkins.edu:funder:20000000", directFunder.getLocalKey());
+        assertEquals("Enormous State University",directFunder.getName());
+        assertEquals("1", directFunder.getPolicy().getId());
+
+        assertEquals("Skip", passGrant.getPi().getFirstName());
+        assertEquals("Avery", passGrant.getPi().getMiddleName());
+        assertEquals("Class", passGrant.getPi().getLastName());
+        assertEquals("sclass1@jhu.edu", passGrant.getPi().getEmail());
+        assertEquals(List.of("johnshopkins.edu:employeeid:31000001", "johnshopkins.edu:eppn:sclass1"),
+            passGrant.getPi().getLocatorIds());
+
+        assertEquals(0, passGrant.getCoPis().size());
+    }
+
+}

--- a/pass-grant-loader/src/test/java/org/eclipse/pass/support/grant/GrantLoaderFileRoundTripTest.java
+++ b/pass-grant-loader/src/test/java/org/eclipse/pass/support/grant/GrantLoaderFileRoundTripTest.java
@@ -16,7 +16,6 @@
 package org.eclipse.pass.support.grant;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
@@ -27,12 +26,6 @@ import java.nio.file.Path;
 import java.sql.SQLException;
 import java.util.List;
 
-import org.eclipse.pass.support.client.PassClientResult;
-import org.eclipse.pass.support.client.PassClientSelector;
-import org.eclipse.pass.support.client.RSQL;
-import org.eclipse.pass.support.client.model.AwardStatus;
-import org.eclipse.pass.support.client.model.Funder;
-import org.eclipse.pass.support.client.model.Grant;
 import org.eclipse.pass.support.client.model.Policy;
 import org.eclipse.pass.support.grant.data.GrantIngestRecord;
 import org.eclipse.pass.support.grant.data.PassUpdater;
@@ -43,7 +36,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 /**
  * @author Russ Poetker (rpoetke1@jh.edu)
  */
-public class GrantLoaderFileRoundTripTest extends AbstractIntegrationTest {
+public class GrantLoaderFileRoundTripTest extends AbstractRoundTripTest {
 
     private static final Path TEST_CSV_PATH = Path.of("src/test/resources/test-pull.csv");
     private static final Path GRANT_UPTS_PATH = Path.of("src/test/resources/grant_update_timestamps");
@@ -91,92 +84,6 @@ public class GrantLoaderFileRoundTripTest extends AbstractIntegrationTest {
 
         String contentUpTs = Files.readString(GRANT_UPTS_PATH);
         assertEquals(passUpdater.getLatestUpdate() + "\n", contentUpTs);
-    }
-
-    private List<GrantIngestRecord> getTestIngestRecords() {
-        GrantIngestRecord piRecord1 = TestUtil.makeGrantIngestRecord(0, 0, "P");
-        GrantIngestRecord coPiRecord1 = TestUtil.makeGrantIngestRecord(0, 1, "C");
-        GrantIngestRecord piRecord2 = TestUtil.makeGrantIngestRecord(3, 1, "P");
-        return List.of(piRecord1, coPiRecord1, piRecord2);
-    }
-
-    private void verifyGrantOne() throws IOException {
-        PassClientSelector<Grant> grantSelector = new PassClientSelector<>(Grant.class);
-        grantSelector.setFilter(RSQL.equals("localKey", "johnshopkins.edu:grant:10000001"));
-        grantSelector.setInclude("primaryFunder", "directFunder", "pi", "coPis");
-        PassClientResult<Grant> resultGrant = passClient.selectObjects(grantSelector);
-        assertEquals(1, resultGrant.getTotal());
-        Grant passGrant = resultGrant.getObjects().get(0);
-        assertNotNull(passGrant.getId());
-        assertEquals("johnshopkins.edu:grant:10000001", passGrant.getLocalKey());
-        assertEquals("B10000000", passGrant.getAwardNumber());
-        assertEquals("Stupendous \"Research Project\" I",
-            passGrant.getProjectName());
-        assertEquals(AwardStatus.ACTIVE, passGrant.getAwardStatus());
-        assertEquals("1999-01-01T00:00Z", passGrant.getAwardDate().toString());
-        assertEquals("2000-07-01T00:00Z", passGrant.getStartDate().toString());
-        assertEquals("2004-06-30T00:00Z", passGrant.getEndDate().toString());
-
-        Funder primaryFunder = passClient.getObject(passGrant.getPrimaryFunder(), "policy");
-        assertEquals("johnshopkins.edu:funder:20000001", primaryFunder.getLocalKey());
-        assertEquals("J L Gotrocks Foundation", primaryFunder.getName());
-        assertEquals("1", primaryFunder.getPolicy().getId());
-
-        Funder directFunder = passClient.getObject(passGrant.getDirectFunder(), "policy");
-        assertEquals("johnshopkins.edu:funder:20000000", directFunder.getLocalKey());
-        assertEquals("Enormous State University",directFunder.getName());
-        assertEquals("1", directFunder.getPolicy().getId());
-
-        assertEquals("Amanda", passGrant.getPi().getFirstName());
-        assertEquals("Bea", passGrant.getPi().getMiddleName());
-        assertEquals("Reckondwith", passGrant.getPi().getLastName());
-        assertEquals("arecko1@jhu.edu", passGrant.getPi().getEmail());
-        assertEquals(List.of("johnshopkins.edu:employeeid:31000000", "johnshopkins.edu:eppn:arecko1"),
-            passGrant.getPi().getLocatorIds());
-
-        assertEquals(1, passGrant.getCoPis().size());
-        assertEquals("Skip", passGrant.getCoPis().get(0).getFirstName());
-        assertEquals("Avery", passGrant.getCoPis().get(0).getMiddleName());
-        assertEquals("Class", passGrant.getCoPis().get(0).getLastName());
-        assertEquals("sclass1@jhu.edu", passGrant.getCoPis().get(0).getEmail());
-        assertEquals(List.of("johnshopkins.edu:employeeid:31000001", "johnshopkins.edu:eppn:sclass1"),
-            passGrant.getCoPis().get(0).getLocatorIds());
-    }
-
-    private void verifyGrantTwo() throws IOException {
-        PassClientSelector<Grant> grantSelector = new PassClientSelector<>(Grant.class);
-        grantSelector.setFilter(RSQL.equals("localKey", "johnshopkins.edu:grant:10000002"));
-        grantSelector.setInclude("primaryFunder", "directFunder", "pi", "coPis");
-        PassClientResult<Grant> resultGrant1 = passClient.selectObjects(grantSelector);
-        assertEquals(1, resultGrant1.getTotal());
-        Grant passGrant = resultGrant1.getObjects().get(0);
-        assertNotNull(passGrant.getId());
-        assertEquals("johnshopkins.edu:grant:10000002", passGrant.getLocalKey());
-        assertEquals("B10000003", passGrant.getAwardNumber());
-        assertEquals("Stupendous Research ProjectIV", passGrant.getProjectName());
-        assertEquals(AwardStatus.ACTIVE, passGrant.getAwardStatus());
-        assertEquals("2004-01-01T00:00Z", passGrant.getAwardDate().toString());
-        assertEquals("2004-07-01T00:00Z", passGrant.getStartDate().toString());
-        assertEquals("2007-06-30T00:00Z", passGrant.getEndDate().toString());
-
-        Funder primaryFunder = passClient.getObject(passGrant.getPrimaryFunder(), "policy");
-        assertEquals("johnshopkins.edu:funder:20000001", primaryFunder.getLocalKey());
-        assertEquals("J L Gotrocks Foundation", primaryFunder.getName());
-        assertEquals("1", primaryFunder.getPolicy().getId());
-
-        Funder directFunder = passClient.getObject(passGrant.getDirectFunder(), "policy");
-        assertEquals("johnshopkins.edu:funder:20000000", directFunder.getLocalKey());
-        assertEquals("Enormous State University",directFunder.getName());
-        assertEquals("1", directFunder.getPolicy().getId());
-
-        assertEquals("Skip", passGrant.getPi().getFirstName());
-        assertEquals("Avery", passGrant.getPi().getMiddleName());
-        assertEquals("Class", passGrant.getPi().getLastName());
-        assertEquals("sclass1@jhu.edu", passGrant.getPi().getEmail());
-        assertEquals(List.of("johnshopkins.edu:employeeid:31000001", "johnshopkins.edu:eppn:sclass1"),
-            passGrant.getPi().getLocatorIds());
-
-        assertEquals(0, passGrant.getCoPis().size());
     }
 
 }

--- a/pass-grant-loader/src/test/java/org/eclipse/pass/support/grant/GrantLoaderLoadFileIT.java
+++ b/pass-grant-loader/src/test/java/org/eclipse/pass/support/grant/GrantLoaderLoadFileIT.java
@@ -57,11 +57,12 @@ public class GrantLoaderLoadFileIT extends AbstractIntegrationTest {
         Policy policy = new Policy();
         policy.setTitle("test policy");
         passClient.createObject(policy);
+        Files.createFile(Path.of("src/test/resources/grant_update_timestamps"));
 
         // WHEN
         PassCliException passCliException = assertThrows(PassCliException.class, () -> {
             grantLoaderApp.run("", "01/01/2011", "grant",
-                "load", "src/test/resources/test-load.csv", null);
+                "load", "file:./src/test/resources/test-load.csv", null);
         });
 
         // THEN

--- a/pass-grant-loader/src/test/java/org/eclipse/pass/support/grant/GrantLoaderS3RoundTripTest.java
+++ b/pass-grant-loader/src/test/java/org/eclipse/pass/support/grant/GrantLoaderS3RoundTripTest.java
@@ -16,7 +16,6 @@
 package org.eclipse.pass.support.grant;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
@@ -32,12 +31,6 @@ import java.util.List;
 
 import io.awspring.cloud.s3.S3Resource;
 import io.awspring.cloud.s3.S3Template;
-import org.eclipse.pass.support.client.PassClientResult;
-import org.eclipse.pass.support.client.PassClientSelector;
-import org.eclipse.pass.support.client.RSQL;
-import org.eclipse.pass.support.client.model.AwardStatus;
-import org.eclipse.pass.support.client.model.Funder;
-import org.eclipse.pass.support.client.model.Grant;
 import org.eclipse.pass.support.client.model.Policy;
 import org.eclipse.pass.support.grant.data.GrantIngestRecord;
 import org.eclipse.pass.support.grant.data.PassUpdater;
@@ -60,7 +53,7 @@ import org.testcontainers.utility.DockerImageName;
     "pass.policy.prop.path=s3://test-bucket/s3-policy.properties",
     "pass.grant.update.ts.path=s3://test-bucket/s3-testgrantupdatets"
 })
-public class GrantLoaderS3RoundTripTest extends AbstractIntegrationTest {
+public class GrantLoaderS3RoundTripTest extends AbstractRoundTripTest {
 
     private static final DockerImageName LOCALSTACK_IMG =
         DockerImageName.parse("localstack/localstack:3.1.0");
@@ -132,92 +125,6 @@ public class GrantLoaderS3RoundTripTest extends AbstractIntegrationTest {
             String contentUpTs = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
             assertEquals(passUpdater.getLatestUpdate() + "\n", contentUpTs);
         }
-    }
-
-    private List<GrantIngestRecord> getTestIngestRecords() {
-        GrantIngestRecord piRecord1 = TestUtil.makeGrantIngestRecord(0, 0, "P");
-        GrantIngestRecord coPiRecord1 = TestUtil.makeGrantIngestRecord(0, 1, "C");
-        GrantIngestRecord piRecord2 = TestUtil.makeGrantIngestRecord(3, 1, "P");
-        return List.of(piRecord1, coPiRecord1, piRecord2);
-    }
-
-    private void verifyGrantOne() throws IOException {
-        PassClientSelector<Grant> grantSelector = new PassClientSelector<>(Grant.class);
-        grantSelector.setFilter(RSQL.equals("localKey", "johnshopkins.edu:grant:10000001"));
-        grantSelector.setInclude("primaryFunder", "directFunder", "pi", "coPis");
-        PassClientResult<Grant> resultGrant = passClient.selectObjects(grantSelector);
-        assertEquals(1, resultGrant.getTotal());
-        Grant passGrant = resultGrant.getObjects().get(0);
-        assertNotNull(passGrant.getId());
-        assertEquals("johnshopkins.edu:grant:10000001", passGrant.getLocalKey());
-        assertEquals("B10000000", passGrant.getAwardNumber());
-        assertEquals("Stupendous \"Research Project\" I",
-            passGrant.getProjectName());
-        assertEquals(AwardStatus.ACTIVE, passGrant.getAwardStatus());
-        assertEquals("1999-01-01T00:00Z", passGrant.getAwardDate().toString());
-        assertEquals("2000-07-01T00:00Z", passGrant.getStartDate().toString());
-        assertEquals("2004-06-30T00:00Z", passGrant.getEndDate().toString());
-
-        Funder primaryFunder = passClient.getObject(passGrant.getPrimaryFunder(), "policy");
-        assertEquals("johnshopkins.edu:funder:20000001", primaryFunder.getLocalKey());
-        assertEquals("J L Gotrocks Foundation", primaryFunder.getName());
-        assertEquals("1", primaryFunder.getPolicy().getId());
-
-        Funder directFunder = passClient.getObject(passGrant.getDirectFunder(), "policy");
-        assertEquals("johnshopkins.edu:funder:20000000", directFunder.getLocalKey());
-        assertEquals("Enormous State University",directFunder.getName());
-        assertEquals("1", directFunder.getPolicy().getId());
-
-        assertEquals("Amanda", passGrant.getPi().getFirstName());
-        assertEquals("Bea", passGrant.getPi().getMiddleName());
-        assertEquals("Reckondwith", passGrant.getPi().getLastName());
-        assertEquals("arecko1@jhu.edu", passGrant.getPi().getEmail());
-        assertEquals(List.of("johnshopkins.edu:employeeid:31000000", "johnshopkins.edu:eppn:arecko1"),
-            passGrant.getPi().getLocatorIds());
-
-        assertEquals(1, passGrant.getCoPis().size());
-        assertEquals("Skip", passGrant.getCoPis().get(0).getFirstName());
-        assertEquals("Avery", passGrant.getCoPis().get(0).getMiddleName());
-        assertEquals("Class", passGrant.getCoPis().get(0).getLastName());
-        assertEquals("sclass1@jhu.edu", passGrant.getCoPis().get(0).getEmail());
-        assertEquals(List.of("johnshopkins.edu:employeeid:31000001", "johnshopkins.edu:eppn:sclass1"),
-            passGrant.getCoPis().get(0).getLocatorIds());
-    }
-
-    private void verifyGrantTwo() throws IOException {
-        PassClientSelector<Grant> grantSelector = new PassClientSelector<>(Grant.class);
-        grantSelector.setFilter(RSQL.equals("localKey", "johnshopkins.edu:grant:10000002"));
-        grantSelector.setInclude("primaryFunder", "directFunder", "pi", "coPis");
-        PassClientResult<Grant> resultGrant1 = passClient.selectObjects(grantSelector);
-        assertEquals(1, resultGrant1.getTotal());
-        Grant passGrant = resultGrant1.getObjects().get(0);
-        assertNotNull(passGrant.getId());
-        assertEquals("johnshopkins.edu:grant:10000002", passGrant.getLocalKey());
-        assertEquals("B10000003", passGrant.getAwardNumber());
-        assertEquals("Stupendous Research ProjectIV", passGrant.getProjectName());
-        assertEquals(AwardStatus.ACTIVE, passGrant.getAwardStatus());
-        assertEquals("2004-01-01T00:00Z", passGrant.getAwardDate().toString());
-        assertEquals("2004-07-01T00:00Z", passGrant.getStartDate().toString());
-        assertEquals("2007-06-30T00:00Z", passGrant.getEndDate().toString());
-
-        Funder primaryFunder = passClient.getObject(passGrant.getPrimaryFunder(), "policy");
-        assertEquals("johnshopkins.edu:funder:20000001", primaryFunder.getLocalKey());
-        assertEquals("J L Gotrocks Foundation", primaryFunder.getName());
-        assertEquals("1", primaryFunder.getPolicy().getId());
-
-        Funder directFunder = passClient.getObject(passGrant.getDirectFunder(), "policy");
-        assertEquals("johnshopkins.edu:funder:20000000", directFunder.getLocalKey());
-        assertEquals("Enormous State University",directFunder.getName());
-        assertEquals("1", directFunder.getPolicy().getId());
-
-        assertEquals("Skip", passGrant.getPi().getFirstName());
-        assertEquals("Avery", passGrant.getPi().getMiddleName());
-        assertEquals("Class", passGrant.getPi().getLastName());
-        assertEquals("sclass1@jhu.edu", passGrant.getPi().getEmail());
-        assertEquals(List.of("johnshopkins.edu:employeeid:31000001", "johnshopkins.edu:eppn:sclass1"),
-            passGrant.getPi().getLocatorIds());
-
-        assertEquals(0, passGrant.getCoPis().size());
     }
 
 }

--- a/pass-grant-loader/src/test/java/org/eclipse/pass/support/grant/GrantLoaderS3RoundTripTest.java
+++ b/pass-grant-loader/src/test/java/org/eclipse/pass/support/grant/GrantLoaderS3RoundTripTest.java
@@ -120,10 +120,22 @@ public class GrantLoaderS3RoundTripTest extends AbstractRoundTripTest {
         verifyGrantOne();
         verifyGrantTwo();
 
-        S3Resource actualTestGrantUpTs = s3Template.download("test-bucket", "s3-testgrantupdatets");
-        try (InputStream inputStream = actualTestGrantUpTs.getInputStream()) {
+        S3Resource actualTestGrantUpTs1 = s3Template.download("test-bucket", "s3-testgrantupdatets");
+        try (InputStream inputStream = actualTestGrantUpTs1.getInputStream()) {
             String contentUpTs = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
             assertEquals(passUpdater.getLatestUpdate() + "\n", contentUpTs);
+        }
+
+        // WHEN - run again to verify grant update timestamps
+        String firstLastUpdate = passUpdater.getLatestUpdate();
+        grantLoaderApp.run("", "01/01/2011", "grant",
+            "load", "s3://test-bucket/test-pull.csv", null);
+
+        S3Resource actualTestGrantUpTs2 = s3Template.download("test-bucket", "s3-testgrantupdatets");
+        String expectedGrantUpdateTs = firstLastUpdate + "\n" + passUpdater.getLatestUpdate() + "\n";
+        try (InputStream inputStream = actualTestGrantUpTs2.getInputStream()) {
+            String contentUpTs = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+            assertEquals(expectedGrantUpdateTs, contentUpTs);
         }
     }
 

--- a/pass-grant-loader/src/test/java/org/eclipse/pass/support/grant/PolicyPropertiesS3IT.java
+++ b/pass-grant-loader/src/test/java/org/eclipse/pass/support/grant/PolicyPropertiesS3IT.java
@@ -44,7 +44,8 @@ import org.testcontainers.utility.DockerImageName;
 @SpringBootTest
 @TestPropertySource(properties = {
     "spring.cloud.aws.s3.enabled=true",
-    "pass.policy.prop.path=s3://test-bucket/s3-policy.properties"
+    "pass.policy.prop.path=s3://test-bucket/s3-policy.properties",
+    "pass.grant.update.ts.path=file:./src/test/resources/s3-testgrantupdatets"
 })
 @Testcontainers
 public class PolicyPropertiesS3IT {
@@ -80,7 +81,6 @@ public class PolicyPropertiesS3IT {
     @Test
     public void testLoadRepositoryConfigurations() {
         assertNotNull(policyProperties);
-
         assertEquals(Set.of("s3-1", "s3-2"), policyProperties.stringPropertyNames());
     }
 

--- a/pass-grant-loader/src/test/resources/test-application.properties
+++ b/pass-grant-loader/src/test/resources/test-application.properties
@@ -1,5 +1,5 @@
-app.home=src/test/resources
-pass.policy.prop.path=/policy.properties
+pass.policy.prop.path=file:./src/test/resources/policy.properties
+pass.grant.update.ts.path=file:./src/test/resources/grant_update_timestamps
 # pass-core properties
 pass.client.url=http://localhost:8080/
 pass.client.user=backend


### PR DESCRIPTION
Now the grant loader can use S3 (if enabled) for all file operations.  For example, the grant-data file can be read and written from an S3 bucket if the file path is an S3 url (`s3://`).  

The grant loader now uses Spring Resources for reading/writing the grant data, grant update timestamp, and policy.properties files.  This is the abstraction that performs the appropriate reading and writing depending on the resource URL.  For files on a disk, file URLs (`file://`) should be used, for files in an S3 bucket, s3 URLs (`s3://`) should be used.