### PR TITLE
Fix grant loader coeus SQL

### DIFF
--- a/pass-grant-loader/src/main/java/org/eclipse/pass/support/grant/data/jhu/CoeusConnector.java
+++ b/pass-grant-loader/src/main/java/org/eclipse/pass/support/grant/data/jhu/CoeusConnector.java
@@ -213,8 +213,8 @@ public class CoeusConnector implements GrantConnector {
 
     private String buildGrantQueryString(String grant) {
         return StringUtils.isEmpty(grant)
-            ? SELECT_GRANT_SQL + "AND A.GRANT_NUMBER IS NOT NULL)"
-            : SELECT_GRANT_SQL + "AND A.GRANT_NUMBER = ?)";
+            ? SELECT_GRANT_SQL + "AND EA.GRANT_NUMBER IS NOT NULL)"
+            : SELECT_GRANT_SQL + "AND EA.GRANT_NUMBER = ?)";
     }
 
     private List<GrantIngestRecord> retrieveFunderUpdates(Set<String> funderIds) throws SQLException {

--- a/pass-grant-loader/src/main/java/org/eclipse/pass/support/grant/data/jhu/CoeusConnector.java
+++ b/pass-grant-loader/src/main/java/org/eclipse/pass/support/grant/data/jhu/CoeusConnector.java
@@ -106,12 +106,14 @@ public class CoeusConnector implements GrantConnector {
         "LEFT JOIN COEUS.SWIFT_SPONSOR D ON A.PRIME_SPONSOR_CODE = D.SPONSOR_CODE " +
         "WHERE (B.ABBREVIATED_ROLE = 'P' OR B.ABBREVIATED_ROLE = 'C' " +
         "OR REGEXP_LIKE (UPPER(B.ROLE), '^CO ?-?INVESTIGATOR$')) " +
+        "AND A.PROPOSAL_STATUS = 'Funded' " +
+        "AND A.GRANT_NUMBER IS NOT NULL " +
         "AND EXISTS (" +
         "    select * from COEUS.JHU_FACULTY_FORCE_PROP EA where" +
         "        EA.UPDATE_TIMESTAMP > ?" +
         "        AND TO_DATE(EA.AWARD_END, 'MM/DD/YYYY') >= TO_DATE(?, 'MM/DD/YYYY')" +
-        "        and EA.PROPOSAL_STATUS = 'Funded'" +
-        "        and EA.GRANT_NUMBER = A.GRANT_NUMBER ";
+        "        AND EA.GRANT_NUMBER = A.GRANT_NUMBER" +
+        "        AND EA.PROPOSAL_STATUS = 'Funded' ";
 
     private static final String SELECT_USER_SQL =
         "SELECT " +

--- a/pass-grant-loader/src/main/java/org/eclipse/pass/support/grant/data/jhu/CoeusConnector.java
+++ b/pass-grant-loader/src/main/java/org/eclipse/pass/support/grant/data/jhu/CoeusConnector.java
@@ -106,13 +106,14 @@ public class CoeusConnector implements GrantConnector {
         "LEFT JOIN COEUS.SWIFT_SPONSOR D ON A.PRIME_SPONSOR_CODE = D.SPONSOR_CODE " +
         "WHERE (B.ABBREVIATED_ROLE = 'P' OR B.ABBREVIATED_ROLE = 'C' " +
         "OR REGEXP_LIKE (UPPER(B.ROLE), '^CO ?-?INVESTIGATOR$')) " +
+        "AND TO_DATE(A.AWARD_END, 'MM/DD/YYYY') >= TO_DATE('01/01/2011', 'MM/DD/YYYY') "  +
         "AND A.PROPOSAL_STATUS = 'Funded' " +
         "AND A.GRANT_NUMBER IS NOT NULL " +
         "AND EXISTS (" +
         "    select * from COEUS.JHU_FACULTY_FORCE_PROP EA where" +
         "        EA.UPDATE_TIMESTAMP > ?" +
-        "        AND TO_DATE(EA.AWARD_END, 'MM/DD/YYYY') >= TO_DATE(?, 'MM/DD/YYYY')" +
         "        AND EA.GRANT_NUMBER = A.GRANT_NUMBER" +
+        "        AND TO_DATE(EA.AWARD_END, 'MM/DD/YYYY') >= TO_DATE(?, 'MM/DD/YYYY')" +
         "        AND EA.PROPOSAL_STATUS = 'Funded' ";
 
     private static final String SELECT_USER_SQL =


### PR DESCRIPTION
While working on updates to the JHU grant database SQL for Fibi, I realized an issue with the current SQL executing against Coeus.  Luckily the impact is small.

The current SQL selects all records for a grant if one of the records has been updated if the last update timestamp is greater than the supplied filter timestamp.  The issue was the set of grant records returned need to be only those with a Proposal Status of Funded.  But with the current SQL, it was possible that grant records with Proposal Status of some other value would return too.

I fixed this issue by adding the `AND A.PROPOSAL_STATUS = 'Funded' ` to the main SQL so only Funded grant records are returned.

The changes related to checking `GRANT_NUMBER IS NOT NULL` are also needed to ensure we don't get any records with NULL grant number.  Turned out I had wrong the alias inside the EXISTS statement, but that actually works out in the end.  But I changed the SQL to check in the EXISTS on the EXISTS alias and the outer query view as well to be complete and more understandable.

I did analysis since this SQL was deployed on 2024-03-28, and luckily there are only three records that were returned with a non-Funded Proposal Status for two grants.  There were no records returned with a NULL GRANT_NUMBER.  When this change is deployed in PROD, I will backdate to 2024-03-28 and run the grant loader to clean up the two grants.