### PR TITLE
Dependency upgrade fixes

### DIFF
--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/config/spring/email/NihmsMailAuthOauthConfiguration.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/config/spring/email/NihmsMailAuthOauthConfiguration.java
@@ -63,6 +63,7 @@ public class NihmsMailAuthOauthConfiguration {
     private Properties getImapOauthProperties() {
         Properties javaMailProperties = mailIntegration.getImapDefaultProperties();
         javaMailProperties.setProperty("mail.imaps.sasl.mechanisms", "XOAUTH2");
+        javaMailProperties.setProperty("mail.imaps.auth.xoauth2.disable", "false");
         return javaMailProperties;
     }
 

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceOauthIT.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceOauthIT.java
@@ -17,14 +17,12 @@ package org.eclipse.pass.deposit.service;
 
 import org.eclipse.pass.deposit.DepositApp;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
 
 /**
  * @author Russ Poetker (rpoetke1@jh.edu)
  */
 @SpringBootTest(classes = DepositApp.class)
-@Import(OauthTestConfig.class)
 @TestPropertySource("classpath:test-application.properties")
 @TestPropertySource(properties = {
     "nihms.email.oauth.test.it=true",

--- a/pass-nihms-loader/nihms-data-transform-load/pom.xml
+++ b/pass-nihms-loader/nihms-data-transform-load/pom.xml
@@ -35,6 +35,12 @@
     </dependency>
 
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>${commons-io.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
     </dependency>
@@ -138,12 +144,6 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>${commons-io.version}</version>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>org.wiremock</groupId>
       <artifactId>wiremock-standalone</artifactId>

--- a/pass-nihms-loader/pom.xml
+++ b/pass-nihms-loader/pom.xml
@@ -166,6 +166,7 @@
                                 <ignoredNonTestScopedDependency>org.junit.jupiter:junit-jupiter-api:</ignoredNonTestScopedDependency>
                                 <!-- Needed for when data-transform jar is created -->
                                 <ignoredNonTestScopedDependency>org.json:json:</ignoredNonTestScopedDependency>
+                                <ignoredNonTestScopedDependency>commons-io:commons-io:</ignoredNonTestScopedDependency>
                             </ignoredNonTestScopedDependencies>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Fixes the following issues from dependency upgrades:

- Nihms email service authentication is failing when logging in with xoath2
- Nihms loader transform step is failing with ClassNotFound exception on an commons.io class