### PR TITLE
Add option to load app props from AWS Parameter Store

### DIFF
--- a/pass-deposit-services/deposit-core/pom.xml
+++ b/pass-deposit-services/deposit-core/pom.xml
@@ -93,6 +93,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.awspring.cloud</groupId>
+      <artifactId>spring-cloud-aws-starter-parameter-store</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.jsoup</groupId>
       <artifactId>jsoup</artifactId>
       <version>${jsoup.version}</version>

--- a/pass-deposit-services/deposit-core/src/main/resources/application.properties
+++ b/pass-deposit-services/deposit-core/src/main/resources/application.properties
@@ -16,9 +16,9 @@
 spring.jms.listener.auto-startup=true
 aws.sqs.endpoint.override=
 
-pass.client.url=${PASS_CLIENT_URL:localhost:8080}
-pass.client.user=${PASS_CLIENT_USER:fakeuser}
-pass.client.password=${PASS_CLIENT_PASSWORD:fakepassword}
+pass.client.url=${PASS_CORE_URL:localhost:8080}
+pass.client.user=${PASS_CORE_USER:fakeuser}
+pass.client.password=${PASS_CORE_PASSWORD:fakepassword}
 
 pmc.ftp.host=${PMC_FTP_HOST:localhost}
 pmc.ftp.port=${PMC_FTP_PORT:21}

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/AbstractDepositSubmissionIT.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/AbstractDepositSubmissionIT.java
@@ -93,8 +93,8 @@ public abstract class AbstractDepositSubmissionIT {
     @Container
     protected static final GenericContainer<?> PASS_CORE_CONTAINER = new GenericContainer<>(PASS_CORE_IMG)
         .withEnv("PASS_CORE_BASE_URL", "http://localhost:8080")
-        .withEnv("PASS_CORE_BACKEND_USER", "backend")
-        .withEnv("PASS_CORE_BACKEND_PASSWORD", "backend")
+        .withEnv("PASS_CORE_USER", "backend")
+        .withEnv("PASS_CORE_PASSWORD", "backend")
         .waitingFor(Wait.forHttp("/data/grant").forStatusCode(200).withBasicCredentials("backend", "backend"))
         .withExposedPorts(8080);
 

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/config/spring/AwsParamStoreConfigTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/config/spring/AwsParamStoreConfigTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2024 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.deposit.config.spring;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.SSM;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.env.Environment;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest(
+    properties = {
+        "spring.cloud.aws.credentials.access-key=noop",
+        "spring.cloud.aws.credentials.secret-key=noop",
+        "spring.cloud.aws.region.static=us-east-1",
+        "spring.jms.listener.auto-startup=false"
+    })
+@ContextConfiguration(initializers = ConfigDataApplicationContextInitializer.class)
+@Testcontainers
+class AwsParamStoreConfigTest {
+    private static final DockerImageName LOCALSTACK_IMG =
+        DockerImageName.parse("localstack/localstack:3.1.0");
+
+    @Container
+    private static final LocalStackContainer localStack = new LocalStackContainer(LOCALSTACK_IMG).withServices(SSM);
+
+    @Autowired private Environment environment;
+
+    @DynamicPropertySource
+    static void properties(DynamicPropertyRegistry registry) {
+        registry.add("spring.cloud.aws.parameterstore.endpoint", () -> localStack.getEndpoint().toString());
+        registry.add("spring.cloud.aws.parameterstore.region", localStack::getRegion);
+        registry.add("spring.cloud.aws.endpoint", () -> localStack.getEndpoint().toString());
+        registry.add("spring.cloud.aws.region.static", localStack::getRegion);
+        registry.add("spring.config.import[0]", () -> "aws-parameterstore:/config/pass-core-client/");
+        registry.add("spring.config.import[1]", () -> "aws-parameterstore:/config/pass-deposit/");
+    }
+
+    @BeforeAll
+    static void beforeAll() throws IOException, InterruptedException {
+        localStack.execInContainer("awslocal", "ssm", "put-parameter",
+            "--name", "/config/pass-core-client/PASS_CORE_PASSWORD",
+            "--value", "aws-param-store-core-pw",
+            "--type", "SecureString");
+        localStack.execInContainer("awslocal", "ssm", "put-parameter",
+            "--name", "/config/pass-deposit/DSPACE_PASSWORD",
+            "--value", "aws-param-store-dspace-pw",
+            "--type", "SecureString");
+    }
+
+    @Test
+    public void testLoadPropFromParamStore() {
+        String userNameProp = environment.getProperty("dspace.user");
+        assertEquals("test@test.edu", userNameProp);
+        String dspacePwProp = environment.getProperty("dspace.password");
+        assertEquals("aws-param-store-dspace-pw", dspacePwProp);
+        String passClientPwProp = environment.getProperty("pass.client.password");
+        assertEquals("aws-param-store-core-pw", passClientPwProp);
+    }
+
+}

--- a/pass-deposit-services/deposit-core/src/test/resources/logback-test.xml
+++ b/pass-deposit-services/deposit-core/src/test/resources/logback-test.xml
@@ -31,16 +31,8 @@
   <logger name="org.eclipse" additivity="false" level="${org.eclipse.level:-WARN}">
     <appender-ref ref="STDERR"/>
   </logger>
-  <logger name="org.eclipse.pass.deposit" additivity="false"
-          level="${org.eclipse.pass.deposit.level:-DEBUG}">
-    <appender-ref ref="STDERR"/>
-  </logger>
   <logger name="org.eclipse.pass.client" additivity="false"
           level="${org.eclipse.pass.client.level:-ERROR}">
-    <appender-ref ref="STDERR"/>
-  </logger>
-  <logger name="org.testcontainers" additivity="false"
-          level="${org.testcontainers:-INFO}">
     <appender-ref ref="STDERR"/>
   </logger>
 </configuration>

--- a/pass-deposit-services/pom.xml
+++ b/pass-deposit-services/pom.xml
@@ -459,6 +459,7 @@
                 <!-- These come from bundled jars -->
                 <ignoredDependency>org.springframework*::</ignoredDependency>
                 <ignoredDependency>software.amazon.awssdk::</ignoredDependency>
+                <ignoredDependency>io.awspring.cloud::</ignoredDependency>
                 <!-- Comes from outdated sword2 client -->
                 <ignoredDependency>org.apache.abdera::</ignoredDependency>
                 <ignoredDependency>junit:junit:</ignoredDependency>

--- a/pass-grant-loader/pom.xml
+++ b/pass-grant-loader/pom.xml
@@ -83,6 +83,10 @@
         </exclusions>
       </dependency>
       <dependency>
+        <groupId>io.awspring.cloud</groupId>
+        <artifactId>spring-cloud-aws-starter-parameter-store</artifactId>
+      </dependency>
+      <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-test</artifactId>
         <scope>test</scope>
@@ -251,7 +255,7 @@
                     <excludes>
                       <exclude>com.squareup.okio:okio:*</exclude>
                       <exclude>org.jetbrains.kotlin:kotlin-stdlib-jdk8:*</exclude>
-                      <!-- TODO try removing -->
+                      <!-- TODO try removing, strange conflict with pass-data-client -->
                       <exclude>org.apache.commons:commons-lang3:*</exclude>
                     </excludes>
                   </dependencyConvergence>

--- a/pass-grant-loader/src/main/resources/application.properties
+++ b/pass-grant-loader/src/main/resources/application.properties
@@ -10,6 +10,6 @@ grant.db.url=${GRANT_DB_URL:}
 grant.db.username=${GRANT_DB_USER:}
 grant.db.password=${GRANT_DB_PASSWORD:}
 
-pass.client.url=${PASS_CLIENT_URL:localhost:8080}
-pass.client.user=${PASS_CLIENT_USER:fakeuser}
-pass.client.password=${PASS_CLIENT_PASSWORD:fakepassword}
+pass.client.url=${PASS_CORE_URL:localhost:8080}
+pass.client.user=${PASS_CORE_USER:fakeuser}
+pass.client.password=${PASS_CORE_PASSWORD:fakepassword}

--- a/pass-grant-loader/src/test/java/org/eclipse/pass/support/grant/AbstractIntegrationTest.java
+++ b/pass-grant-loader/src/test/java/org/eclipse/pass/support/grant/AbstractIntegrationTest.java
@@ -60,8 +60,8 @@ public abstract class AbstractIntegrationTest {
     @Container
     protected static final GenericContainer<?> PASS_CORE_CONTAINER = new GenericContainer<>(PASS_CORE_IMG)
         .withEnv("PASS_CORE_BASE_URL", "http://localhost:8080")
-        .withEnv("PASS_CORE_BACKEND_USER", "backend")
-        .withEnv("PASS_CORE_BACKEND_PASSWORD", "backend")
+        .withEnv("PASS_CORE_USER", "backend")
+        .withEnv("PASS_CORE_PASSWORD", "backend")
         .waitingFor(Wait.forHttp("/data/grant").forStatusCode(200).withBasicCredentials("backend", "backend"))
         .withExposedPorts(8080);
 

--- a/pass-grant-loader/src/test/java/org/eclipse/pass/support/grant/AwsParamStoreConfigTest.java
+++ b/pass-grant-loader/src/test/java/org/eclipse/pass/support/grant/AwsParamStoreConfigTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2024 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.support.grant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.SSM;
+
+import java.io.IOException;
+
+import org.eclipse.pass.support.grant.data.GrantConnector;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.core.env.Environment;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest(
+    properties = {
+        "spring.cloud.aws.credentials.access-key=noop",
+        "spring.cloud.aws.credentials.secret-key=noop",
+        "spring.cloud.aws.region.static=us-east-1",
+        "pass.policy.prop.path=file:./src/test/resources/policy.properties",
+        "pass.grant.update.ts.path=file:./src/test/resources/grant_update_timestamps"
+    })
+@ContextConfiguration(initializers = ConfigDataApplicationContextInitializer.class)
+@Testcontainers
+class AwsParamStoreConfigTest {
+    private static final DockerImageName LOCALSTACK_IMG =
+        DockerImageName.parse("localstack/localstack:3.1.0");
+
+    @Container
+    private static final LocalStackContainer localStack = new LocalStackContainer(LOCALSTACK_IMG).withServices(SSM);
+
+    @Autowired private Environment environment;
+    @MockBean protected GrantConnector grantConnector;
+    @MockBean protected GrantLoaderCLIRunner grantLoaderCLIRunner;
+
+    @DynamicPropertySource
+    static void properties(DynamicPropertyRegistry registry) {
+        registry.add("spring.cloud.aws.parameterstore.endpoint", () -> localStack.getEndpoint().toString());
+        registry.add("spring.cloud.aws.parameterstore.region", localStack::getRegion);
+        registry.add("spring.cloud.aws.endpoint", () -> localStack.getEndpoint().toString());
+        registry.add("spring.cloud.aws.region.static", localStack::getRegion);
+        registry.add("spring.config.import[0]", () -> "aws-parameterstore:/config/pass-core-client/");
+        registry.add("spring.config.import[1]", () -> "aws-parameterstore:/config/pass-grant/");
+    }
+
+    @BeforeAll
+    static void beforeAll() throws IOException, InterruptedException {
+        localStack.execInContainer("awslocal", "ssm", "put-parameter",
+            "--name", "/config/pass-core-client/PASS_CORE_PASSWORD",
+            "--value", "aws-param-store-core-pw",
+            "--type", "SecureString");
+        localStack.execInContainer("awslocal", "ssm", "put-parameter",
+            "--name", "/config/pass-grant/GRANT_DB_PASSWORD",
+            "--value", "aws-param-store-grant-pw",
+            "--type", "SecureString");
+    }
+
+    @Test
+    public void testLoadPropFromParamStore() {
+        String userNameProp = environment.getProperty("grant.db.username");
+        assertEquals("", userNameProp);
+        String userPwProp = environment.getProperty("grant.db.password");
+        assertEquals("aws-param-store-grant-pw", userPwProp);
+        String passClientPwProp = environment.getProperty("pass.client.password");
+        assertEquals("aws-param-store-core-pw", passClientPwProp);
+    }
+
+}

--- a/pass-journal-loader/pass-journal-loader-nih/pom.xml
+++ b/pass-journal-loader/pass-journal-loader-nih/pom.xml
@@ -134,8 +134,8 @@
                 <platform>${docker.platforms}</platform>
 		        <env>
                   <PASS_CORE_BASE_URL>${pass.core.url}</PASS_CORE_BASE_URL>
-                  <PASS_CORE_BACKEND_USER>${pass.core.user}</PASS_CORE_BACKEND_USER>
-                  <PASS_CORE_BACKEND_PASSWORD>${pass.core.password}</PASS_CORE_BACKEND_PASSWORD>
+                  <PASS_CORE_USER>${pass.core.user}</PASS_CORE_USER>
+                  <PASS_CORE_PASSWORD>${pass.core.password}</PASS_CORE_PASSWORD>
 		        </env>
                 <wait>
                   <http>

--- a/pass-nihms-loader/nihms-data-harvest/pom.xml
+++ b/pass-nihms-loader/nihms-data-harvest/pom.xml
@@ -77,6 +77,17 @@
     </dependency>
 
     <dependency>
+      <groupId>io.awspring.cloud</groupId>
+      <artifactId>spring-cloud-aws-starter-parameter-store</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
@@ -85,6 +96,18 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>localstack</artifactId>
+      <scope>test</scope>
     </dependency>
 
   </dependencies>

--- a/pass-nihms-loader/nihms-data-harvest/src/test/java/org/eclipse/pass/loader/nihms/AwsParamStoreConfigTest.java
+++ b/pass-nihms-loader/nihms-data-harvest/src/test/java/org/eclipse/pass/loader/nihms/AwsParamStoreConfigTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2024 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.loader.nihms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.SSM;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.core.env.Environment;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest(
+    properties = {
+        "spring.cloud.aws.credentials.access-key=noop",
+        "spring.cloud.aws.credentials.secret-key=noop",
+        "spring.cloud.aws.region.static=us-east-1"
+    })
+@ContextConfiguration(initializers = ConfigDataApplicationContextInitializer.class)
+@Testcontainers
+class AwsParamStoreConfigTest {
+    private static final DockerImageName LOCALSTACK_IMG =
+        DockerImageName.parse("localstack/localstack:3.1.0");
+
+    @Container
+    private static final LocalStackContainer localStack = new LocalStackContainer(LOCALSTACK_IMG).withServices(SSM);
+
+    @Autowired private Environment environment;
+
+    @MockBean private NihmsHarvesterCLIRunner nihmsHarvesterCLIRunner;
+    @MockBean private NihmsHarvesterDownloader nihmsHarvesterDownloader;
+
+    @DynamicPropertySource
+    static void properties(DynamicPropertyRegistry registry) {
+        registry.add("spring.cloud.aws.parameterstore.endpoint", () -> localStack.getEndpoint().toString());
+        registry.add("spring.cloud.aws.parameterstore.region", localStack::getRegion);
+        registry.add("spring.cloud.aws.endpoint", () -> localStack.getEndpoint().toString());
+        registry.add("spring.cloud.aws.region.static", localStack::getRegion);
+        registry.add("spring.config.import", () -> "aws-parameterstore:/config/pass-nihms/");
+    }
+
+    @BeforeAll
+    static void beforeAll() throws IOException, InterruptedException {
+        localStack.execInContainer("awslocal", "ssm", "put-parameter",
+            "--name", "/config/pass-nihms/NIHMS_API_TOKEN",
+            "--value", "aws-param-store-test-token",
+            "--type", "SecureString");
+    }
+
+    @Test
+    public void testLoadPropFromParamStore() {
+        String nihmsApiHostProp = environment.getProperty("nihmsetl.api.host");
+        assertEquals("www.ncbi.nlm.nih.gov", nihmsApiHostProp);
+        String repoIdProp = environment.getProperty("nihmsetl.api.url.param.api-token");
+        assertEquals("aws-param-store-test-token", repoIdProp);
+    }
+
+}

--- a/pass-nihms-loader/nihms-data-transform-load/pom.xml
+++ b/pass-nihms-loader/nihms-data-transform-load/pom.xml
@@ -89,6 +89,17 @@
       <artifactId>spring-boot-starter</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.awspring.cloud</groupId>
+      <artifactId>spring-cloud-aws-starter-parameter-store</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
     <!-- Test dependencies -->
 
     <dependency>
@@ -115,6 +126,12 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>localstack</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/pass-nihms-loader/nihms-data-transform-load/src/main/resources/application.properties
+++ b/pass-nihms-loader/nihms-data-transform-load/src/main/resources/application.properties
@@ -5,6 +5,6 @@ nihmsetl.pmcurl.template=https://www.ncbi.nlm.nih.gov/pmc/articles/%s/
 
 pmc.entrez.service.url=https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=pubmed&retmode=json&rettype=abstract&id=%s
 
-pass.client.url=${PASS_CLIENT_URL:localhost:8080}
-pass.client.user=${PASS_CLIENT_USER:fakeuser}
-pass.client.password=${PASS_CLIENT_PASSWORD:fakepassword}
+pass.client.url=${PASS_CORE_URL:localhost:8080}
+pass.client.user=${PASS_CORE_USER:fakeuser}
+pass.client.password=${PASS_CORE_PASSWORD:fakepassword}

--- a/pass-nihms-loader/nihms-data-transform-load/src/test/java/org/eclipse/pass/loader/nihms/AwsParamStoreConfigTest.java
+++ b/pass-nihms-loader/nihms-data-transform-load/src/test/java/org/eclipse/pass/loader/nihms/AwsParamStoreConfigTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2024 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.loader.nihms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.SSM;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.core.env.Environment;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest(
+    properties = {
+        "spring.cloud.aws.credentials.access-key=noop",
+        "spring.cloud.aws.credentials.secret-key=noop",
+        "spring.cloud.aws.region.static=us-east-1"
+    })
+@ContextConfiguration(initializers = ConfigDataApplicationContextInitializer.class)
+@Testcontainers
+class AwsParamStoreConfigTest {
+    private static final DockerImageName LOCALSTACK_IMG =
+        DockerImageName.parse("localstack/localstack:3.1.0");
+
+    @Container
+    private static final LocalStackContainer localStack = new LocalStackContainer(LOCALSTACK_IMG).withServices(SSM);
+
+    @Autowired private Environment environment;
+
+    @MockBean private NihmsTransformLoadCLIRunner nihmsTransformLoadCLIRunner;
+
+    @DynamicPropertySource
+    static void properties(DynamicPropertyRegistry registry) {
+        registry.add("spring.cloud.aws.parameterstore.endpoint", () -> localStack.getEndpoint().toString());
+        registry.add("spring.cloud.aws.parameterstore.region", localStack::getRegion);
+        registry.add("spring.cloud.aws.endpoint", () -> localStack.getEndpoint().toString());
+        registry.add("spring.cloud.aws.region.static", localStack::getRegion);
+        registry.add("spring.config.import[0]", () -> "aws-parameterstore:/config/pass-core-client/");
+        registry.add("spring.config.import[1]", () -> "aws-parameterstore:/config/pass-nihms/");
+    }
+
+    @BeforeAll
+    static void beforeAll() throws IOException, InterruptedException {
+        localStack.execInContainer("awslocal", "ssm", "put-parameter",
+            "--name", "/config/pass-core-client/PASS_CORE_PASSWORD",
+            "--value", "aws-param-store-core-pw",
+            "--type", "SecureString");
+        localStack.execInContainer("awslocal", "ssm", "put-parameter",
+            "--name", "/config/pass-nihms/NIHMS_REPO_ID",
+            "--value", "aws-param-store-repo-id",
+            "--type", "SecureString");
+    }
+
+    @Test
+    public void testLoadPropFromParamStore() {
+        String clientUrlNameProp = environment.getProperty("pass.client.url");
+        assertEquals("localhost:8080", clientUrlNameProp);
+        String repoIdProp = environment.getProperty("nihmsetl.repository.id");
+        assertEquals("aws-param-store-repo-id", repoIdProp);
+        String passClientPwProp = environment.getProperty("pass.client.password");
+        assertEquals("aws-param-store-core-pw", passClientPwProp);
+    }
+
+}

--- a/pass-nihms-loader/nihms-data-transform-load/src/test/java/org/eclipse/pass/loader/nihms/NihmsSubmissionEtlITBase.java
+++ b/pass-nihms-loader/nihms-data-transform-load/src/test/java/org/eclipse/pass/loader/nihms/NihmsSubmissionEtlITBase.java
@@ -93,8 +93,8 @@ public abstract class NihmsSubmissionEtlITBase {
     @Container
     protected static final GenericContainer<?> PASS_CORE_CONTAINER = new GenericContainer<>(PASS_CORE_IMG)
         .withEnv("PASS_CORE_BASE_URL", "http://localhost:8080")
-        .withEnv("PASS_CORE_BACKEND_USER", "backend")
-        .withEnv("PASS_CORE_BACKEND_PASSWORD", "backend")
+        .withEnv("PASS_CORE_USER", "backend")
+        .withEnv("PASS_CORE_PASSWORD", "backend")
         .waitingFor(Wait.forHttp("/data/grant").forStatusCode(200).withBasicCredentials("backend", "backend"))
         .withExposedPorts(8080);
 

--- a/pass-nihms-loader/nihms-docker/entrypoint.sh
+++ b/pass-nihms-loader/nihms-docker/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Execute NIHMS harvest
-java -jar nihms-data-harvest-cli-exec.jar "$@"
+java $PASS_NIHMS_LOADER_JAVA_OPTS -jar nihms-data-harvest-cli-exec.jar "$@"
 
 # Execute NIHMS transform and load into PASS
-java -jar nihms-data-transform-load-exec.jar
+java $PASS_NIHMS_LOADER_JAVA_OPTS -jar nihms-data-transform-load-exec.jar

--- a/pass-nihms-loader/pom.xml
+++ b/pass-nihms-loader/pom.xml
@@ -21,6 +21,7 @@
     <properties>
         <!-- Properties for dependency versions -->
         <spring-boot-maven-plugin.version>3.2.1</spring-boot-maven-plugin.version>
+        <awsspring.version>3.1.0</awsspring.version>
         <http-client.version>4.5.14</http-client.version>
         <org-json.version>20231013</org-json.version>
         <commons.csv.version>1.10.0</commons.csv.version>
@@ -85,6 +86,14 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
                 <version>${spring-boot-maven-plugin.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>io.awspring.cloud</groupId>
+                <artifactId>spring-cloud-aws-dependencies</artifactId>
+                <version>${awsspring.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -192,6 +201,7 @@
                             <ignoredDependencies>
                                 <!-- These come from bundled jars -->
                                 <ignoredDependency>org.springframework*::</ignoredDependency>
+                                <ignoredDependency>io.awspring.cloud::</ignoredDependency>
                             </ignoredDependencies>
                             <ignoredUsedUndeclaredDependencies>
                                 <!-- These both come from junit-jupiter, so version is tied to that direct dependency -->

--- a/pass-notification-service/pom.xml
+++ b/pass-notification-service/pom.xml
@@ -44,6 +44,7 @@
     <properties>
         <!-- Properties for dependency versions -->
         <spring-boot-maven-plugin.version>3.2.1</spring-boot-maven-plugin.version>
+        <awsspring.version>3.1.0</awsspring.version>
         <lombok.version>1.18.30</lombok.version>
         <logback.version>1.4.14</logback.version>
         <slf4j.version>2.0.7</slf4j.version>
@@ -58,6 +59,25 @@
         <javax-json.version>1.1.4</javax-json.version>
         <maven-model.version>3.9.6</maven-model.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot-maven-plugin.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.awspring.cloud</groupId>
+                <artifactId>spring-cloud-aws-dependencies</artifactId>
+                <version>${awsspring.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
 
@@ -89,31 +109,31 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
-            <version>${spring-boot-maven-plugin.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-artemis</artifactId>
-            <version>${spring-boot-maven-plugin.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-aop</artifactId>
-            <version>${spring-boot-maven-plugin.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-json</artifactId>
-            <version>${spring-boot-maven-plugin.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-mail</artifactId>
-            <version>${spring-boot-maven-plugin.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.awspring.cloud</groupId>
+            <artifactId>spring-cloud-aws-starter-parameter-store</artifactId>
         </dependency>
 
         <dependency>
@@ -149,7 +169,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <version>${spring-boot-maven-plugin.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -291,6 +310,8 @@
                                         <exclude>net.bytebuddy:byte-buddy:</exclude>
                                         <!-- These are all transitive dependencies, but 2.0.7 is closest -->
                                         <exclude>org.slf4j:slf4j-api:</exclude>
+                                        <!-- TODO try removing, strange conflict with pass-data-client -->
+                                        <exclude>org.apache.commons:commons-lang3:*</exclude>
                                     </excludes>
                                 </dependencyConvergence>
                             </rules>
@@ -315,6 +336,7 @@
                                 <!-- These come from bundled jars -->
                                 <ignoredDependency>org.springframework*::</ignoredDependency>
                                 <ignoredDependency>software.amazon.awssdk::</ignoredDependency>
+                                <ignoredDependency>io.awspring.cloud::</ignoredDependency>
                             </ignoredDependencies>
                             <ignoredUsedUndeclaredDependencies>
                                 <!-- These come from spring boot starter json -->

--- a/pass-notification-service/src/main/resources/application.properties
+++ b/pass-notification-service/src/main/resources/application.properties
@@ -32,9 +32,9 @@ spring.mail.properties.mail.smtp.connectiontimeout=5000
 spring.mail.properties.mail.smtp.timeout=3000
 spring.mail.properties.mail.smtp.writetimeout=5000
 
-pass.client.url=${PASS_CLIENT_URL:localhost:8080}
-pass.client.user=${PASS_CLIENT_USER:fakeuser}
-pass.client.password=${PASS_CLIENT_PASSWORD:fakepassword}
+pass.client.url=${PASS_CORE_URL:localhost:8080}
+pass.client.user=${PASS_CORE_USER:fakeuser}
+pass.client.password=${PASS_CORE_PASSWORD:fakepassword}
 
 pass.jms.queue.submission.event.name=${PASS_JMS_QUEUE_SUBMISSION_EVENT_NAME:event}
 

--- a/pass-notification-service/src/main/resources/logback.xml
+++ b/pass-notification-service/src/main/resources/logback.xml
@@ -38,16 +38,4 @@
             level="${org.eclipse.pass.notification.level:-WARN}">
         <appender-ref ref="STDERR"/>
     </logger>
-    <logger name="NOTIFICATION_LOG" additivity="false" level="${org.eclipse.pass.notification.level:-INFO}">
-        <appender-ref ref="STDERR"/>
-    </logger>
-
-    <logger name="com.sun.mail.imap" additivity="false" level="${com.sun.mail.imap.level:-WARN}">
-        <appender-ref ref="STDERR"/>
-    </logger>
-    <!-- the rest client is noisy, and detracts from looking at test logging output -->
-    <logger name="org.elasticsearch.client.RestClient" additivity="false"
-            level="${org.elasticsearch.client.level:-ERROR}">
-        <appender-ref ref="STDERR"/>
-    </logger>
 </configuration>

--- a/pass-notification-service/src/test/java/org/eclipse/pass/notification/config/AwsParamStoreConfigTest.java
+++ b/pass-notification-service/src/test/java/org/eclipse/pass/notification/config/AwsParamStoreConfigTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2024 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.notification.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.SSM;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.env.Environment;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest(
+    properties = {
+        "spring.cloud.aws.credentials.access-key=noop",
+        "spring.cloud.aws.credentials.secret-key=noop",
+        "spring.cloud.aws.region.static=us-east-1",
+        "spring.jms.listener.auto-startup=false"
+    })
+@ContextConfiguration(initializers = ConfigDataApplicationContextInitializer.class)
+@Testcontainers
+class AwsParamStoreConfigTest {
+    private static final DockerImageName LOCALSTACK_IMG =
+        DockerImageName.parse("localstack/localstack:3.1.0");
+
+    @Container
+    private static final LocalStackContainer localStack = new LocalStackContainer(LOCALSTACK_IMG).withServices(SSM);
+
+    @Autowired private Environment environment;
+
+    @DynamicPropertySource
+    static void properties(DynamicPropertyRegistry registry) {
+        registry.add("spring.cloud.aws.parameterstore.endpoint", () -> localStack.getEndpoint().toString());
+        registry.add("spring.cloud.aws.parameterstore.region", localStack::getRegion);
+        registry.add("spring.cloud.aws.endpoint", () -> localStack.getEndpoint().toString());
+        registry.add("spring.cloud.aws.region.static", localStack::getRegion);
+        registry.add("spring.config.import[0]", () -> "aws-parameterstore:/config/pass-core-client/");
+        registry.add("spring.config.import[1]", () -> "aws-parameterstore:/config/pass-notif/");
+    }
+
+    @BeforeAll
+    static void beforeAll() throws IOException, InterruptedException {
+        localStack.execInContainer("awslocal", "ssm", "put-parameter",
+            "--name", "/config/pass-core-client/PASS_CORE_PASSWORD",
+            "--value", "aws-param-store-core-pw",
+            "--type", "SecureString");
+        localStack.execInContainer("awslocal", "ssm", "put-parameter",
+            "--name", "/config/pass-notif/SPRING_MAIL_PASSWORD",
+            "--value", "aws-param-store-notif-pw",
+            "--type", "SecureString");
+    }
+
+    @Test
+    public void testLoadPropFromParamStore() {
+        String mailHostNameProp = environment.getProperty("spring.mail.host");
+        assertEquals("localhost", mailHostNameProp);
+        String userPwProp = environment.getProperty("spring.mail.password");
+        assertEquals("aws-param-store-notif-pw", userPwProp);
+        String passClientPwProp = environment.getProperty("pass.client.password");
+        assertEquals("aws-param-store-core-pw", passClientPwProp);
+    }
+
+}

--- a/pass-notification-service/src/test/java/org/eclipse/pass/notification/service/NotificationServiceIT.java
+++ b/pass-notification-service/src/test/java/org/eclipse/pass/notification/service/NotificationServiceIT.java
@@ -89,8 +89,8 @@ public class NotificationServiceIT extends AbstractNotificationSpringIntegration
     @Container
     static final GenericContainer<?> PASS_CORE_CONTAINER = new GenericContainer<>(PASS_CORE_IMG)
         .withEnv("PASS_CORE_BASE_URL", "http://localhost:8080")
-        .withEnv("PASS_CORE_BACKEND_USER", "backend")
-        .withEnv("PASS_CORE_BACKEND_PASSWORD", "backend")
+        .withEnv("PASS_CORE_USER", "backend")
+        .withEnv("PASS_CORE_PASSWORD", "backend")
         .waitingFor(Wait.forHttp("/data/grant").forStatusCode(200).withBasicCredentials("backend", "backend"))
         .withExposedPorts(8080);
 

--- a/pass-notification-service/src/test/resources/logback-test.xml
+++ b/pass-notification-service/src/test/resources/logback-test.xml
@@ -27,22 +27,4 @@
     <root level="WARN">
         <appender-ref ref="STDERR"/>
     </root>
-    <logger name="org.springframework" additivity="false" level="${org.springframework.level:-WARN}">
-        <appender-ref ref="STDERR"/>
-    </logger>
-    <logger name="com.github.jknack.handlebars" additivity="false" level="${com.github.jknack.handlebars.level:-WARN}">
-        <appender-ref ref="STDERR"/>
-    </logger>
-    <logger name="org.eclipse.pass" additivity="false" level="${org.eclipse.pass.level:-WARN}">
-        <appender-ref ref="STDERR"/>
-    </logger>
-    <logger name="org.eclipse.pass.notification" additivity="false" level="${org.eclipse.pass.notification.level:-INFO}">
-        <appender-ref ref="STDERR"/>
-    </logger>
-    <logger name="NOTIFICATION_LOG" additivity="false" level="${org.eclipse.pass.notification.level:-INFO}">
-        <appender-ref ref="STDERR"/>
-    </logger>
-    <logger name="org.testcontainers" additivity="false" level="${org.testcontainers.level:-INFO}">
-        <appender-ref ref="STDERR"/>
-    </logger>
 </configuration>


### PR DESCRIPTION
This PR goes along with pass-core PR: https://github.com/eclipse-pass/pass-core/pull/93

Tests will not pass in this PR until the pass-core PR is merged.

Note that journal loader does not have this option, it is not a spring app. There is an issue to convert it to one, I will add a comment to that ticket to add this option when that ticket is done.