### PR TITLE
Clean default application property values

### DIFF
--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/config/spring/email/MailIntegration.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/config/spring/email/MailIntegration.java
@@ -22,6 +22,7 @@ import jakarta.mail.Authenticator;
 import jakarta.mail.internet.MimeMessage;
 import org.eclipse.pass.deposit.service.NihmsReceiveMailService;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.MessageChannels;
 import org.springframework.integration.mail.ImapMailReceiver;
@@ -33,6 +34,7 @@ import org.springframework.stereotype.Component;
 /**
  * @author Russ Poetker (rpoetke1@jh.edu)
  */
+@ConditionalOnProperty(name = "pass.deposit.nihms.email.enabled")
 @Component
 public class MailIntegration {
 

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/NihmsReceiveMailService.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/NihmsReceiveMailService.java
@@ -43,11 +43,13 @@ import org.jsoup.select.Elements;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
 /**
  * @author Russ Poetker (rpoetke1@jh.edu)
  */
+@ConditionalOnProperty(name = "pass.deposit.nihms.email.enabled")
 @Service
 public class NihmsReceiveMailService {
     private static final Logger LOG = LoggerFactory.getLogger(NihmsReceiveMailService.class);

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/support/deploymenttest/DeploymentTestDataService.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/support/deploymenttest/DeploymentTestDataService.java
@@ -39,8 +39,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
+@ConditionalOnProperty(name = "pass.test.data.job.enabled")
 @Component
 public class DeploymentTestDataService {
     private static final Logger LOG = LoggerFactory.getLogger(DeploymentTestDataService.class);

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/support/deploymenttest/DspaceDepositService.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/support/deploymenttest/DspaceDepositService.java
@@ -33,6 +33,7 @@ import org.eclipse.pass.support.client.model.Deposit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -45,6 +46,7 @@ import org.springframework.web.client.RestClient;
 /**
  * @author Russ Poetker (rpoetke1@jh.edu)
  */
+@ConditionalOnProperty(name = "pass.test.data.job.enabled")
 @Service
 public class DspaceDepositService {
     private static final Logger LOG = LoggerFactory.getLogger(DspaceDepositService.class);

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/transport/inveniordm/InvenioRdmTransport.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/transport/inveniordm/InvenioRdmTransport.java
@@ -20,11 +20,13 @@ import java.util.Map;
 import org.eclipse.pass.deposit.transport.Transport;
 import org.eclipse.pass.deposit.transport.TransportSession;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Russ Poetker (rpoetke1@jh.edu)
  */
+@ConditionalOnExpression("!T(org.springframework.util.StringUtils).isEmpty('${inveniordm.api.baseUrl}')")
 @Component
 public class InvenioRdmTransport implements Transport {
 

--- a/pass-deposit-services/deposit-core/src/main/resources/application.properties
+++ b/pass-deposit-services/deposit-core/src/main/resources/application.properties
@@ -16,26 +16,26 @@
 spring.jms.listener.auto-startup=true
 aws.sqs.endpoint.override=
 
-pass.client.url=${PASS_CORE_URL:localhost:8080}
-pass.client.user=${PASS_CORE_USER:fakeuser}
-pass.client.password=${PASS_CORE_PASSWORD:fakepassword}
+pass.client.url=${PASS_CORE_URL}
+pass.client.user=${PASS_CORE_USER}
+pass.client.password=${PASS_CORE_PASSWORD}
 
-pmc.ftp.host=${PMC_FTP_HOST:localhost}
-pmc.ftp.port=${PMC_FTP_PORT:21}
-pmc.ftp.user=${PMC_FTP_USER:nihmsftpuser}
-pmc.ftp.password=${PMC_FTP_PASSWORD:nihmsftppass}
+pmc.ftp.host=${PMC_FTP_HOST}
+pmc.ftp.port=${PMC_FTP_PORT}
+pmc.ftp.user=${PMC_FTP_USER}
+pmc.ftp.password=${PMC_FTP_PASSWORD}
 
-dspace.host=${DSPACE_HOST:localhost}
-dspace.port=${DSPACE_PORT:8181}
-dspace.server=${DSPACE_SERVER:dspace}
-dspace.user=${DSPACE_USER:test@test.edu}
-dspace.password=${DSPACE_PASSWORD:admin}
-dspace.server.api.protocol=${DSPACE_API_PROTOCOL:https}
-dspace.server.api.path=${DSPACE_API_PATH:/server/api}
+dspace.host=${DSPACE_HOST}
+dspace.port=${DSPACE_PORT}
+dspace.server=${DSPACE_SERVER}
+dspace.user=${DSPACE_USER}
+dspace.password=${DSPACE_PASSWORD}
+dspace.server.api.protocol=${DSPACE_API_PROTOCOL}
+dspace.server.api.path=${DSPACE_API_PATH}
 
 inveniordm.api.baseUrl=${INVENIORDM_API_BASE_URL:}
 inveniordm.api.verifySslCertificate=${INVENIORDM_VERIFY_SSL_CERT:true}
-inveniordm.api.token=${INVENIORDM_API_TOKEN:}
+inveniordm.api.token=${INVENIORDM_API_TOKEN}
 
 pass.deposit.repository.configuration=${PASS_DEPOSIT_REPOSITORY_CONFIGURATION:classpath:/repositories.json}
 pass.deposit.workers.concurrency=${PASS_DEPOSIT_WORKERS_CONCURRENCY:4}
@@ -65,18 +65,18 @@ nihms.mail.username=${NIHMS_MAIL_USERNAME}
 nihms.mail.password=${NIHMS_MAIL_PASSWORD}
 
 # Required for OAuth2 authentication to nihms email inbox
-nihms.mail.tenant.id=${NIHMS_MAIL_TENANT_ID:}
-nihms.mail.client.id=${NIHMS_MAIL_CLIENT_ID:}
-nihms.mail.client.secret=${NIHMS_MAIL_CLIENT_SECRET:}
+nihms.mail.tenant.id=${NIHMS_MAIL_TENANT_ID}
+nihms.mail.client.id=${NIHMS_MAIL_CLIENT_ID}
+nihms.mail.client.secret=${NIHMS_MAIL_CLIENT_SECRET}
 
 pass.deposit.nihms.email.enabled=false
 pass.deposit.nihms.email.delay=720000
 pass.deposit.nihms.email.auth=${NIHMS_MAIL_AUTH:LOGIN}
-pass.deposit.nihms.email.from=${PASS_DEPOSIT_NIHMS_EMAIL_FROM:nihms-help@ncbi.nlm.nih.gov}
+pass.deposit.nihms.email.from=${PASS_DEPOSIT_NIHMS_EMAIL_FROM}
 
 pass.test.data.job.enabled=false
 pass.test.data.job.interval-ms=${TEST_DATA_JOB_INTVL_MS:1800000}
-pass.test.data.policy.title=${TEST_DATA_POLICY_TITLE:}
-pass.test.data.user.email=${TEST_DATA_USER_EMAIL:}
+pass.test.data.policy.title=${TEST_DATA_POLICY_TITLE}
+pass.test.data.user.email=${TEST_DATA_USER_EMAIL}
 pass.test.skip.deposits=${TEST_DATA_SKIP_DEPOSITS:true}
-pass.test.dspace.repo.key=${TEST_DATA_DSPACE_REPO_KEY:JScholarship}
+pass.test.dspace.repo.key=${TEST_DATA_DSPACE_REPO_KEY}

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/AbstractDepositSubmissionIT.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/AbstractDepositSubmissionIT.java
@@ -67,12 +67,13 @@ import org.testcontainers.utility.DockerImageName;
  */
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = DepositApp.class)
-@TestPropertySource("classpath:test-application.properties")
-@TestPropertySource(properties = {
-    "pass.client.url=http://localhost:8080",
-    "pass.client.user=backend",
-    "pass.client.password=backend"
-})
+@TestPropertySource(
+    locations = "/test-application.properties",
+    properties = {
+        "pass.client.url=http://localhost:8080",
+        "pass.client.user=backend",
+        "pass.client.password=backend"
+    })
 @Testcontainers
 @DirtiesContext
 public abstract class AbstractDepositSubmissionIT {

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/config/repository/AbstractJacksonMappingTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/config/repository/AbstractJacksonMappingTest.java
@@ -27,7 +27,14 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(classes = DepositApp.class)
-@TestPropertySource("classpath:test-application.properties")
+@TestPropertySource(
+    locations = "/test-application.properties",
+    properties = {
+        "dspace.host=test-dspace-host",
+        "dspace.port=test-dspace-port",
+        "pmc.ftp.host=test-ftp-host",
+        "pmc.ftp.port=test-ftp-port",
+    })
 public abstract class AbstractJacksonMappingTest {
 
     @Autowired

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/config/repository/PropertyResolvingDeserializerTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/config/repository/PropertyResolvingDeserializerTest.java
@@ -30,7 +30,7 @@ public class PropertyResolvingDeserializerTest extends AbstractJacksonMappingTes
             RepositoryConfig.class);
         assertEquals(SwordV2Binding.PROTO, config.getTransportConfig().getProtocolBinding().getProtocol());
         SwordV2Binding swordV2Binding = (SwordV2Binding) config.getTransportConfig().getProtocolBinding();
-        assertTrue(swordV2Binding.getDefaultCollectionUrl().contains("http://localhost:8181"));
+        assertTrue(swordV2Binding.getDefaultCollectionUrl().contains("http://test-dspace-host:test-dspace-port"));
     }
 
     @Test

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/config/repository/SimpleClassMappingTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/config/repository/SimpleClassMappingTest.java
@@ -121,8 +121,9 @@ public class SimpleClassMappingTest extends AbstractJacksonMappingTest {
         assertEquals("SWORDv2", swordBinding.getProtocol());
         assertEquals("sworduser", swordBinding.getUsername());
         assertEquals("swordpass", swordBinding.getPassword());
-        assertEquals("http://localhost:8181/swordv2/servicedocument", swordBinding.getServiceDocUrl());
-        assertEquals("http://localhost:8181/swordv2/collection/123456789/2",
+        assertEquals("http://test-dspace-host:test-dspace-port/swordv2/servicedocument",
+            swordBinding.getServiceDocUrl());
+        assertEquals("http://test-dspace-host:test-dspace-port/swordv2/collection/123456789/2",
                      swordBinding.getDefaultCollectionUrl());
         assertNull(swordBinding.getOnBehalfOf());
         assertTrue(swordBinding.isDepositReceipt());
@@ -157,8 +158,8 @@ public class SimpleClassMappingTest extends AbstractJacksonMappingTest {
         assertEquals("sftp", sftpBinding.getProtocol());
         assertEquals("sftpuser", sftpBinding.getUsername());
         assertEquals("sftppass", sftpBinding.getPassword());
-        assertEquals("localhost", sftpBinding.getServerFqdn());
-        assertEquals("21", sftpBinding.getServerPort());
+        assertEquals("test-ftp-host", sftpBinding.getServerFqdn());
+        assertEquals("test-ftp-port", sftpBinding.getServerPort());
         assertEquals("/logs/upload/%s", sftpBinding.getDefaultDirectory());
     }
 
@@ -169,8 +170,8 @@ public class SimpleClassMappingTest extends AbstractJacksonMappingTest {
         assertEquals("ftp", ftpBinding.getProtocol());
         assertEquals("ftpuser", ftpBinding.getUsername());
         assertEquals("ftppass", ftpBinding.getPassword());
-        assertEquals("localhost", ftpBinding.getServerFqdn());
-        assertEquals("21", ftpBinding.getServerPort());
+        assertEquals("test-ftp-host", ftpBinding.getServerFqdn());
+        assertEquals("test-ftp-port", ftpBinding.getServerPort());
         assertEquals("binary", ftpBinding.getDataType());
         assertEquals("stream", ftpBinding.getTransferMode());
         assertTrue(ftpBinding.isUsePasv());

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/config/spring/AwsParamStoreConfigTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/config/spring/AwsParamStoreConfigTest.java
@@ -34,13 +34,18 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
-@SpringBootTest(
-    properties = {
-        "spring.cloud.aws.credentials.access-key=noop",
-        "spring.cloud.aws.credentials.secret-key=noop",
-        "spring.cloud.aws.region.static=us-east-1",
-        "spring.jms.listener.auto-startup=false"
-    })
+@SpringBootTest(properties = """
+    spring.cloud.aws.credentials.access-key=noop
+    spring.cloud.aws.credentials.secret-key=noop
+    spring.cloud.aws.region.static=us-east-1
+    spring.jms.listener.auto-startup=false
+    pass.client.url=http://localhost:8080/
+    pass.client.user=${PASS_CORE_USER:test}
+    pass.client.password=${PASS_CORE_PASSWORD:test-pw}
+    dspace.user=${DSPACE_USER:test@test.edu}
+    dspace.password=${DSPACE_PASSWORD:test-dspace-pw}
+    """
+)
 @ContextConfiguration(initializers = ConfigDataApplicationContextInitializer.class)
 @Testcontainers
 class AwsParamStoreConfigTest {

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/config/spring/RepositoriesConfigS3IT.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/config/spring/RepositoriesConfigS3IT.java
@@ -44,11 +44,13 @@ import org.testcontainers.utility.DockerImageName;
  */
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = DepositApp.class)
-@TestPropertySource(properties = {
-    "spring.jms.listener.auto-startup=false",
-    "spring.cloud.aws.s3.enabled=true",
-    "pass.deposit.repository.configuration=s3://test-bucket/s3-test-repositories.json"
-})
+@TestPropertySource(
+    locations = "/test-application.properties",
+    properties = {
+        "spring.jms.listener.auto-startup=false",
+        "spring.cloud.aws.s3.enabled=true",
+        "pass.deposit.repository.configuration=s3://test-bucket/s3-test-repositories.json"
+    })
 @Testcontainers
 public class RepositoriesConfigS3IT {
 

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/AbstractDepositIT.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/AbstractDepositIT.java
@@ -50,10 +50,13 @@ import org.swordapp.client.SwordIdentifier;
 
 @TestPropertySource(properties = {
     "pass.deposit.repository.configuration=classpath:org/eclipse/pass/deposit/messaging/status/DepositTaskIT.json",
-    "dspace.username=testuser",
-    "dspace.password=testuserpassword",
+    "dspace.host=localhost",
+    "dspace.port=9020",
+    "dspace.user=test-dspace-user",
+    "dspace.password=test-dspace-password",
+    "dspace.server=localhost:9020",
     "dspace.baseuri=http://localhost",
-    "dspace.collection.handle=foobartest"
+    "dspace.collection.handle=foobartest",
 })
 /**
  * @author Elliot Metsger (emetsger@jhu.edu)

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/AbstractListenerIT.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/AbstractListenerIT.java
@@ -35,14 +35,16 @@ import org.testcontainers.utility.DockerImageName;
  */
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = DepositApp.class)
-@TestPropertySource(properties = {
-    "aws.region=us-east-1",
-    "aws.sqs.endpoint.override=",
-    "spring.jms.listener.auto-startup=true",
-    "spring.cloud.aws.s3.enabled=false",
-    "pass.deposit.queue.submission.name=" + AwsSqsTestConfig.QUEUE_NAME,
-    "pass.deposit.jobs.disabled=true"
-})
+@TestPropertySource(
+    locations = "/test-application.properties",
+    properties = {
+        "aws.region=us-east-1",
+        "aws.sqs.endpoint.override=",
+        "spring.jms.listener.auto-startup=true",
+        "spring.cloud.aws.s3.enabled=false",
+        "pass.deposit.queue.submission.name=" + AwsSqsTestConfig.QUEUE_NAME,
+        "pass.deposit.jobs.disabled=true"
+    })
 @Testcontainers
 @DirtiesContext
 public abstract class AbstractListenerIT {

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/DepositProcessorIT.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/DepositProcessorIT.java
@@ -43,7 +43,9 @@ import org.springframework.test.context.TestPropertySource;
  * @author Russ Poetker (rpoetke1@jh.edu)
  */
 @TestPropertySource(properties = {
-    "pass.deposit.repository.configuration=classpath:/full-test-repositories.json"
+    "pass.deposit.repository.configuration=classpath:/full-test-repositories.json",
+    "inveniordm.api.baseUrl=http://localhost",
+    "inveniordm.api.token=test-token",
 })
 public class DepositProcessorIT extends AbstractDepositIT {
 

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/DepositUpdaterIT.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/DepositUpdaterIT.java
@@ -39,7 +39,9 @@ import org.springframework.test.context.TestPropertySource;
  * @author Russ Poetker (rpoetke1@jh.edu)
  */
 @TestPropertySource(properties = {
-    "pass.deposit.repository.configuration=classpath:/full-test-repositories.json"
+    "pass.deposit.repository.configuration=classpath:/full-test-repositories.json",
+    "inveniordm.api.baseUrl=http://localhost",
+    "inveniordm.api.token=test-token",
 })
 public class DepositUpdaterIT extends AbstractDepositIT {
 

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/support/deploymenttest/DeploymentTestDataServiceIT.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/support/deploymenttest/DeploymentTestDataServiceIT.java
@@ -73,13 +73,11 @@ import org.springframework.test.util.ReflectionTestUtils;
  * @author Russ Poetker (rpoetke1@jh.edu)
  */
 @TestPropertySource(properties = {
-    "pass.test.data.policy.title=test-policy-title",
-    "pass.test.data.user.email=test-user-email@foo",
-    "dspace.user=test-dspace-user",
-    "dspace.password=test-dspace-password",
-    "dspace.server=localhost:9020",
     "dspace.server.api.protocol=http",
     "dspace.server.api.path=/server/api",
+    "pass.test.data.job.enabled=true",
+    "pass.test.data.policy.title=test-policy-title",
+    "pass.test.data.user.email=test-user-email@foo",
     "pass.test.dspace.repo.key=TestDspace"
 })
 @WireMockTest(httpPort = 9020)

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/support/jobs/ScheduledJobsTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/support/jobs/ScheduledJobsTest.java
@@ -32,16 +32,22 @@ import org.springframework.test.context.TestPropertySource;
  * @author Russ Poetker (rpoetke1@jh.edu)
  */
 @SpringBootTest(classes = DepositApp.class)
-@TestPropertySource("classpath:test-application.properties")
-@TestPropertySource(properties = {
-    "pass.deposit.jobs.disabled=false",
-    "pass.test.data.job.enabled=true",
-    "pass.deposit.jobs.default-interval-ms=1500",
-    "pass.test.data.job.interval-ms=1500",
-    "pass.deposit.jobs.1.init.delay=50",
-    "pass.deposit.jobs.2.init.delay=100",
-    "pass.deposit.jobs.3.init.delay=120"
-})
+@TestPropertySource(
+    locations = "classpath:test-application.properties",
+    properties = {
+        "pass.deposit.jobs.disabled=false",
+        "pass.test.data.job.enabled=true",
+        "pass.deposit.jobs.default-interval-ms=1500",
+        "pass.test.data.job.interval-ms=1500",
+        "pass.deposit.jobs.1.init.delay=50",
+        "pass.deposit.jobs.2.init.delay=100",
+        "pass.deposit.jobs.3.init.delay=120",
+        "dspace.user=test-dspace-user",
+        "dspace.password=test-dspace-password",
+        "dspace.server=localhost:9020",
+        "dspace.server.api.protocol=http",
+        "dspace.server.api.path=/server/api",
+    })
 public class ScheduledJobsTest {
 
     @MockBean private SubmissionStatusUpdater submissionStatusUpdater;

--- a/pass-deposit-services/deposit-core/src/test/resources/org/eclipse/pass/deposit/messaging/status/DepositTaskIT.json
+++ b/pass-deposit-services/deposit-core/src/test/resources/org/eclipse/pass/deposit/messaging/status/DepositTaskIT.json
@@ -18,14 +18,14 @@
       "auth-realms": [
         {
           "mech": "basic",
-          "username": "${dspace.username}",
+          "username": "${dspace.user}",
           "password": "${dspace.password}",
           "url": "${dspace.baseuri}/swordv2"
         }
       ],
       "protocol-binding": {
         "protocol": "SWORDv2",
-        "username": "${dspace.username}",
+        "username": "${dspace.user}",
         "password": "${dspace.password}",
         "server-fqdn": "${dspace.host}",
         "server-port": "${dspace.port}",

--- a/pass-grant-loader/src/main/resources/application.properties
+++ b/pass-grant-loader/src/main/resources/application.properties
@@ -6,10 +6,10 @@ spring.profiles.active=jhu
 pass.policy.prop.path=${POLICY_PROP_PATH:file:///data/grantloader/policy.properties}
 pass.grant.update.ts.path=${GRANT_UPDATE_TS_PATH:file:///data/grantloader/grant_update_timestamps}
 
-grant.db.url=${GRANT_DB_URL:}
-grant.db.username=${GRANT_DB_USER:}
-grant.db.password=${GRANT_DB_PASSWORD:}
+grant.db.url=${GRANT_DB_URL}
+grant.db.username=${GRANT_DB_USER}
+grant.db.password=${GRANT_DB_PASSWORD}
 
-pass.client.url=${PASS_CORE_URL:localhost:8080}
-pass.client.user=${PASS_CORE_USER:fakeuser}
-pass.client.password=${PASS_CORE_PASSWORD:fakepassword}
+pass.client.url=${PASS_CORE_URL}
+pass.client.user=${PASS_CORE_USER}
+pass.client.password=${PASS_CORE_PASSWORD}

--- a/pass-grant-loader/src/test/java/org/eclipse/pass/support/grant/AwsParamStoreConfigTest.java
+++ b/pass-grant-loader/src/test/java/org/eclipse/pass/support/grant/AwsParamStoreConfigTest.java
@@ -42,7 +42,13 @@ import org.testcontainers.utility.DockerImageName;
         "spring.cloud.aws.credentials.secret-key=noop",
         "spring.cloud.aws.region.static=us-east-1",
         "pass.policy.prop.path=file:./src/test/resources/policy.properties",
-        "pass.grant.update.ts.path=file:./src/test/resources/grant_update_timestamps"
+        "pass.grant.update.ts.path=file:./src/test/resources/grant_update_timestamps",
+        "pass.client.url=http://localhost:8080/",
+        "pass.client.user=${PASS_CORE_USER:test}",
+        "pass.client.password=${PASS_CORE_PASSWORD:test-pw}",
+        "grant.db.url=${GRANT_DB_URL:test-grant-db-url}",
+        "grant.db.username=${GRANT_DB_USER:test-grant-db-user}",
+        "grant.db.password=${GRANT_DB_PASSWORD:test-grant-db-pw}"
     })
 @ContextConfiguration(initializers = ConfigDataApplicationContextInitializer.class)
 @Testcontainers
@@ -82,7 +88,7 @@ class AwsParamStoreConfigTest {
     @Test
     public void testLoadPropFromParamStore() {
         String userNameProp = environment.getProperty("grant.db.username");
-        assertEquals("", userNameProp);
+        assertEquals("test-grant-db-user", userNameProp);
         String userPwProp = environment.getProperty("grant.db.password");
         assertEquals("aws-param-store-grant-pw", userPwProp);
         String passClientPwProp = environment.getProperty("pass.client.password");

--- a/pass-grant-loader/src/test/java/org/eclipse/pass/support/grant/GrantLoaderCLITest.java
+++ b/pass-grant-loader/src/test/java/org/eclipse/pass/support/grant/GrantLoaderCLITest.java
@@ -30,7 +30,14 @@ import org.springframework.test.context.TestPropertySource;
  */
 @SpringBootTest(classes = GrantLoaderCLI.class,
     args = {"--startDateTime=2024-01-01T00:00:00", "-awardEndDate=01/01/2025", "-action=pull", "test-pull-file.csv"})
-@TestPropertySource("classpath:test-application.properties")
+@TestPropertySource(
+    locations = "classpath:test-application.properties",
+    properties = """
+    grant.db.url=test-grant-db-url
+    grant.db.username=test-grant-db-user
+    grant.db.password=test-grant-db-pw
+    """
+)
 public class GrantLoaderCLITest {
 
     @MockBean GrantLoaderApp grantLoaderApp;

--- a/pass-grant-loader/src/test/java/org/eclipse/pass/support/grant/PolicyPropertiesS3IT.java
+++ b/pass-grant-loader/src/test/java/org/eclipse/pass/support/grant/PolicyPropertiesS3IT.java
@@ -45,7 +45,13 @@ import org.testcontainers.utility.DockerImageName;
 @TestPropertySource(properties = {
     "spring.cloud.aws.s3.enabled=true",
     "pass.policy.prop.path=s3://test-bucket/s3-policy.properties",
-    "pass.grant.update.ts.path=file:./src/test/resources/s3-testgrantupdatets"
+    "pass.grant.update.ts.path=file:./src/test/resources/s3-testgrantupdatets",
+    "pass.client.url=http://localhost:8080/",
+    "pass.client.user=test",
+    "pass.client.password=test-pw",
+    "grant.db.url=test-grant-db-url",
+    "grant.db.username=test-grant-db-user",
+    "grant.db.password=test-grant-db-pw"
 })
 @Testcontainers
 public class PolicyPropertiesS3IT {

--- a/pass-nihms-loader/nihms-data-harvest/src/main/resources/application.properties
+++ b/pass-nihms-loader/nihms-data-harvest/src/main/resources/application.properties
@@ -18,11 +18,11 @@ nihmsetl.http.connect-timeout-ms=30000
 # Format ought to be CSV, otherwise the loader won't be able to process the saved files
 nihmsetl.api.url.param.format=csv
 # Institution name, unclear as to how it is used
-nihmsetl.api.url.param.inst=${NIHMS_API_INST:}
+nihmsetl.api.url.param.inst=${NIHMS_API_INST}
 #  IPF (Institutional Profile File) number, the unique ID assigned to a grantee organization in the eRA system.
-nihmsetl.api.url.param.ipf=${NIHMS_API_IPF:}
+nihmsetl.api.url.param.ipf=${NIHMS_API_IPF}
 # The API token retrieved from the PACM website.  These expire every three months.
-nihmsetl.api.url.param.api-token=${NIHMS_API_TOKEN:}
+nihmsetl.api.url.param.api-token=${NIHMS_API_TOKEN}
 # Date in MM/YYYY format that the PACM data should start from (may be set using the `-s` harvester command line option).
 # By default this date will be set to the current month, one year ago
 nihmsetl.api.url.param.pdf=

--- a/pass-nihms-loader/nihms-data-transform-load/src/main/resources/application.properties
+++ b/pass-nihms-loader/nihms-data-transform-load/src/main/resources/application.properties
@@ -1,10 +1,10 @@
 spring.main.web-application-type=NONE
-nihmsetl.repository.id=${NIHMS_REPO_ID:}
+nihmsetl.repository.id=${NIHMS_REPO_ID}
 nihmsetl.data.dir=/data/nihmsloader/data
 nihmsetl.pmcurl.template=https://www.ncbi.nlm.nih.gov/pmc/articles/%s/
 
 pmc.entrez.service.url=https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=pubmed&retmode=json&rettype=abstract&id=%s
 
-pass.client.url=${PASS_CORE_URL:localhost:8080}
-pass.client.user=${PASS_CORE_USER:fakeuser}
-pass.client.password=${PASS_CORE_PASSWORD:fakepassword}
+pass.client.url=${PASS_CORE_URL}
+pass.client.user=${PASS_CORE_USER}
+pass.client.password=${PASS_CORE_PASSWORD}

--- a/pass-nihms-loader/nihms-data-transform-load/src/test/java/org/eclipse/pass/loader/nihms/AwsParamStoreConfigTest.java
+++ b/pass-nihms-loader/nihms-data-transform-load/src/test/java/org/eclipse/pass/loader/nihms/AwsParamStoreConfigTest.java
@@ -39,7 +39,10 @@ import org.testcontainers.utility.DockerImageName;
     properties = {
         "spring.cloud.aws.credentials.access-key=noop",
         "spring.cloud.aws.credentials.secret-key=noop",
-        "spring.cloud.aws.region.static=us-east-1"
+        "spring.cloud.aws.region.static=us-east-1",
+        "pass.client.url=http://localhost:8080/",
+        "pass.client.user=${PASS_CORE_USER:test}",
+        "pass.client.password=${PASS_CORE_PASSWORD:test-pw}",
     })
 @ContextConfiguration(initializers = ConfigDataApplicationContextInitializer.class)
 @Testcontainers
@@ -79,7 +82,7 @@ class AwsParamStoreConfigTest {
     @Test
     public void testLoadPropFromParamStore() {
         String clientUrlNameProp = environment.getProperty("pass.client.url");
-        assertEquals("localhost:8080", clientUrlNameProp);
+        assertEquals("http://localhost:8080/", clientUrlNameProp);
         String repoIdProp = environment.getProperty("nihmsetl.repository.id");
         assertEquals("aws-param-store-repo-id", repoIdProp);
         String passClientPwProp = environment.getProperty("pass.client.password");

--- a/pass-nihms-loader/nihms-data-transform-load/src/test/resources/test-application.properties
+++ b/pass-nihms-loader/nihms-data-transform-load/src/test/resources/test-application.properties
@@ -1,5 +1,6 @@
 # directory to harvest data from
 nihmsetl.data.dir=./src/test/resources/data
+nihmsetl.repository.id=test-repo-id
 # PubMed Central Entrez Service URL
 pmc.entrez.service.url=http://localhost:9911/entrez/eutils/esummary.fcgi?db=pubmed&retmode=json&rettype=abstract&id=%s
 # pass-core properties

--- a/pass-notification-service/src/main/resources/application.properties
+++ b/pass-notification-service/src/main/resources/application.properties
@@ -21,8 +21,8 @@ spring.jms.listener.auto-startup=true
 spring.jms.cache.enabled=false
 
 spring.mail.protocol=${SPRING_MAIL_PROTOCOL:smtp}
-spring.mail.host=${SPRING_MAIL_HOST:localhost}
-spring.mail.port=${SPRING_MAIL_PORT:587}
+spring.mail.host=${SPRING_MAIL_HOST}
+spring.mail.port=${SPRING_MAIL_PORT}
 spring.mail.username=${SPRING_MAIL_USERNAME}
 spring.mail.password=${SPRING_MAIL_PASSWORD}
 spring.mail.properties.mail.smtp.starttls.enable=true
@@ -32,14 +32,14 @@ spring.mail.properties.mail.smtp.connectiontimeout=5000
 spring.mail.properties.mail.smtp.timeout=3000
 spring.mail.properties.mail.smtp.writetimeout=5000
 
-pass.client.url=${PASS_CORE_URL:localhost:8080}
-pass.client.user=${PASS_CORE_USER:fakeuser}
-pass.client.password=${PASS_CORE_PASSWORD:fakepassword}
+pass.client.url=${PASS_CORE_URL}
+pass.client.user=${PASS_CORE_USER}
+pass.client.password=${PASS_CORE_PASSWORD}
 
 pass.jms.queue.submission.event.name=${PASS_JMS_QUEUE_SUBMISSION_EVENT_NAME:event}
 
 pass.notification.mode=${PASS_NOTIFICATION_MODE:DEMO}
 pass.notification.configuration=${PASS_NOTIFICATION_CONFIGURATION:classpath:/notification.json}
 pass.link.scheme=${PASS_LINK_SCHEME:https}
-pass.link.host=${PASS_LINK_HOST:passreplacethis.foo}
-pass.app.domain=${PASS_APP_DOMAIN:passreplacethis.foo}
+pass.link.host=${PASS_LINK_HOST}
+pass.app.domain=${PASS_APP_DOMAIN}

--- a/pass-notification-service/src/test/java/org/eclipse/pass/notification/config/AwsParamStoreConfigTest.java
+++ b/pass-notification-service/src/test/java/org/eclipse/pass/notification/config/AwsParamStoreConfigTest.java
@@ -39,7 +39,15 @@ import org.testcontainers.utility.DockerImageName;
         "spring.cloud.aws.credentials.access-key=noop",
         "spring.cloud.aws.credentials.secret-key=noop",
         "spring.cloud.aws.region.static=us-east-1",
-        "spring.jms.listener.auto-startup=false"
+        "spring.jms.listener.auto-startup=false",
+        "spring.mail.host=${SPRING_MAIL_HOST:test-mail-host}",
+        "spring.mail.port=${SPRING_MAIL_PORT:999}",
+        "spring.mail.username=${SPRING_MAIL_USERNAME:test-mail-user}",
+        "spring.mail.password=${SPRING_MAIL_PASSWORD:test-mail-pw}",
+        "pass.client.url=http://localhost:8080/",
+        "pass.client.user=${PASS_CORE_USER:test}",
+        "pass.client.password=${PASS_CORE_PASSWORD:test-pw}",
+        "pass.app.domain=testing-pass-app-domain",
     })
 @ContextConfiguration(initializers = ConfigDataApplicationContextInitializer.class)
 @Testcontainers
@@ -77,7 +85,7 @@ class AwsParamStoreConfigTest {
     @Test
     public void testLoadPropFromParamStore() {
         String mailHostNameProp = environment.getProperty("spring.mail.host");
-        assertEquals("localhost", mailHostNameProp);
+        assertEquals("test-mail-host", mailHostNameProp);
         String userPwProp = environment.getProperty("spring.mail.password");
         assertEquals("aws-param-store-notif-pw", userPwProp);
         String passClientPwProp = environment.getProperty("pass.client.password");

--- a/pass-notification-service/src/test/resources/test-application.properties
+++ b/pass-notification-service/src/test/resources/test-application.properties
@@ -19,6 +19,10 @@
 #
 spring.jms.listener.auto-startup=false
 
+pass.client.url=http://localhost:8080/
+pass.client.user=backend
+pass.client.password=backend
+
 spring.mail.protocol=smtp
 spring.mail.host=localhost
 spring.mail.port=3025


### PR DESCRIPTION
Cleans up all default application properties for modules that are Spring Boot modules.  I did review `pass-data-client` and `pass-journal-loader` as well (not Spring Boot modules) and didn't see any default values for the required env vars for each.

For deposit services, I did some additional clean up on making certain beans conditionals on property.  This is so that deposit services will start up correctly when certain application properties are present or missing.

