### PR TITLE
Put plugin back for journal-loader so docker image is built

### DIFF
--- a/pass-journal-loader/pass-journal-loader-nih/pom.xml
+++ b/pass-journal-loader/pass-journal-loader-nih/pom.xml
@@ -105,6 +105,27 @@
       </plugin>
 
       <plugin>
+        <groupId>io.fabric8</groupId>
+        <artifactId>docker-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>build-after-its</id>
+            <phase>post-integration-test</phase>
+            <configuration>
+              <images>
+                <image>
+                  <name>ghcr.io/eclipse-pass/pass-journal-loader:%v</name>
+                </image>
+              </images>
+            </configuration>
+            <goals>
+              <goal>build</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <executions>


### PR DESCRIPTION
Removed by accident in https://github.com/eclipse-pass/pass-support/pull/130/files#diff-139606e7404e8d3da69aebf57b6bb8fba15fc4a29f4a8e506d87d855da33bfd8L96