### PR TITLE
Change repackage configurations

### DIFF
--- a/pass-deposit-services/deposit-core/Dockerfile
+++ b/pass-deposit-services/deposit-core/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:17.0.8_7-jre-jammy
 
 WORKDIR /app
 
-COPY target/pass-deposit-service-exec.jar .
+COPY target/deposit-core-*-exec.jar pass-deposit-service-exec.jar
 COPY entrypoint.sh .
 
 RUN apt update \

--- a/pass-deposit-services/deposit-core/pom.xml
+++ b/pass-deposit-services/deposit-core/pom.xml
@@ -318,16 +318,17 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <configuration>
-          <mainClass>org.eclipse.pass.deposit.DepositApp</mainClass>
-          <finalName>pass-deposit-service</finalName>
-          <classifier>exec</classifier>
-        </configuration>
         <executions>
           <execution>
+            <id>repackage</id>
             <goals>
               <goal>repackage</goal>
             </goals>
+            <configuration>
+              <mainClass>org.eclipse.pass.deposit.DepositApp</mainClass>
+              <classifier>exec</classifier>
+              <attach>false</attach>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/pass-grant-loader/Dockerfile
+++ b/pass-grant-loader/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:17.0.8_7-jre-jammy
 
 WORKDIR /app
 
-COPY target/jhu-grant-loader-exec.jar .
+COPY target/pass-grant-loader-*-exec.jar jhu-grant-loader-exec.jar
 COPY entrypoint.sh .
 
 RUN apt update \

--- a/pass-grant-loader/pom.xml
+++ b/pass-grant-loader/pom.xml
@@ -221,16 +221,17 @@
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-maven-plugin</artifactId>
           <version>${spring-boot-maven-plugin.version}</version>
-          <configuration>
-            <mainClass>org.eclipse.pass.support.grant.GrantLoaderCLI</mainClass>
-            <finalName>jhu-grant-loader</finalName>
-            <classifier>exec</classifier>
-          </configuration>
           <executions>
             <execution>
+              <id>repackage</id>
               <goals>
                 <goal>repackage</goal>
               </goals>
+              <configuration>
+                <mainClass>org.eclipse.pass.support.grant.GrantLoaderCLI</mainClass>
+                <classifier>exec</classifier>
+                <attach>false</attach>
+              </configuration>
             </execution>
           </executions>
         </plugin>

--- a/pass-journal-loader/pass-journal-loader-nih/Dockerfile
+++ b/pass-journal-loader/pass-journal-loader-nih/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:17.0.8_7-jre-jammy
 
 WORKDIR /app
 
-COPY target/pass-journal-loader-nih-exec.jar .
+COPY target/pass-journal-loader-nih-*-exec.jar pass-journal-loader-nih-exec.jar
 COPY entrypoint.sh .
 
 RUN apt update \

--- a/pass-journal-loader/pass-journal-loader-nih/pom.xml
+++ b/pass-journal-loader/pass-journal-loader-nih/pom.xml
@@ -73,35 +73,21 @@
 
   <build>
     <plugins>
+
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <version>3.0.0</version>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${spring-boot-maven-plugin.version}</version>
         <executions>
           <execution>
+            <id>repackage</id>
             <goals>
-              <goal>shade</goal>
+              <goal>repackage</goal>
             </goals>
             <configuration>
