### PR TITLE
Fix deployment test repocopy externalId value

### DIFF
--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/transport/devnull/DevNullTransport.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/transport/devnull/DevNullTransport.java
@@ -85,11 +85,11 @@ public class DevNullTransport implements Transport {
                                             (rc) -> true,
                                             (rc) -> true,
                                             (rc) -> {
-                                                rc.getExternalIds().add("devnull-fake-extid-" + repositoryCopy.getId());
+                                                String accessUrl = "https://devnull-fake-url/handle/" +
+                                                    repositoryCopy.getId();
+                                                rc.getExternalIds().add(accessUrl);
                                                 rc.setCopyStatus(CopyStatus.COMPLETE);
-                                                rc.setAccessUrl(
-                                                    URI.create("https://devnull-fake-url/handle/" + repositoryCopy.getId())
-                                                );
+                                                rc.setAccessUrl(URI.create(accessUrl));
                                                 return rc;
                                             }, true);
 

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/SubmissionProcessorIT.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/SubmissionProcessorIT.java
@@ -219,9 +219,14 @@ public class SubmissionProcessorIT extends AbstractSubmissionIT {
         RepositoryCopy j10pRepoCopy = passClient.getObject(deposit.getRepositoryCopy());
         String accessUrl = j10pRepoCopy.getAccessUrl().toString();
         if (usingDevNull) {
-            assertEquals("https://devnull-fake-url/handle/" + j10pRepoCopy.getId(), accessUrl);
+            String expectedUrl = "https://devnull-fake-url/handle/" + j10pRepoCopy.getId();
+            assertEquals(expectedUrl, accessUrl);
+            assertEquals(1, j10pRepoCopy.getExternalIds().size());
+            assertEquals(expectedUrl, j10pRepoCopy.getExternalIds().get(0));
         } else {
             assertTrue(accessUrl.startsWith("file:"));
+            assertEquals(1, j10pRepoCopy.getExternalIds().size());
+            assertTrue(j10pRepoCopy.getExternalIds().get(0).startsWith("file:"));
         }
     }
 


### PR DESCRIPTION
This is needed so deployment tests can pass whether skip deposits is true or false.  Turns out the UI uses both the RepoCopy.accessUrl and RepoCopy.externalId values for rendering.  Had to change the dev null transport to set the accessUrl as an externalId too.