### PR TITLE
Upgrade cleanup

### DIFF
--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/config/spring/AwsParamStoreConfigTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/config/spring/AwsParamStoreConfigTest.java
@@ -39,6 +39,7 @@ import org.testcontainers.utility.DockerImageName;
     spring.cloud.aws.credentials.secret-key=noop
     spring.cloud.aws.region.static=us-east-1
     spring.jms.listener.auto-startup=false
+    pass.deposit.jobs.disabled=true
     pass.client.url=http://localhost:8080/
     pass.client.user=${PASS_CORE_USER:test}
     pass.client.password=${PASS_CORE_PASSWORD:test-pw}

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/config/spring/email/Oauth2ExchangeMailAuthenticatorTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/config/spring/email/Oauth2ExchangeMailAuthenticatorTest.java
@@ -40,14 +40,15 @@ import org.springframework.test.context.TestPropertySource;
  * @author Russ Poetker (rpoetke1@jh.edu)
  */
 @SpringBootTest(classes = DepositApp.class)
-@TestPropertySource("classpath:test-application.properties")
-@TestPropertySource(properties = {
-    "pass.deposit.nihms.email.auth=MS_EXCHANGE_OAUTH2",
-    "nihms.mail.username=testnihms-oauth@localhost",
-    "nihms.mail.tenant.id=test-tenant",
-    "nihms.mail.client.id=test-client-id",
-    "nihms.mail.client.secret=test-client-id"
-})
+@TestPropertySource(
+    locations = "/test-application.properties",
+    properties = {
+        "pass.deposit.nihms.email.auth=MS_EXCHANGE_OAUTH2",
+        "nihms.mail.username=testnihms-oauth@localhost",
+        "nihms.mail.tenant.id=test-tenant",
+        "nihms.mail.client.id=test-client-id",
+        "nihms.mail.client.secret=test-client-id"
+    })
 public class Oauth2ExchangeMailAuthenticatorTest {
 
     @Autowired private Oauth2ExchangeMailAuthenticator oauth2ExchangeMailAuthenticator;

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceTest.java
@@ -64,18 +64,18 @@ import org.springframework.test.context.TestPropertySource;
  * @author Russ Poetker (rpoetke1@jh.edu)
  */
 @SpringBootTest(classes = DepositApp.class)
-@TestPropertySource("classpath:test-application.properties")
-@TestPropertySource(properties = {
-    "pass.deposit.nihms.email.enabled=true",
-    "pass.deposit.nihms.email.delay=2000",
-    "pass.deposit.nihms.email.from=test-from-2@localhost,test-from@localhost",
-    "pass.deposit.nihms.email.ssl.checkserveridentity=false",
-    "nihms.mail.host=localhost",
-    "nihms.mail.port=3993",
-    "nihms.mail.username=testnihms@localhost",
-    "nihms.mail.password=testnihmspassword"
-
-})
+@TestPropertySource(
+    locations = "/test-application.properties",
+    properties = {
+        "pass.deposit.nihms.email.enabled=true",
+        "pass.deposit.nihms.email.delay=2000",
+        "pass.deposit.nihms.email.from=test-from-2@localhost,test-from@localhost",
+        "pass.deposit.nihms.email.ssl.checkserveridentity=false",
+        "nihms.mail.host=localhost",
+        "nihms.mail.port=3993",
+        "nihms.mail.username=testnihms@localhost",
+        "nihms.mail.password=testnihmspassword"
+    })
 public class NihmsReceiveMailServiceTest {
 
     @RegisterExtension

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/NihmsReceiveMailServiceTest.java
@@ -58,6 +58,7 @@ import org.mockito.Captor;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 
 /**
@@ -76,6 +77,7 @@ import org.springframework.test.context.TestPropertySource;
         "nihms.mail.username=testnihms@localhost",
         "nihms.mail.password=testnihmspassword"
     })
+@DirtiesContext
 public class NihmsReceiveMailServiceTest {
 
     @RegisterExtension

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/support/jobs/ScheduledJobsTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/support/jobs/ScheduledJobsTest.java
@@ -26,6 +26,7 @@ import org.eclipse.pass.deposit.support.deploymenttest.DeploymentTestDataService
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 
 /**
@@ -48,6 +49,7 @@ import org.springframework.test.context.TestPropertySource;
         "dspace.server.api.protocol=http",
         "dspace.server.api.path=/server/api",
     })
+@DirtiesContext
 public class ScheduledJobsTest {
 
     @MockBean private SubmissionStatusUpdater submissionStatusUpdater;

--- a/pass-deposit-services/pom.xml
+++ b/pass-deposit-services/pom.xml
@@ -304,7 +304,6 @@
             <execution>
               <goals>
                 <goal>jar</goal>
-                <goal>test-jar</goal>
               </goals>
             </execution>
           </executions>
@@ -323,11 +322,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
Couple more clean up changes found after dependency upgrade:

- Fully remove `maven-jar-plugin` from deposit services.
- Clean up tests related to scheduled jobs that left async threads running after test run.