-              <shadedArtifactAttached>true</shadedArtifactAttached>
-              <shadedClassifierName>exe</shadedClassifierName>
-              <finalName>pass-journal-loader-nih-exec</finalName>
-              <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <mainClass>org.eclipse.pass.loader.journal.nih.Main</mainClass>
-                </transformer>
-              </transformers>
-              <filters>
-                <filter>
-                  <artifact>*:*</artifact>
-                  <excludes>
-                    <exclude>META-INF/*.SF</exclude>
-                    <exclude>META-INF/*.DSA</exclude>
-                    <exclude>META-INF/*.RSA</exclude>
-                  </excludes>
-                </filter>
-              </filters>
+              <mainClass>org.eclipse.pass.loader.journal.nih.Main</mainClass>
+              <classifier>exec</classifier>
+              <attach>false</attach>
             </configuration>
           </execution>
         </executions>

--- a/pass-journal-loader/pom.xml
+++ b/pass-journal-loader/pom.xml
@@ -26,6 +26,7 @@
   </modules>
 
   <properties>
+    <spring-boot-maven-plugin.version>3.2.1</spring-boot-maven-plugin.version>
     <commons.csv.version>1.10.0</commons.csv.version>
     <commons-lang.version>3.14.0</commons-lang.version>
     <logback.version>1.4.14</logback.version>

--- a/pass-nihms-loader/nihms-data-harvest/pom.xml
+++ b/pass-nihms-loader/nihms-data-harvest/pom.xml
@@ -94,16 +94,17 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <configuration>
-          <mainClass>org.eclipse.pass.loader.nihms.NihmsHarvesterCLI</mainClass>
-          <finalName>nihms-data-harvest-cli</finalName>
-          <classifier>exec</classifier>
-        </configuration>
         <executions>
           <execution>
+            <id>repackage</id>
             <goals>
               <goal>repackage</goal>
             </goals>
+            <configuration>
+              <mainClass>org.eclipse.pass.loader.nihms.NihmsHarvesterCLI</mainClass>
+              <classifier>exec</classifier>
+              <attach>false</attach>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/pass-nihms-loader/nihms-data-transform-load/pom.xml
+++ b/pass-nihms-loader/nihms-data-transform-load/pom.xml
@@ -149,16 +149,17 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <configuration>
-          <mainClass>org.eclipse.pass.loader.nihms.NihmsTransformLoadCLI</mainClass>
-          <finalName>nihms-data-transform-load</finalName>
-          <classifier>exec</classifier>
-        </configuration>
         <executions>
           <execution>
+            <id>repackage</id>
             <goals>
               <goal>repackage</goal>
             </goals>
+            <configuration>
+              <mainClass>org.eclipse.pass.loader.nihms.NihmsTransformLoadCLI</mainClass>
+              <classifier>exec</classifier>
+              <attach>false</attach>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/pass-nihms-loader/nihms-docker/Dockerfile
+++ b/pass-nihms-loader/nihms-docker/Dockerfile
@@ -2,8 +2,8 @@ FROM eclipse-temurin:17.0.8_7-jre-jammy
 
 WORKDIR /app
 
-COPY ./target/nihms-data-harvest-cli-exec.jar .
-COPY ./target/nihms-data-transform-load-exec.jar .
+COPY ./target/nihms-data-harvest-*-exec.jar nihms-data-harvest-cli-exec.jar
+COPY ./target/nihms-data-transform-load-*-exec.jar nihms-data-transform-load-exec.jar
 COPY entrypoint.sh .
 
 RUN apt update \

--- a/pass-nihms-loader/nihms-docker/pom.xml
+++ b/pass-nihms-loader/nihms-docker/pom.xml
@@ -31,13 +31,13 @@
                 <resource>
                   <directory>../nihms-data-harvest/target</directory>
                   <includes>
-                    <include>nihms-data-harvest-cli-exec.jar</include>
+                    <include>nihms-data-harvest-*-exec.jar</include>
                   </includes>
                 </resource>
                 <resource>
                   <directory>../nihms-data-transform-load/target</directory>
                   <includes>
-                    <include>nihms-data-transform-load-exec.jar</include>
+                    <include>nihms-data-transform-load-*-exec.jar</include>
                   </includes>
                 </resource>
               </resources>

--- a/pass-notification-service/Dockerfile
+++ b/pass-notification-service/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:17.0.8_7-jre-jammy
 
 WORKDIR /app
 
-COPY target/pass-notification-service-exec.jar .
+COPY target/pass-notification-service-*-exec.jar pass-notification-service-exec.jar
 COPY entrypoint.sh .
 
 RUN apt update \

--- a/pass-notification-service/pom.xml
+++ b/pass-notification-service/pom.xml
@@ -211,16 +211,17 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <version>${spring-boot-maven-plugin.version}</version>
-                <configuration>
-                    <mainClass>org.eclipse.pass.notification.NotificationApp</mainClass>
-                    <finalName>pass-notification-service</finalName>
-                    <classifier>exec</classifier>
-                </configuration>
                 <executions>
                     <execution>
+                        <id>repackage</id>
                         <goals>
                             <goal>repackage</goal>
                         </goals>
+                        <configuration>
+                            <mainClass>org.eclipse.pass.notification.NotificationApp</mainClass>
+                            <classifier>exec</classifier>
+                            <attach>false</attach>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,6 @@
     <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
     <maven-remote-resources-plugin.version>3.1.0</maven-remote-resources-plugin.version>
     <maven-dependency-plugin.version>3.6.1</maven-dependency-plugin.version>
-    <docker.platforms>linux/amd64</docker.platforms>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
This PR makes the following changes to the repackage configuration:

- Remove the finalName configuration. It is read-only and should not be changed any longer: https://github.com/spring-projects/spring-boot/issues/16202#issuecomment-500208885
- Set attach as false so the repackaged jar file is not deployed. If this works like I think it will, it may speed up the deploy goal since the repackaged jar file will not be deployed to sonatype snapshot/release.
- Change journal loader to use spring maven plugin repackage instead of shade plugin for consistency.