### PR TITLE
NIHMS API Token Refresh RPA

### DIFF
--- a/pass-nihms-loader/nihms-token-refresh/README.md
+++ b/pass-nihms-loader/nihms-token-refresh/README.md
@@ -1,11 +1,11 @@
-# NIHMS API Token Refresher
+# NIHMS API Token Refresh
 
 The NIHMS harvester process requires an Authentication token.  This token is available from the PACM utils page and is
-valid for three months.  There is currently no API available to refresh the token.  This small TestCafe script logs
+valid for three months.  There is currently no API available to refresh the token.  This TestCafe script logs
 into the PACM utils page using th ERA Commons login option, clicks on the API Token link, and writes the new token
 to a file named in the `NIHMS_OUTFILE` environment variable.
 
-In order to run the token refresher, do the following:
+In order to run the token refresh RPA, do the following:
 
 - Install NodeJS version 20 or higher: https://nodejs.org/en/learn/getting-started/how-to-install-nodejs
 

--- a/pass-nihms-loader/nihms-token-refresh/README.md
+++ b/pass-nihms-loader/nihms-token-refresh/README.md
@@ -1,0 +1,23 @@
+# NIHMS API Token Refresher
+
+The NIHMS harvester process requires an Authentication token.  This token is available from the PACM utils page and is
+valid for three months.  There is currently no API available to refresh the token.  This small TestCafe script logs
+into the PACM utils page using th ERA Commons login option, clicks on the API Token link, and writes the new token
+to a file named in the `NIHMS_OUTFILE` environment variable.
+
+In order to run the token refresher, do the following:
+
+- Install NodeJS version 20 or higher: https://nodejs.org/en/learn/getting-started/how-to-install-nodejs
+
+- Set the following environment variables:
+
+`NIHMS_USER` : The ERA Commons login username  
+`NIHMS_PASSWORD` : The ERA Commons login password  
+`NIHMS_OUTFILE` : The full path to the file to write the new token
+
+- Then run the following:
+
+`npm install`  
+`npm run refresh-token`  
+
+

--- a/pass-nihms-loader/nihms-token-refresh/package.json
+++ b/pass-nihms-loader/nihms-token-refresh/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "nihms-token-refresh",
+  "version": "1.0",
+  "description": "RAP to refresh NIHMS API token",
+  "type": "module",
+  "scripts": {
+    "refresh-token": "./run.sh"
+  },
+  "devDependencies": {
+    "testcafe": "3.3.0"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/pass-nihms-loader/nihms-token-refresh/refreshtoken.js
+++ b/pass-nihms-loader/nihms-token-refresh/refreshtoken.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fixture, test, Selector } from 'testcafe';
+import fs from 'fs';
+
+fixture('NIHMS API Token Refresh')
+    .skipJsErrors();
+
+test('Get New NIHMS API Token', async t => {
+    const nihmsUser = process.env.NIHMS_USER;
+    const nihmsPassword = process.env.NIHMS_PASSWORD;
+
+    await t
+        .navigateTo('https://www.ncbi.nlm.nih.gov/pmc/utils/pacm/login')
+        .setTestSpeed(0.5)
+        .switchToIframe('#loginframe')
+        .click(Selector('#era'))
+        .switchToMainWindow()
+        .typeText('#USER', nihmsUser)
+        .typeText('#PASSWORD', nihmsPassword)
+        .click('form.nih-login-form button.nih-white-button')
+        .click(Selector('a').withText('API Token'));
+
+    const sectionContent = await Selector('div.section-content').textContent;
+    const partsContent = sectionContent.split('&api-token=');
+    if (partsContent.length < 2) {
+        throw new Error('Unable to find api-token in: ' + sectionContent);
+    }
+    const token = partsContent[1];
+    const nihmsOutFile = process.env.NIHMS_OUTFILE;
+    try {
+        fs.writeFileSync(nihmsOutFile, token);
+    } catch (err) {
+        console.error(err);
+    }
+});

--- a/pass-nihms-loader/nihms-token-refresh/refreshtoken.js
+++ b/pass-nihms-loader/nihms-token-refresh/refreshtoken.js
@@ -41,9 +41,5 @@ test('Get New NIHMS API Token', async t => {
     }
     const token = partsContent[1];
     const nihmsOutFile = process.env.NIHMS_OUTFILE;
-    try {
-        fs.writeFileSync(nihmsOutFile, token);
-    } catch (err) {
-        console.error(err);
-    }
+    fs.writeFileSync(nihmsOutFile, token);
 });

--- a/pass-nihms-loader/nihms-token-refresh/run.sh
+++ b/pass-nihms-loader/nihms-token-refresh/run.sh
@@ -1,0 +1,3 @@
+#! /bin/sh
+
+testcafe 'chrome' refreshtoken.js


### PR DESCRIPTION
This adds the NIHMS API Token Refresher RPA using TestCafe.  The `README.md` in the `nihms-token-refresh` directory has instructions for running it to produce the file with the new token in it.