### PR TITLE
Deployment tests data cleanup enhancements

### DIFF
--- a/pass-deposit-services/deposit-core/pom.xml
+++ b/pass-deposit-services/deposit-core/pom.xml
@@ -36,7 +36,10 @@
     <javax-json.version>1.1.4</javax-json.version>
     <maven-model.version>3.9.6</maven-model.version>
     <awsspring.version>3.1.0</awsspring.version>
-    <msal4j-version>1.15.1</msal4j-version>
+    <msal4j.version>1.15.1</msal4j.version>
+    <httpclient5.version>5.3.1</httpclient5.version>
+    <json-path.version>2.9.0</json-path.version>
+    <wiremock.version>3.3.1</wiremock.version>
   </properties>
 
   <dependencyManagement>
@@ -217,7 +220,19 @@
     <dependency>
       <groupId>com.microsoft.azure</groupId>
       <artifactId>msal4j</artifactId>
-      <version>${msal4j-version}</version>
+      <version>${msal4j.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents.client5</groupId>
+      <artifactId>httpclient5</artifactId>
+      <version>${httpclient5.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.jayway.jsonpath</groupId>
+      <artifactId>json-path</artifactId>
+      <version>${json-path.version}</version>
     </dependency>
 
     <dependency>
@@ -273,6 +288,13 @@
       <groupId>com.icegreen</groupId>
       <artifactId>greenmail-junit5</artifactId>
       <version>${greenmail-junit5.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
+      <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/DepositTask.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/DepositTask.java
@@ -35,6 +35,7 @@ import org.eclipse.pass.deposit.cri.CriticalRepositoryInteraction;
 import org.eclipse.pass.deposit.cri.CriticalRepositoryInteraction.CriticalResult;
 import org.eclipse.pass.deposit.model.Packager;
 import org.eclipse.pass.deposit.service.DepositUtil.DepositWorkerContext;
+import org.eclipse.pass.deposit.support.deploymenttest.DeploymentTestDataService;
 import org.eclipse.pass.deposit.transport.Transport;
 import org.eclipse.pass.deposit.transport.TransportResponse;
 import org.eclipse.pass.deposit.transport.TransportSession;

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/DepositTaskHelper.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/DepositTaskHelper.java
@@ -130,7 +130,8 @@ public class DepositTaskHelper {
     public void submitDeposit(Submission submission, DepositSubmission depositSubmission, Repository repo,
                               Deposit deposit, Packager packager) {
         try {
-            Submission includedSubmission = passClient.getObject(submission, "grants");
+            Submission includedSubmission = passClient.getObject(submission,
+                "publication", "repositories", "submitter", "preparers", "grants", "effectivePolicies");
             DepositUtil.DepositWorkerContext dc = DepositUtil.toDepositWorkerContext(
                 deposit, includedSubmission, depositSubmission, repo, packager, devNullTransport,
                 skipDeploymentTestDeposits);

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/DepositUtil.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/DepositUtil.java
@@ -19,6 +19,7 @@ import org.eclipse.pass.deposit.cri.CriticalRepositoryInteraction;
 import org.eclipse.pass.deposit.cri.CriticalRepositoryInteraction.CriticalResult;
 import org.eclipse.pass.deposit.model.DepositSubmission;
 import org.eclipse.pass.deposit.model.Packager;
+import org.eclipse.pass.deposit.transport.devnull.DevNullTransport;
 import org.eclipse.pass.support.client.model.AggregatedDepositStatus;
 import org.eclipse.pass.support.client.model.Deposit;
 import org.eclipse.pass.support.client.model.DepositStatus;
@@ -52,13 +53,17 @@ public class DepositUtil {
      */
     public static DepositWorkerContext toDepositWorkerContext(Deposit depositResource, Submission submission,
                                                               DepositSubmission depositSubmission,
-                                                              Repository repository, Packager packager) {
+                                                              Repository repository, Packager packager,
+                                                              DevNullTransport devNullTransport,
+                                                              boolean skipDeploymentTestDeposits) {
         DepositWorkerContext dc = new DepositWorkerContext();
         dc.depositResource = depositResource;
         dc.depositSubmission = depositSubmission;
         dc.repository = repository;
         dc.packager = packager;
         dc.submission = submission;
+        dc.devNullTransport = devNullTransport;
+        dc.skipDeploymentTestDeposits = skipDeploymentTestDeposits;
         return dc;
     }
 
@@ -143,6 +148,8 @@ public class DepositUtil {
         private Packager packager;
         private RepositoryCopy repoCopy;
         private String statusUri;
+        private DevNullTransport devNullTransport;
+        private boolean skipDeploymentTestDeposits;
 
         /**
          * the {@code Deposit} itself
@@ -225,6 +232,14 @@ public class DepositUtil {
 
         public void statusUri(String statusUri) {
             this.statusUri = statusUri;
+        }
+
+        public DevNullTransport getDevNullTransport() {
+            return devNullTransport;
+        }
+
+        public boolean isSkipDeploymentTestDeposits() {
+            return skipDeploymentTestDeposits;
         }
 
         @Override

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/support/deploymenttest/DspaceDepositService.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/support/deploymenttest/DspaceDepositService.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2024 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.deposit.support.deploymenttest;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import com.jayway.jsonpath.JsonPath;
+import org.apache.hc.client5.http.config.ConnectionConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.core5.http.io.SocketConfig;
+import org.apache.hc.core5.util.TimeValue;
+import org.apache.hc.core5.util.Timeout;
+import org.eclipse.pass.support.client.model.Deposit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+/**
+ * @author Russ Poetker (rpoetke1@jh.edu)
+ */
+@Service
+public class DspaceDepositService {
+    private static final Logger LOG = LoggerFactory.getLogger(DspaceDepositService.class);
+
+    private final RestClient restClient;
+
+    @Value("${dspace.user}")
+    private String dspaceUsername;
+
+    @Value("${dspace.password}")
+    private String dspacePassword;
+
+    @Value("${dspace.server}")
+    private String dspaceServer;
+
+    @Value("${dspace.server.api.protocol}")
+    private String dspaceApiProtocol;
+
+    protected record AuthContext(String xsrfToken, String authToken){}
+
+    public DspaceDepositService(@Value("${dspace.server.api.protocol}") String dspaceApiProtocol,
+                                @Value("${dspace.server}") String dspaceServer,
+                                @Value("${dspace.server.api.path}") String dspaceApiPath) {
+        PoolingHttpClientConnectionManager connectionManager = PoolingHttpClientConnectionManagerBuilder.create()
+            .setDefaultSocketConfig(SocketConfig.custom()
+                .setSoTimeout(Timeout.ofMinutes(1))
+                .build())
+            .setDefaultConnectionConfig(ConnectionConfig.custom()
+                .setSocketTimeout(Timeout.ofMinutes(1))
+                .setConnectTimeout(Timeout.ofMinutes(1))
+                .setTimeToLive(TimeValue.ofMinutes(10))
+                .build())
+            .build();
+        final CloseableHttpClient httpClient = HttpClients.custom()
+            .setConnectionManager(connectionManager)
+            .disableCookieManagement()
+            .build();
+        this.restClient = RestClient.builder()
+            .requestFactory(new HttpComponentsClientHttpRequestFactory(httpClient))
+            .baseUrl(dspaceApiProtocol + "://" + dspaceServer + dspaceApiPath)
+            .build();
+    }
+
+    /**
+     * Authenticate with the repository. This should be called as appropriate per the repository's API
+     * authentication docs.
+     * @return an AuthContext containing authToken and xsrfToken
+     */
+    AuthContext authenticate() {
+        // Using exchange is needed for this call because dspace returns 404, but the response headers has the
+        // csrf token header DSPACE-XSRF-TOKEN
+        ResponseEntity<Void> csrfResponse = restClient.get()
+            .uri("/security/csrf")
+            .exchange((request, response) -> new ResponseEntity<>(null, response.getHeaders(), HttpStatus.OK));
+        String xsrfToken = csrfResponse.getHeaders().get("DSPACE-XSRF-TOKEN").get(0);
+
+        MultiValueMap<String, String> bodyPair = new LinkedMultiValueMap<>();
+        bodyPair.add("user",  dspaceUsername);
+        bodyPair.add("password",  dspacePassword);
+        ResponseEntity<Void> authResponse = restClient.post()
+            .uri("/authn/login")
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            .header("X-XSRF-TOKEN", xsrfToken)
+            .header("Cookie", "DSPACE-XSRF-COOKIE=" + xsrfToken)
+            .body(bodyPair)
+            .retrieve()
+            .toBodilessEntity();
+        String authToken = authResponse.getHeaders().get("Authorization").get(0);
+
+        return new AuthContext(xsrfToken, authToken);
+    }
+
+    /**
+     * Deletes the deposit in the remote repository.
+     * @param deposit contains deposit info to do the delete
+     */
+    void deleteDeposit(Deposit deposit, AuthContext authContext) {
+        LOG.warn("Deleting Test Deposit In Dspace (PASS Deposit ID={})", deposit.getId());
+        URI accessUrl = deposit.getRepositoryCopy().getAccessUrl();
+        LOG.warn("Deposit accessUrl={}", accessUrl);
+        if (Objects.nonNull(accessUrl)) {
+            String handleValue = parseHandleFilter(accessUrl);
+            String submissionMetadata = deposit.getSubmission().getMetadata();
+            String submissionTitle = JsonPath.parse(submissionMetadata).read("$.title");
+            String itemUuid = findItemUuid(handleValue, authContext, submissionTitle);
+            if (Objects.nonNull(itemUuid)) {
+                LOG.warn("Processing item UUID={}", itemUuid);
+                List<String> bundleUuidArray = findBundleUuids(itemUuid, authContext);
+                bundleUuidArray.forEach(bundleUuid -> deleteBundle(bundleUuid, authContext));
+                deleteItem(itemUuid, authContext);
+                LOG.warn("Deleted Test Deposit In Dspace (PASS Deposit ID={})", deposit.getId());
+            } else {
+                LOG.error("Did not find item in Dspace with handle={}, nothing deleted", handleValue);
+            }
+        } else {
+            LOG.error("Deposit has no accessUrl (PASS Deposit ID={}), nothing deleted", deposit.getId());
+        }
+    }
+
+    private String parseHandleFilter(URI accessUrl) {
+        String handleDelim = dspaceApiProtocol + "://" + dspaceServer + "/handle/";
+        String[] handleTokens = accessUrl.toString().split(handleDelim);
+        if (handleTokens.length != 2) {
+            throw new RuntimeException("Unable to determine dspace item handle for " + accessUrl);
+        }
+        return handleTokens[1];
+    }
+
+    private String findItemUuid(String handleValue, AuthContext authContext, String submissionTitle) {
+        LOG.warn("Search Dspace for item with handle={}", handleValue);
+        String searchResponse = restClient.get()
+            .uri("/discover/search/objects?query=handle:{handleValue}&dsoType=item", handleValue)
+            .accept(MediaType.APPLICATION_JSON)
+            .header("Authorization", authContext.authToken())
+            .retrieve()
+            .body(String.class);
+        List<Map<String, ?>> searchArray = JsonPath.parse(searchResponse).read("$..indexableObject[?(@.handle)]");
+        if (searchArray.size() == 1) {
+            @SuppressWarnings("unchecked")
+            Map<String, ?> itemMap = searchArray.get(0);
+            String itemName = itemMap.get("name").toString();
+            String itemHandle = itemMap.get("handle").toString();
+            String itemUuid = itemMap.get("uuid").toString();
+            LOG.warn("Found item UUID={} with handle={} and name={}", itemUuid, itemHandle, itemName);
+            if (handleValue.equals(itemHandle) && itemName.equals(submissionTitle)) {
+                return itemUuid;
+            } else {
+                throw new RuntimeException(
+                    String.format("Item handle and name don't match [expected handle=%s, " +
+                            "name=%s/actual handle=%s and name=%s]",
+                    handleValue, submissionTitle, itemHandle, itemName));
+            }
+        }
+        return null;
+    }
+
+    private  List<String> findBundleUuids(String itemUuid, AuthContext authContext) {
+        LOG.warn("Search Dspace for item bundles with item UUID={}",  itemUuid);
+        String bundlesResponse = restClient.get()
+            .uri("/core/items/{itemUuid}/bundles", itemUuid)
+            .accept(MediaType.APPLICATION_JSON)
+            .header("Authorization", authContext.authToken())
+            .retrieve()
+            .body(String.class);
+        return JsonPath.parse(bundlesResponse).read("$..bundles[*].uuid");
+    }
+
+    private void deleteBundle(String bundleUuid, AuthContext authContext) {
+        LOG.warn("Deleting bundle UUID={}", bundleUuid);
+        restClient.delete()
+            .uri("/core/bundles/{bundleUuid}", bundleUuid)
+            .accept(MediaType.APPLICATION_JSON)
+            .header("Authorization", authContext.authToken())
+            .header("X-XSRF-TOKEN", authContext.xsrfToken())
+            .header("Cookie", "DSPACE-XSRF-COOKIE=" + authContext.xsrfToken())
+            .retrieve()
+            .toBodilessEntity();
+        LOG.warn("Deleted bundle UUID={}", bundleUuid);
+    }
+
+    private void deleteItem(String itemUuid, AuthContext authContext) {
+        LOG.warn("Deleting item UUID={}", itemUuid);
+        restClient.delete()
+            .uri("/core/items/{itemUuid}", itemUuid)
+            .accept(MediaType.APPLICATION_JSON)
+            .header("Authorization", authContext.authToken())
+            .header("X-XSRF-TOKEN", authContext.xsrfToken())
+            .header("Cookie", "DSPACE-XSRF-COOKIE=" + authContext.xsrfToken())
+            .retrieve()
+            .toBodilessEntity();
+        LOG.warn("Deleted item UUID={}", itemUuid);
+    }
+}

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/support/jobs/DeploymentTestDataJob.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/support/jobs/DeploymentTestDataJob.java
@@ -15,7 +15,7 @@
  */
 package org.eclipse.pass.deposit.support.jobs;
 
-import org.eclipse.pass.deposit.service.DeploymentTestDataService;
+import org.eclipse.pass.deposit.support.deploymenttest.DeploymentTestDataService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/transport/Transport.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/transport/Transport.java
@@ -128,7 +128,8 @@ public interface Transport {
         ftp,
         sftp,
         SWORDv2,
-        filesystem
+        filesystem,
+        devnull
     }
 
     /**

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/transport/devnull/DevNullTransport.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/transport/devnull/DevNullTransport.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2024 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.deposit.transport.devnull;
+
+import java.net.URI;
+import java.util.Map;
+
+import org.eclipse.pass.deposit.assembler.PackageStream;
+import org.eclipse.pass.deposit.cri.CriticalRepositoryInteraction;
+import org.eclipse.pass.deposit.cri.CriticalRepositoryInteraction.CriticalResult;
+import org.eclipse.pass.deposit.transport.Transport;
+import org.eclipse.pass.deposit.transport.TransportResponse;
+import org.eclipse.pass.deposit.transport.TransportSession;
+import org.eclipse.pass.support.client.model.CopyStatus;
+import org.eclipse.pass.support.client.model.Deposit;
+import org.eclipse.pass.support.client.model.DepositStatus;
+import org.eclipse.pass.support.client.model.RepositoryCopy;
+import org.eclipse.pass.support.client.model.Submission;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ *
+ * @author Russ Poetker (rpoetke1@jh.edu)
+ */
+@Component
+public class DevNullTransport implements Transport {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DevNullTransport.class);
+
+    private final CriticalRepositoryInteraction cri;
+
+    @Autowired
+    public DevNullTransport(CriticalRepositoryInteraction cri) {
+        this.cri = cri;
+    }
+
+    @Override
+    public PROTOCOL protocol() {
+        return PROTOCOL.devnull;
+    }
+
+    @Override
+    public TransportSession open(Map<String, String> hints) {
+        return new FilesystemTransportSession();
+    }
+
+    class FilesystemTransportSession implements TransportSession {
+
+        @Override
+        public TransportResponse send(PackageStream packageStream, Map<String, String> metadata) {
+            // no-op, just return successful response
+            return new TransportResponse() {
+                @Override
+                public boolean success() {
+                    return true;
+                }
+
+                @Override
+                public Throwable error() {
+                    return null;
+                }
+
+                @Override
+                public void onSuccess(Submission submission, Deposit deposit, RepositoryCopy repositoryCopy) {
+                    LOG.trace("Invoking onSuccess for tuple [{} {} {}]",
+                              submission.getId(), deposit.getId(), repositoryCopy.getId());
+                    CriticalResult<RepositoryCopy, RepositoryCopy> rcCr =
+                        cri.performCritical(repositoryCopy.getId(), RepositoryCopy.class,
+                                            (rc) -> true,
+                                            (rc) -> true,
+                                            (rc) -> {
+                                                rc.getExternalIds().add("devnull-fake-extid-" + repositoryCopy.getId());
+                                                rc.setCopyStatus(CopyStatus.COMPLETE);
+                                                rc.setAccessUrl(
+                                                    URI.create("devnull-fake-url/" + repositoryCopy.getId())
+                                                );
+                                                return rc;
+                                            }, true);
+
+                    LOG.trace("onSuccess updated RepositoryCopy {}", rcCr.resource().get().getId());
+
+                    CriticalResult<Deposit, Deposit> depositCr =
+                        cri.performCritical(deposit.getId(), Deposit.class,
+                                            (criDeposit) -> DepositStatus.SUBMITTED == criDeposit.getDepositStatus(),
+                                            (criDeposit) -> DepositStatus.ACCEPTED == criDeposit.getDepositStatus(),
+                                            (criDeposit) -> {
+                                                criDeposit.setDepositStatus(DepositStatus.ACCEPTED);
+                                                return criDeposit;
+                                            }, true);
+
+                    LOG.trace("onSuccess updated Deposit {}", depositCr.resource().get().getId());
+                }
+            };
+        }
+
+        @Override
+        public boolean closed() {
+            return false;
+        }
+
+        @Override
+        public void close() throws Exception {
+            // no-op
+        }
+
+    }
+
+}

--- a/pass-deposit-services/deposit-core/src/main/resources/application.properties
+++ b/pass-deposit-services/deposit-core/src/main/resources/application.properties
@@ -30,6 +30,8 @@ dspace.port=${DSPACE_PORT:8181}
 dspace.server=${DSPACE_SERVER:dspace}
 dspace.user=${DSPACE_USER:test@test.edu}
 dspace.password=${DSPACE_PASSWORD:admin}
+dspace.server.api.protocol=${DSPACE_API_PROTOCOL:https}
+dspace.server.api.path=${DSPACE_API_PATH:/server/api}
 
 pass.deposit.repository.configuration=${PASS_DEPOSIT_REPOSITORY_CONFIGURATION:classpath:/repositories.json}
 pass.deposit.workers.concurrency=${PASS_DEPOSIT_WORKERS_CONCURRENCY:4}
@@ -69,8 +71,8 @@ pass.deposit.nihms.email.auth=${NIHMS_MAIL_AUTH:LOGIN}
 pass.deposit.nihms.email.from=${PASS_DEPOSIT_NIHMS_EMAIL_FROM:nihms-help@ncbi.nlm.nih.gov}
 
 pass.test.data.job.enabled=false
-# Run every 12 hours
-pass.test.data.job.interval-ms=43200000
+pass.test.data.job.interval-ms=${TEST_DATA_JOB_INTVL_MS:1800000}
 pass.test.data.policy.title=${TEST_DATA_POLICY_TITLE:}
 pass.test.data.user.email=${TEST_DATA_USER_EMAIL:}
 pass.test.skip.deposits=${TEST_DATA_SKIP_DEPOSITS:true}
+pass.test.dspace.repo.key=${TEST_DATA_DSPACE_REPO_KEY:JScholarship}

--- a/pass-deposit-services/deposit-core/src/main/resources/application.properties
+++ b/pass-deposit-services/deposit-core/src/main/resources/application.properties
@@ -73,3 +73,4 @@ pass.test.data.job.enabled=false
 pass.test.data.job.interval-ms=43200000
 pass.test.data.policy.title=${TEST_DATA_POLICY_TITLE:}
 pass.test.data.user.email=${TEST_DATA_USER_EMAIL:}
+pass.test.skip.deposits=${TEST_DATA_SKIP_DEPOSITS:true}

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/SubmissionProcessorIT.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/SubmissionProcessorIT.java
@@ -30,6 +30,7 @@ import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.deposit.util.async.Condition;
+import org.eclipse.pass.deposit.support.deploymenttest.DeploymentTestDataService;
 import org.eclipse.pass.deposit.transport.devnull.DevNullTransport;
 import org.eclipse.pass.deposit.transport.fs.FilesystemTransport;
 import org.eclipse.pass.deposit.util.ResourceTestUtil;

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/SubmissionProcessorTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/SubmissionProcessorTest.java
@@ -53,6 +53,7 @@ import org.eclipse.pass.deposit.model.DepositFile;
 import org.eclipse.pass.deposit.model.DepositSubmission;
 import org.eclipse.pass.deposit.model.Packager;
 import org.eclipse.pass.deposit.model.Registry;
+import org.eclipse.pass.deposit.transport.devnull.DevNullTransport;
 import org.eclipse.pass.support.client.PassClient;
 import org.eclipse.pass.support.client.model.AggregatedDepositStatus;
 import org.eclipse.pass.support.client.model.Deposit;
@@ -62,6 +63,7 @@ import org.eclipse.pass.support.client.model.Submission;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedConstruction;
+import org.springframework.test.util.ReflectionTestUtils;
 
 /**
  * @author Elliot Metsger (emetsger@jhu.edu)
@@ -82,7 +84,9 @@ public class SubmissionProcessorTest {
         cri = mock(CriticalRepositoryInteraction.class);
         Repositories repositories = mock(Repositories.class);
         DepositServiceErrorHandler depositServiceErrorHandler = mock(DepositServiceErrorHandler.class);
-        DepositTaskHelper depositTaskHelper = new DepositTaskHelper(passClient, cri, repositories);
+        DevNullTransport devNullTransport = mock(DevNullTransport.class);
+        DepositTaskHelper depositTaskHelper = new DepositTaskHelper(passClient, cri, repositories, devNullTransport);
+        ReflectionTestUtils.setField(depositTaskHelper, "skipDeploymentTestDeposits", true);
         submissionProcessor =
             new SubmissionProcessor(passClient, depositSubmissionModelBuilder, packagerRegistry,
                 depositTaskHelper, cri, depositServiceErrorHandler);

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/support/deploymenttest/DeploymentTestDataServiceIT.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/support/deploymenttest/DeploymentTestDataServiceIT.java
@@ -13,22 +13,37 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.eclipse.pass.deposit.service;
+package org.eclipse.pass.deposit.support.deploymenttest;
 
-import static org.eclipse.pass.deposit.service.DeploymentTestDataService.PASS_E2E_TEST_GRANT;
+import static com.github.tomakehurst.wiremock.client.WireMock.delete;
+import static com.github.tomakehurst.wiremock.client.WireMock.deleteRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.eclipse.pass.deposit.support.deploymenttest.DeploymentTestDataService.PASS_E2E_TEST_GRANT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.time.ZonedDateTime;
 import java.util.List;
 
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import org.eclipse.pass.deposit.service.AbstractDepositIT;
 import org.eclipse.pass.support.client.PassClientSelector;
 import org.eclipse.pass.support.client.RSQL;
 import org.eclipse.pass.support.client.model.AwardStatus;
@@ -50,18 +65,28 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.util.ReflectionTestUtils;
 
 /**
  * @author Russ Poetker (rpoetke1@jh.edu)
  */
 @TestPropertySource(properties = {
     "pass.test.data.policy.title=test-policy-title",
-    "pass.test.data.user.email=test-user-email@foo"
+    "pass.test.data.user.email=test-user-email@foo",
+    "dspace.user=test-dspace-user",
+    "dspace.password=test-dspace-password",
+    "dspace.server=localhost:9020",
+    "dspace.server.api.protocol=http",
+    "dspace.server.api.path=/server/api",
+    "pass.test.dspace.repo.key=TestDspace"
 })
+@WireMockTest(httpPort = 9020)
 public class DeploymentTestDataServiceIT extends AbstractDepositIT {
 
     @Autowired private DeploymentTestDataService deploymentTestDataService;
+    @SpyBean private DspaceDepositService dspaceDepositService;
 
     @BeforeEach
     public void initPolicyAndUser() throws IOException {
@@ -78,6 +103,7 @@ public class DeploymentTestDataServiceIT extends AbstractDepositIT {
             testUser.setEmail("test-user-email@foo");
             passClient.createObject(testUser);
         }
+        ReflectionTestUtils.setField(deploymentTestDataService, "skipDeploymentTestDeposits", Boolean.TRUE);
     }
 
     @AfterEach
@@ -123,7 +149,7 @@ public class DeploymentTestDataServiceIT extends AbstractDepositIT {
     }
 
     @Test
-    public void testProcessData_TestGrantDataCreatedIfNotExist() throws Exception {
+    public void testProcessTestData_TestGrantDataCreatedIfNotExist() throws Exception {
         // WHEN
         deploymentTestDataService.processTestData();
 
@@ -142,7 +168,7 @@ public class DeploymentTestDataServiceIT extends AbstractDepositIT {
     }
 
     @Test
-    public void testProcessData_DoesNotTestGrantDataCreatedIfExist() throws Exception {
+    public void testProcessTestData_DoesNotTestGrantDataCreatedIfExist() throws Exception {
         // GIVEN
         Grant testGrant = new Grant();
         testGrant.setProjectName(PASS_E2E_TEST_GRANT);
@@ -166,18 +192,240 @@ public class DeploymentTestDataServiceIT extends AbstractDepositIT {
     }
 
     @Test
-    public void testProcessData_DeleteTestSubmissionsForTestGrant() throws Exception {
+    public void testProcessTestData_DeleteTestSubmissionsForTestGrant() throws Exception {
         // GIVEN
         Grant testGrant = new Grant();
         testGrant.setProjectName(PASS_E2E_TEST_GRANT);
         testGrant.setAwardStatus(AwardStatus.ACTIVE);
         passClient.createObject(testGrant);
         initSubmissionAndDeposits(testGrant);
+        initDspaceApiStubs("Test-Title");
+        ReflectionTestUtils.setField(deploymentTestDataService, "skipDeploymentTestDeposits", Boolean.FALSE);
 
         // WHEN
         deploymentTestDataService.processTestData();
 
         // THEN
+        verifyTestGrantDeleted();
+        verify(dspaceDepositService, times(1)).deleteDeposit(
+            argThat(deposit -> deposit.getRepository().getRepositoryKey().equals("TestDspace")),
+            any(DspaceDepositService.AuthContext.class));
+        verify(dspaceDepositService, times(0)).deleteDeposit(
+            argThat(deposit -> deposit.getRepository().getRepositoryKey().equals("TestNihms")),
+            any(DspaceDepositService.AuthContext.class));
+        verifyDspaceApiStubs(1);
+    }
+
+    @Test
+    public void testProcessTestData_DoesNotDeleteTestSubmissionsForOtherGrant() throws Exception {
+        // GIVEN
+        Grant deploymentGrant = new Grant();
+        deploymentGrant.setProjectName(PASS_E2E_TEST_GRANT);
+        deploymentGrant.setAwardStatus(AwardStatus.ACTIVE);
+        passClient.createObject(deploymentGrant);
+        initSubmissionAndDeposits(deploymentGrant);
+
+        Grant testOtherGrant = new Grant();
+        testOtherGrant.setProjectName("Some Other Grant");
+        testOtherGrant.setAwardStatus(AwardStatus.ACTIVE);
+        passClient.createObject(testOtherGrant);
+        Submission testOtherSubmission = initSubmissionAndDeposits(testOtherGrant);
+        initDspaceApiStubs("Test-Title");
+        ReflectionTestUtils.setField(deploymentTestDataService, "skipDeploymentTestDeposits", Boolean.FALSE);
+
+        // WHEN
+        deploymentTestDataService.processTestData();
+
+        // THEN
+        final PassClientSelector<Grant> grantSelector = new PassClientSelector<>(Grant.class);
+        grantSelector.setFilter(RSQL.equals("projectName", PASS_E2E_TEST_GRANT));
+        List<Grant> actualTestGrants = passClient.streamObjects(grantSelector).toList();
+        assertEquals(1, actualTestGrants.size());
+        Grant actualTestGrant = actualTestGrants.get(0);
+        assertEquals(PASS_E2E_TEST_GRANT, actualTestGrant.getProjectName());
+        assertEquals(AwardStatus.ACTIVE, actualTestGrant.getAwardStatus());
+
+        PassClientSelector<Submission> submissionSelector = new PassClientSelector<>(Submission.class);
+        List<Submission> testSubmissions = passClient.streamObjects(submissionSelector).toList();
+        assertEquals(1, testSubmissions.size());
+        Submission actualSubmission = testSubmissions.get(0);
+        assertEquals(testOtherSubmission.getId(), actualSubmission.getId());
+        assertEquals(testOtherGrant.getId(), actualSubmission.getGrants().get(0).getId());
+
+        PassClientSelector<Deposit> depositSelector = new PassClientSelector<>(Deposit.class);
+        List<Deposit> testDeposits = passClient.streamObjects(depositSelector).toList();
+        assertEquals(2, testDeposits.size());
+        Deposit actualDeposit = testDeposits.get(0);
+        assertEquals(testOtherSubmission.getId(), actualDeposit.getSubmission().getId());
+
+        PassClientSelector<RepositoryCopy> repoCopySelector = new PassClientSelector<>(RepositoryCopy.class);
+        List<RepositoryCopy> testRepoCopies = passClient.streamObjects(repoCopySelector).toList();
+        assertEquals(2, testRepoCopies.size());
+        RepositoryCopy actualRepoCopy = testRepoCopies.get(0);
+        assertEquals(actualDeposit.getRepositoryCopy().getId(), actualRepoCopy.getId());
+
+        PassClientSelector<Publication> publicationSelector = new PassClientSelector<>(Publication.class);
+        List<Publication> testPublications = passClient.streamObjects(publicationSelector).toList();
+        assertEquals(1, testPublications.size());
+        Publication actualPublication = testPublications.get(0);
+        assertEquals(actualRepoCopy.getPublication().getId(), actualPublication.getId());
+        assertEquals(actualSubmission.getPublication().getId(), actualPublication.getId());
+
+        PassClientSelector<File> fileSelector = new PassClientSelector<>(File.class);
+        List<File> testFiles = passClient.streamObjects(fileSelector).toList();
+        assertEquals(1, testFiles.size());
+        File actualFile = testFiles.get(0);
+        assertEquals(actualSubmission.getId(), actualFile.getSubmission().getId());
+
+        PassClientSelector<SubmissionEvent> subEventSelector = new PassClientSelector<>(SubmissionEvent.class);
+        List<SubmissionEvent> testSubEvents = passClient.streamObjects(subEventSelector).toList();
+        assertEquals(1, testSubEvents.size());
+        SubmissionEvent actualSubEvent = testSubEvents.get(0);
+        assertEquals(actualSubmission.getId(), actualSubEvent.getSubmission().getId());
+
+        verify(dspaceDepositService, times(1)).deleteDeposit(
+            argThat(deposit -> deposit.getRepository().getRepositoryKey().equals("TestDspace")),
+            any(DspaceDepositService.AuthContext.class));
+        verify(dspaceDepositService, times(0)).deleteDeposit(
+            argThat(deposit -> deposit.getRepository().getRepositoryKey().equals("TestNihms")),
+            any(DspaceDepositService.AuthContext.class));
+        verifyDspaceApiStubs(1);
+    }
+
+    @Test
+    public void testProcessTestData_DoesNotDeleteDspaceDepositIfSkip() throws Exception {
+        // GIVEN
+        Grant testGrant = new Grant();
+        testGrant.setProjectName(PASS_E2E_TEST_GRANT);
+        testGrant.setAwardStatus(AwardStatus.ACTIVE);
+        passClient.createObject(testGrant);
+        initSubmissionAndDeposits(testGrant);
+        initDspaceApiStubs("Test-Title");
+
+        // WHEN
+        deploymentTestDataService.processTestData();
+
+        // THEN
+        verifyTestGrantDeleted();
+        verify(dspaceDepositService, times(0)).deleteDeposit(
+            argThat(deposit -> deposit.getRepository().getRepositoryKey().equals("TestDspace")),
+            any(DspaceDepositService.AuthContext.class));
+        verify(dspaceDepositService, times(0)).deleteDeposit(
+            argThat(deposit -> deposit.getRepository().getRepositoryKey().equals("TestNihms")),
+            any(DspaceDepositService.AuthContext.class));
+        verifyDspaceApiStubs(0);
+    }
+
+    @Test
+    public void testProcessTestData_DoesNotDeleteDspaceDepositIfNameMismatch() throws Exception {
+        // GIVEN
+        Grant testGrant = new Grant();
+        testGrant.setProjectName(PASS_E2E_TEST_GRANT);
+        testGrant.setAwardStatus(AwardStatus.ACTIVE);
+        passClient.createObject(testGrant);
+        initSubmissionAndDeposits(testGrant);
+        initDspaceApiStubs("Test-Title-Mismatch");
+        ReflectionTestUtils.setField(deploymentTestDataService, "skipDeploymentTestDeposits", Boolean.FALSE);
+
+        // WHEN
+        deploymentTestDataService.processTestData();
+
+        // THEN
+        verifyTestGrantDeleted();
+        verify(dspaceDepositService, times(1)).deleteDeposit(
+            argThat(deposit -> deposit.getRepository().getRepositoryKey().equals("TestDspace")),
+            any(DspaceDepositService.AuthContext.class));
+        verify(dspaceDepositService, times(0)).deleteDeposit(
+            argThat(deposit -> deposit.getRepository().getRepositoryKey().equals("TestNihms")),
+            any(DspaceDepositService.AuthContext.class));
+        WireMock.verify(1, getRequestedFor(urlEqualTo("/server/api/security/csrf")));
+        WireMock.verify(1, postRequestedFor(urlEqualTo("/server/api/authn/login")));
+        WireMock.verify(1, getRequestedFor(
+            urlEqualTo("/server/api/discover/search/objects?query=handle:a.1234%2Fabcd&dsoType=item")));
+        WireMock.verify(0, getRequestedFor(urlEqualTo("/server/api/core/items/12345-aabb/bundles")));
+        WireMock.verify(0, deleteRequestedFor(urlEqualTo("/server/api/core/bundles/aa-11")));
+        WireMock.verify(0, deleteRequestedFor(urlEqualTo("/server/api/core/bundles/bb-22")));
+        WireMock.verify(0, deleteRequestedFor(urlEqualTo("/server/api/core/bundles/cc-33")));
+        WireMock.verify(0, deleteRequestedFor(urlEqualTo("/server/api/core/items/12345-aabb")));
+    }
+
+    private Submission initSubmissionAndDeposits(Grant testGrant) throws Exception {
+        Submission submission = new Submission();
+        submission.setMetadata(
+            "{\"issns\":[{\"issn\":\"1234\",\"pubType\":\"Print\"}],\"journal-title\":\"Test-Journal\"," +
+                "\"title\":\"Test-Title\",\"authors\":[{\"author\":\"test-user\"}],\"agreements\":" +
+                "[{\"TestDspace\":\"Test agreement\"}]}"
+        );
+        submission.setGrants(List.of(testGrant));
+        submission.setSubmittedDate(ZonedDateTime.now().minusDays(2));
+        passClient.createObject(submission);
+
+        Repository repositoryDspace = new Repository();
+        repositoryDspace.setName("test-repository-dspace");
+        repositoryDspace.setRepositoryKey("TestDspace");
+        passClient.createObject(repositoryDspace);
+
+        Repository repositoryNihms = new Repository();
+        repositoryNihms.setName("test-repository-nihms");
+        repositoryNihms.setRepositoryKey("TestNihms");
+        passClient.createObject(repositoryNihms);
+
+        Publication publication = new Publication();
+        publication.setTitle("test-publication");
+        passClient.createObject(publication);
+
+        RepositoryCopy repositoryCopyDspace = new RepositoryCopy();
+        repositoryCopyDspace.setRepository(repositoryDspace);
+        repositoryCopyDspace.setPublication(publication);
+        repositoryCopyDspace.setAccessUrl(URI.create("http://localhost:9020/handle/a.1234/abcd"));
+        passClient.createObject(repositoryCopyDspace);
+
+        RepositoryCopy repositoryCopyNihms = new RepositoryCopy();
+        repositoryCopyNihms.setRepository(repositoryNihms);
+        repositoryCopyNihms.setPublication(publication);
+        repositoryCopyDspace.setAccessUrl(URI.create("http://foobar/nihms-fake"));
+        passClient.createObject(repositoryCopyNihms);
+
+        Deposit dspaceDeposit = new Deposit();
+        dspaceDeposit.setSubmission(submission);
+        dspaceDeposit.setDepositStatus(DepositStatus.SUBMITTED);
+        dspaceDeposit.setRepositoryCopy(repositoryCopyDspace);
+        dspaceDeposit.setRepository(repositoryDspace);
+        passClient.createObject(dspaceDeposit);
+
+        Deposit nihmsDeposit = new Deposit();
+        nihmsDeposit.setSubmission(submission);
+        nihmsDeposit.setDepositStatus(DepositStatus.SUBMITTED);
+        nihmsDeposit.setRepositoryCopy(repositoryCopyNihms);
+        nihmsDeposit.setRepository(repositoryNihms);
+        passClient.createObject(nihmsDeposit);
+
+        submission.setPublication(publication);
+        passClient.updateObject(submission);
+
+        File file = new File();
+        String data = "Test data file";
+        file.setName("test_data_file.txt");
+        URI data_uri = passClient.uploadBinary(file.getName(), data.getBytes(StandardCharsets.UTF_8));
+        assertNotNull(data_uri);
+        file.setUri(data_uri);
+        file.setSubmission(submission);
+        passClient.createObject(file);
+
+        PassClientSelector<User> selectorUser = new PassClientSelector<>(User.class);
+        selectorUser.setFilter(RSQL.equals("email", "test-user-email@foo"));
+        User testUser = passClient.streamObjects(selectorUser).toList().get(0);
+
+        SubmissionEvent submissionEvent = new SubmissionEvent();
+        submissionEvent.setSubmission(submission);
+        submissionEvent.setEventType(EventType.SUBMITTED);
+        submissionEvent.setPerformedBy(testUser);
+        passClient.createObject(submissionEvent);
+
+        return submission;
+    }
+
+    private void verifyTestGrantDeleted() throws IOException {
         PassClientSelector<Grant> grantSelector = new PassClientSelector<>(Grant.class);
         grantSelector.setFilter(RSQL.equals("projectName", PASS_E2E_TEST_GRANT));
         List<Grant> testGrants = passClient.streamObjects(grantSelector).toList();
@@ -205,120 +453,44 @@ public class DeploymentTestDataServiceIT extends AbstractDepositIT {
         assertTrue(testSubEvents.isEmpty());
     }
 
-    @Test
-    public void testProcessData_DoesNotDeleteTestSubmissionsForOtherGrant() throws Exception {
-        // GIVEN
-        Grant deploymentGrant = new Grant();
-        deploymentGrant.setProjectName(PASS_E2E_TEST_GRANT);
-        deploymentGrant.setAwardStatus(AwardStatus.ACTIVE);
-        passClient.createObject(deploymentGrant);
-        initSubmissionAndDeposits(deploymentGrant);
+    private void initDspaceApiStubs(String expectedName) throws Exception {
+        stubFor(get("/server/api/security/csrf")
+            .willReturn(ok().withHeader("DSPACE-XSRF-TOKEN", "test-csrf-token")));
+        stubFor(post("/server/api/authn/login")
+            .willReturn(ok().withHeader("Authorization", "test-auth-token")));
 
-        Grant testOtherGrant = new Grant();
-        testOtherGrant.setProjectName("Some Other Grant");
-        testOtherGrant.setAwardStatus(AwardStatus.ACTIVE);
-        passClient.createObject(testOtherGrant);
-        Submission testOtherSubmission = initSubmissionAndDeposits(testOtherGrant);
+        String searchJson = Files.readString(
+            Paths.get(DeploymentTestDataServiceIT.class.getResource("/dspace-resp/search.json").toURI()))
+            .replaceAll("<item_name>", expectedName);
+        stubFor(get("/server/api/discover/search/objects?query=handle:a.1234%2Fabcd&dsoType=item")
+            .willReturn(ok(searchJson)));
 
-        // WHEN
-        deploymentTestDataService.processTestData();
+        String bundlesJson = Files.readString(
+            Paths.get(DeploymentTestDataServiceIT.class.getResource("/dspace-resp/bundles.json").toURI()));
+        stubFor(get("/server/api/core/items/12345-aabb/bundles")
+            .willReturn(ok(bundlesJson)));
 
-        // THEN
-        final PassClientSelector<Grant> grantSelector = new PassClientSelector<>(Grant.class);
-        grantSelector.setFilter(RSQL.equals("projectName", PASS_E2E_TEST_GRANT));
-        List<Grant> actualTestGrants = passClient.streamObjects(grantSelector).toList();
-        assertEquals(1, actualTestGrants.size());
-        Grant actualTestGrant = actualTestGrants.get(0);
-        assertEquals(PASS_E2E_TEST_GRANT, actualTestGrant.getProjectName());
-        assertEquals(AwardStatus.ACTIVE, actualTestGrant.getAwardStatus());
+        stubFor(delete("/server/api/core/bundles/aa-11")
+            .willReturn(ok()));
+        stubFor(delete("/server/api/core/bundles/bb-22")
+            .willReturn(ok()));
+        stubFor(delete("/server/api/core/bundles/cc-33")
+            .willReturn(ok()));
 
-        PassClientSelector<Submission> submissionSelector = new PassClientSelector<>(Submission.class);
-        List<Submission> testSubmissions = passClient.streamObjects(submissionSelector).toList();
-        assertEquals(1, testSubmissions.size());
-        Submission actualSubmission = testSubmissions.get(0);
-        assertEquals(testOtherSubmission.getId(), actualSubmission.getId());
-        assertEquals(testOtherGrant.getId(), actualSubmission.getGrants().get(0).getId());
-
-        PassClientSelector<Deposit> depositSelector = new PassClientSelector<>(Deposit.class);
-        List<Deposit> testDeposits = passClient.streamObjects(depositSelector).toList();
-        assertEquals(1, testDeposits.size());
-        Deposit actualDeposit = testDeposits.get(0);
-        assertEquals(testOtherSubmission.getId(), actualDeposit.getSubmission().getId());
-
-        PassClientSelector<RepositoryCopy> repoCopySelector = new PassClientSelector<>(RepositoryCopy.class);
-        List<RepositoryCopy> testRepoCopies = passClient.streamObjects(repoCopySelector).toList();
-        assertEquals(1, testRepoCopies.size());
-        RepositoryCopy actualRepoCopy = testRepoCopies.get(0);
-        assertEquals(actualDeposit.getRepositoryCopy().getId(), actualRepoCopy.getId());
-
-        PassClientSelector<Publication> publicationSelector = new PassClientSelector<>(Publication.class);
-        List<Publication> testPublications = passClient.streamObjects(publicationSelector).toList();
-        assertEquals(1, testPublications.size());
-        Publication actualPublication = testPublications.get(0);
-        assertEquals(actualRepoCopy.getPublication().getId(), actualPublication.getId());
-        assertEquals(actualSubmission.getPublication().getId(), actualPublication.getId());
-
-        PassClientSelector<File> fileSelector = new PassClientSelector<>(File.class);
-        List<File> testFiles = passClient.streamObjects(fileSelector).toList();
-        assertEquals(1, testFiles.size());
-        File actualFile = testFiles.get(0);
-        assertEquals(actualSubmission.getId(), actualFile.getSubmission().getId());
-
-        PassClientSelector<SubmissionEvent> subEventSelector = new PassClientSelector<>(SubmissionEvent.class);
-        List<SubmissionEvent> testSubEvents = passClient.streamObjects(subEventSelector).toList();
-        assertEquals(1, testSubEvents.size());
-        SubmissionEvent actualSubEvent = testSubEvents.get(0);
-        assertEquals(actualSubmission.getId(), actualSubEvent.getSubmission().getId());
+        stubFor(delete("/server/api/core/items/12345-aabb")
+            .willReturn(ok()));
     }
 
-    private Submission initSubmissionAndDeposits(Grant testGrant) throws Exception {
-        Submission submission = new Submission();
-        submission.setGrants(List.of(testGrant));
-        submission.setSubmittedDate(ZonedDateTime.now().minusDays(2));
-        passClient.createObject(submission);
-
-        Repository repository = new Repository();
-        repository.setName("test-repository");
-        passClient.createObject(repository);
-
-        Publication publication = new Publication();
-        publication.setTitle("test-publication");
-        passClient.createObject(publication);
-
-        RepositoryCopy repositoryCopy = new RepositoryCopy();
-        repositoryCopy.setRepository(repository);
-        repositoryCopy.setPublication(publication);
-        passClient.createObject(repositoryCopy);
-
-        Deposit j10pDeposit = new Deposit();
-        j10pDeposit.setSubmission(submission);
-        j10pDeposit.setDepositStatus(DepositStatus.SUBMITTED);
-        j10pDeposit.setRepositoryCopy(repositoryCopy);
-        passClient.createObject(j10pDeposit);
-
-        submission.setPublication(publication);
-        passClient.updateObject(submission);
-
-        File file = new File();
-        String data = "Test data file";
-        file.setName("test_data_file.txt");
-        URI data_uri = passClient.uploadBinary(file.getName(), data.getBytes(StandardCharsets.UTF_8));
-        assertNotNull(data_uri);
-        file.setUri(data_uri);
-        file.setSubmission(submission);
-        passClient.createObject(file);
-
-        PassClientSelector<User> selectorUser = new PassClientSelector<>(User.class);
-        selectorUser.setFilter(RSQL.equals("email", "test-user-email@foo"));
-        User testUser = passClient.streamObjects(selectorUser).toList().get(0);
-
-        SubmissionEvent submissionEvent = new SubmissionEvent();
-        submissionEvent.setSubmission(submission);
-        submissionEvent.setEventType(EventType.SUBMITTED);
-        submissionEvent.setPerformedBy(testUser);
-        passClient.createObject(submissionEvent);
-
-        return submission;
+    private void verifyDspaceApiStubs(int expectedCount) {
+        WireMock.verify(expectedCount, getRequestedFor(urlEqualTo("/server/api/security/csrf")));
+        WireMock.verify(expectedCount, postRequestedFor(urlEqualTo("/server/api/authn/login")));
+        WireMock.verify(expectedCount, getRequestedFor(
+            urlEqualTo("/server/api/discover/search/objects?query=handle:a.1234%2Fabcd&dsoType=item")));
+        WireMock.verify(expectedCount, getRequestedFor(urlEqualTo("/server/api/core/items/12345-aabb/bundles")));
+        WireMock.verify(expectedCount, deleteRequestedFor(urlEqualTo("/server/api/core/bundles/aa-11")));
+        WireMock.verify(expectedCount, deleteRequestedFor(urlEqualTo("/server/api/core/bundles/bb-22")));
+        WireMock.verify(expectedCount, deleteRequestedFor(urlEqualTo("/server/api/core/bundles/cc-33")));
+        WireMock.verify(expectedCount, deleteRequestedFor(urlEqualTo("/server/api/core/items/12345-aabb")));
     }
 
 }

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/support/jobs/ScheduledJobsTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/support/jobs/ScheduledJobsTest.java
@@ -20,9 +20,9 @@ import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.verify;
 
 import org.eclipse.pass.deposit.DepositApp;
-import org.eclipse.pass.deposit.service.DeploymentTestDataService;
 import org.eclipse.pass.deposit.service.DepositUpdater;
 import org.eclipse.pass.deposit.service.SubmissionStatusUpdater;
+import org.eclipse.pass.deposit.support.deploymenttest.DeploymentTestDataService;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;

--- a/pass-deposit-services/deposit-core/src/test/resources/dspace-resp/bundles.json
+++ b/pass-deposit-services/deposit-core/src/test/resources/dspace-resp/bundles.json
@@ -81,16 +81,16 @@
         "type": "bundle",
         "_links": {
           "item": {
-            "href": "https://localhost:9020/server/api/core/bundles/cc-22/item"
+            "href": "https://localhost:9020/server/api/core/bundles/cc-33/item"
           },
           "bitstreams": {
-            "href": "https://localhost:9020/server/api/core/bundles/cc-22/bitstreams"
+            "href": "https://localhost:9020/server/api/core/bundles/cc-33/bitstreams"
           },
           "primaryBitstream": {
-            "href": "https://localhost:9020/server/api/core/bundles/cc-22/primaryBitstream"
+            "href": "https://localhost:9020/server/api/core/bundles/cc-33/primaryBitstream"
           },
           "self": {
-            "href": "https://localhost:9020/server/api/core/bundles/cc-22"
+            "href": "https://localhost:9020/server/api/core/bundles/cc-33"
           }
         }
       }

--- a/pass-deposit-services/deposit-core/src/test/resources/dspace-resp/bundles.json
+++ b/pass-deposit-services/deposit-core/src/test/resources/dspace-resp/bundles.json
@@ -1,0 +1,110 @@
+{
+  "_embedded": {
+    "bundles": [
+      {
+        "uuid": "aa-11",
+        "name": "ORIGINAL",
+        "handle": null,
+        "metadata": {
+          "dc.title": [
+            {
+              "value": "ORIGINAL",
+              "language": null,
+              "authority": null,
+              "confidence": -1,
+              "place": 0
+            }
+          ]
+        },
+        "type": "bundle",
+        "_links": {
+          "item": {
+            "href": "https://localhost:9020/server/api/core/bundles/aa-11/item"
+          },
+          "bitstreams": {
+            "href": "https://localhost:9020/server/api/core/bundles/aa-11/bitstreams"
+          },
+          "primaryBitstream": {
+            "href": "https://localhost:9020/server/api/core/bundles/aa-11/primaryBitstream"
+          },
+          "self": {
+            "href": "https://localhost:9020/server/api/core/bundles/aa-11"
+          }
+        }
+      },
+      {
+        "uuid": "bb-22",
+        "name": "LICENSE",
+        "handle": null,
+        "metadata": {
+          "dc.title": [
+            {
+              "value": "LICENSE",
+              "language": null,
+              "authority": null,
+              "confidence": -1,
+              "place": 0
+            }
+          ]
+        },
+        "type": "bundle",
+        "_links": {
+          "item": {
+            "href": "https://localhost:9020/server/api/core/bundles/bb-22/item"
+          },
+          "bitstreams": {
+            "href": "https://localhost:9020/server/api/core/bundles/bb-22/bitstreams"
+          },
+          "primaryBitstream": {
+            "href": "https://localhost:9020/server/api/core/bundles/bb-22/primaryBitstream"
+          },
+          "self": {
+            "href": "https://localhost:9020/server/api/core/bundles/bb-22"
+          }
+        }
+      },
+      {
+        "uuid": "cc-33",
+        "name": "SWORD",
+        "handle": null,
+        "metadata": {
+          "dc.title": [
+            {
+              "value": "SWORD",
+              "language": null,
+              "authority": null,
+              "confidence": -1,
+              "place": 0
+            }
+          ]
+        },
+        "type": "bundle",
+        "_links": {
+          "item": {
+            "href": "https://localhost:9020/server/api/core/bundles/cc-22/item"
+          },
+          "bitstreams": {
+            "href": "https://localhost:9020/server/api/core/bundles/cc-22/bitstreams"
+          },
+          "primaryBitstream": {
+            "href": "https://localhost:9020/server/api/core/bundles/cc-22/primaryBitstream"
+          },
+          "self": {
+            "href": "https://localhost:9020/server/api/core/bundles/cc-22"
+          }
+        }
+      }
+    ]
+  },
+  "page": {
+    "number": 0,
+    "size": 20,
+    "totalPages": 1,
+    "totalElements": 3
+  },
+  "_links": {
+    "self": {
+      "href": "https://localhost:9020/server/api/core/items/12345-aabb/bundles"
+    }
+  }
+}

--- a/pass-deposit-services/deposit-core/src/test/resources/dspace-resp/search.json
+++ b/pass-deposit-services/deposit-core/src/test/resources/dspace-resp/search.json
@@ -1,0 +1,168 @@
+{
+  "id": null,
+  "scope": null,
+  "query": "handle:a.1234/abcd",
+  "appliedFilters": null,
+  "sort": null,
+  "configuration": null,
+  "type": "discover",
+  "_links": {
+    "self": {
+      "href": "http://localhost:9020/server/api/discover/search/objects?query=handle:a.1234%2Fabcd&dsoType=item"
+    }
+  },
+  "_embedded": {
+    "searchResult": {
+      "_embedded": {
+        "objects": [
+          {
+            "hitHighlights": null,
+            "type": "discover",
+            "_links": {
+              "indexableObject": {
+                "href": "http://localhost:9020/12345-aabb"
+              }
+            },
+            "_embedded": {
+              "indexableObject": {
+                "id": "12345-aabb",
+                "uuid": "12345-aabb",
+                "name": "<item_name>",
+                "handle": "a.1234/abcd",
+                "metadata": {
+                  "dc.contributor": [
+                    {
+                      "value": "TestUser",
+                      "language": null,
+                      "authority": null,
+                      "confidence": -1,
+                      "place": 0
+                    }
+                  ],
+                  "dc.date.accessioned": [
+                    {
+                      "value": "2024-06-26T19:34:25Z",
+                      "language": null,
+                      "authority": null,
+                      "confidence": -1,
+                      "place": 0
+                    }
+                  ],
+                  "dc.date.available": [
+                    {
+                      "value": "2024-06-26T19:34:25Z",
+                      "language": null,
+                      "authority": null,
+                      "confidence": -1,
+                      "place": 0
+                    }
+                  ],
+                  "dc.date.updated": [
+                    {
+                      "value": "2024-06-26T19:34:25Z",
+                      "language": null,
+                      "authority": null,
+                      "confidence": -1,
+                      "place": 0
+                    }
+                  ],
+                  "dc.identifier.citation": [
+                    {
+                      "value": "TestUser. This is a test.",
+                      "language": null,
+                      "authority": null,
+                      "confidence": -1,
+                      "place": 0
+                    }
+                  ],
+                  "dc.identifier.uri": [
+                    {
+                      "value": "http://localhost:9020/handle/a.1234/abcd",
+                      "language": null,
+                      "authority": null,
+                      "confidence": -1,
+                      "place": 0
+                    }
+                  ],
+                  "dc.title": [
+                    {
+                      "value": "Test-Title",
+                      "language": null,
+                      "authority": null,
+                      "confidence": -1,
+                      "place": 0
+                    }
+                  ]
+                },
+                "inArchive": true,
+                "discoverable": true,
+                "withdrawn": false,
+                "lastModified": "2024-07-11T20:27:29.243+00:00",
+                "entityType": null,
+                "type": "item",
+                "_links": {
+                  "accessStatus": {
+                    "href": "http://localhost:9020/server/api/core/items/12345-aabb/accessStatus"
+                  },
+                  "bundles": {
+                    "href": "http://localhost:9020/server/api/core/items/12345-aabb/bundles"
+                  },
+                  "identifiers": {
+                    "href": "http://localhost:9020/server/api/core/items/12345-aabb/identifiers"
+                  },
+                  "mappedCollections": {
+                    "href": "http://localhost:9020/server/api/core/items/12345-aabb/mappedCollections"
+                  },
+                  "owningCollection": {
+                    "href": "http://localhost:9020/server/api/core/items/12345-aabb/owningCollection"
+                  },
+                  "relationships": {
+                    "href": "http://localhost:9020/server/api/core/items/12345-aabb/relationships"
+                  },
+                  "version": {
+                    "href": "http://localhost:9020/server/api/core/items/12345-aabb/version"
+                  },
+                  "templateItemOf": {
+                    "href": "http://localhost:9020/server/api/core/items/12345-aabb/templateItemOf"
+                  },
+                  "thumbnail": {
+                    "href": "http://localhost:9020/server/api/core/items/12345-aabb/thumbnail"
+                  },
+                  "self": {
+                    "href": "http://localhost:9020/server/api/core/items/12345-aabb"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "page": {
+        "number": 0,
+        "size": 20,
+        "totalPages": 1,
+        "totalElements": 1
+      },
+      "_links": {
+        "self": {
+          "href": "http://localhost:9020/server/api/discover/search/objects?query=handle:a.1234%2Fabcd&dsoType=item"
+        }
+      }
+    },
+    "facets": [
+      {
+        "name": "subject",
+        "facetType": "hierarchical",
+        "facetLimit": 5,
+        "_links": {
+          "self": {
+            "href": "http://localhost:9020/server/api/discover/facets/subject?query=handle:a.1234%2Fabcd&dsoType=item"
+          }
+        },
+        "_embedded": {
+          "values": []
+        }
+      }
+    ]
+  }
+}

--- a/pass-deposit-services/pom.xml
+++ b/pass-deposit-services/pom.xml
@@ -486,6 +486,8 @@
                 <ignoredUsedUndeclaredDependency>com.icegreen:greenmail:</ignoredUsedUndeclaredDependency>
                 <!-- These come from sshd-sftp -->
                 <ignoredUsedUndeclaredDependency>org.apache.sshd:sshd*:</ignoredUsedUndeclaredDependency>
+                <!-- This comes from org.apache.httpcomponents.client5:httpclient5 dep -->
+                <ignoredUsedUndeclaredDependency>org.apache.httpcomponents.core5:httpcore5:</ignoredUsedUndeclaredDependency>
               </ignoredUsedUndeclaredDependencies>
               <ignoredUnusedDeclaredDependencies>
                 <!-- junit-jupiter is a module containing the junit api jars used directly -->

--- a/pass-journal-loader/pass-journal-loader-nih/pom.xml
+++ b/pass-journal-loader/pass-journal-loader-nih/pom.xml
@@ -12,7 +12,7 @@
 
   <properties>
     <!-- Properties for dependency versions -->
-    <wiremock-jre8.version>2.35.1</wiremock-jre8.version>
+    <wiremock.version>3.3.1</wiremock.version>
     <!-- Properties for ITs -->
     <pass.core.port>8080</pass.core.port>
     <pass.core.url>http://localhost:8080</pass.core.url>
@@ -64,9 +64,9 @@
     </dependency>
 
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
-      <version>${wiremock-jre8.version}</version>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
+      <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
The following changes have been made to the deployment tests data cleanup feature:

- Added a new application property named `pass.test.skip.deposits` that is `true` by default.  If this property is true, any deposit for a submission associated with the deployment test grant will not be deposited into the downstream repository.
     - There is a new `DevNullTransport` that will be used in the skip deposits case that will do nothing with the package contents but will create the `RepositoryCopy` and set the Deposit.depositStatus to `ACCEPTED`.
- If the `pass.test.skip.deposits` is `false`, then the deployment tests deposits will be made in the downstream repositories.  
     - In this case, the new service class `DspaceDepositService` is used to delete the DSpace deposits.  The deposit will be deleted from DSpace in about an hour after it was created.
     - The `DspaceDepositService` code is invoked as part of the `DeploymentTestDataJob` which run periodically to clean up deployment test data.