### PR TITLE
Externalize NIHMS api token parameter name

### DIFF
--- a/pass-nihms-loader/nihms-token-refresh/README.md
+++ b/pass-nihms-loader/nihms-token-refresh/README.md
@@ -16,6 +16,7 @@ To run the token refresh RPA, the following needs to be passed to the docker ima
 `NIHMS_USER` : The ERA Commons login username  
 `NIHMS_PASSWORD` : The ERA Commons login password  
 `NIHMS_OUTFILE` : The full path to the file to write the new token
+`NIHMS_API_TOKEN_PARAM_NAME` : The name to use for the NIHMS API Token parameter in the parameter store
 
 If you are setting the token into AWS Parameter Store, the script assumes that the needed aws cli authentication are in
 place such as passing the AWS env vars or assumed roles.

--- a/pass-nihms-loader/nihms-token-refresh/set_aws_param_store.sh
+++ b/pass-nihms-loader/nihms-token-refresh/set_aws_param_store.sh
@@ -3,7 +3,7 @@
 export AWS_PAGER=""
 
 aws ssm put-parameter \
-    --name "NIHMS_API_TOKEN" \
+    --name $NIHMS_API_TOKEN_PARAM_NAME \
     --type "SecureString" \
     --value file://$NIHMS_OUTFILE \
     --overwrite


### PR DESCRIPTION
Needed since parameter name in parameter store may be different.