### PR TITLE
Fix compile warnings in deposit-services

### DIFF
--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/RemedialDepositException.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/RemedialDepositException.java
@@ -24,6 +24,7 @@ import org.eclipse.pass.support.client.model.PassEntity;
  * @author Elliot Metsger (emetsger@jhu.edu)
  */
 public class RemedialDepositException extends DepositServiceRuntimeException {
+    private static final long serialVersionUID = 1L;
 
     public RemedialDepositException(PassEntity resource) {
         super(resource);

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/assembler/ArchiveOutputStreamFactory.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/assembler/ArchiveOutputStreamFactory.java
@@ -18,6 +18,7 @@ package org.eclipse.pass.deposit.assembler;
 import java.io.OutputStream;
 import java.util.Map;
 
+import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.ArchiveOutputStream;
 
 /**
@@ -37,6 +38,7 @@ public interface ArchiveOutputStreamFactory {
      * @param toWrap         the output stream to be wrapped by the returned {@code ArchiveOutputStream}
      * @return the configured {@code ArchiveOutputStream} ready for writing
      */
-    ArchiveOutputStream newInstance(Map<String, Object> packageOptions, OutputStream toWrap);
+    <O extends ArchiveOutputStream<? extends ArchiveEntry>> O newInstance(Map<String, Object> packageOptions,
+                                                                          OutputStream toWrap);
 
 }

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/assembler/ArchivingPackageStream.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/assembler/ArchivingPackageStream.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 
+import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.ArchiveOutputStream;
 import org.eclipse.pass.deposit.assembler.PackageOptions.Archive;
 import org.eclipse.pass.deposit.model.DepositSubmission;
@@ -130,7 +131,7 @@ public class ArchivingPackageStream implements PackageStream {
 
         // Wrap the output stream in an ArchiveOutputStream
         // we support zip, tar and tar.gz so far
-        ArchiveOutputStream archiveOut = archiveOutputStreamFactory.newInstance(packageOptions, pipedOut);
+        ArchiveOutputStream<ArchiveEntry> archiveOut = archiveOutputStreamFactory.newInstance(packageOptions, pipedOut);
 
         // Set on the writer, and used to report any exceptions caught by the writer to the reader.  That way a full
         // stack trace of the exception will be reported when it is encountered by the reader

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/assembler/CallableStreamWriter.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/assembler/CallableStreamWriter.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.ArchiveOutputStream;
 import org.eclipse.pass.deposit.model.DepositSubmission;
 import org.springframework.core.io.Resource;
@@ -36,7 +37,7 @@ public class CallableStreamWriter<V> implements Callable<V>, StreamWriter {
 
     private StreamWriter delegate;
 
-    private ArchiveOutputStream archiveOut;
+    private ArchiveOutputStream<ArchiveEntry> archiveOut;
 
     private List<DepositFileResource> custodialFiles;
 
@@ -55,7 +56,7 @@ public class CallableStreamWriter<V> implements Callable<V>, StreamWriter {
      * @param custodialFiles
      */
     CallableStreamWriter(StreamWriter delegate,
-                         ArchiveOutputStream archiveOut,
+                         ArchiveOutputStream<ArchiveEntry> archiveOut,
                          List<DepositFileResource> custodialFiles) {
         this.delegate = delegate;
         this.archiveOut = archiveOut;
@@ -73,7 +74,8 @@ public class CallableStreamWriter<V> implements Callable<V>, StreamWriter {
     }
 
     @Override
-    public void start(List<DepositFileResource> custodialFiles, ArchiveOutputStream archiveOut) throws IOException {
+    public void start(List<DepositFileResource> custodialFiles, ArchiveOutputStream<ArchiveEntry> archiveOut)
+        throws IOException {
         if (alreadyStarted.getAndSet(true) == Boolean.FALSE) {
             delegate.start(custodialFiles, archiveOut);
         } else {
@@ -98,7 +100,7 @@ public class CallableStreamWriter<V> implements Callable<V>, StreamWriter {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() throws IOException {
         if (alreadyClosed.getAndSet(true) == Boolean.FALSE) {
             delegate.close();
         } else {

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/assembler/DebuggingArchiveOutputStream.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/assembler/DebuggingArchiveOutputStream.java
@@ -28,11 +28,11 @@ import org.apache.commons.compress.archivers.ArchiveOutputStream;
 /**
  * @author Elliot Metsger (emetsger@jhu.edu)
  */
-public class DebuggingArchiveOutputStream extends ArchiveOutputStream {
+public class DebuggingArchiveOutputStream extends ArchiveOutputStream<ArchiveEntry> {
 
-    private ArchiveOutputStream delegate;
+    private ArchiveOutputStream<ArchiveEntry> delegate;
 
-    public DebuggingArchiveOutputStream(ArchiveOutputStream delegate) {
+    public DebuggingArchiveOutputStream(ArchiveOutputStream<ArchiveEntry> delegate) {
         this.delegate = delegate;
     }
 
@@ -76,21 +76,6 @@ public class DebuggingArchiveOutputStream extends ArchiveOutputStream {
     @Override
     public void write(int b) throws IOException {
         delegate.write(b);
-    }
-
-//    @Override
-//    protected void count(int written) {
-//        delegate.count(written);
-//    }
-//
-//    @Override
-//    protected void count(long written) {
-//        delegate.count(written);
-//    }
-
-    @Override
-    public int getCount() {
-        return delegate.getCount();
     }
 
     @Override

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/assembler/DebuggingArchiveOutputStreamFactory.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/assembler/DebuggingArchiveOutputStreamFactory.java
@@ -18,6 +18,7 @@ package org.eclipse.pass.deposit.assembler;
 import java.io.OutputStream;
 import java.util.Map;
 
+import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.ArchiveOutputStream;
 
 /**
@@ -29,8 +30,10 @@ public class DebuggingArchiveOutputStreamFactory extends DefaultArchiveOutputStr
         super(packageOptions);
     }
 
+    @SuppressWarnings("unchecked")
     @Override
-    public ArchiveOutputStream newInstance(Map<String, Object> packageOptions, OutputStream toWrap) {
-        return new DebuggingArchiveOutputStream(super.newInstance(packageOptions, toWrap));
+    public <O extends ArchiveOutputStream<? extends ArchiveEntry>> O newInstance(Map<String, Object> packageOptions,
+                                                                                 OutputStream toWrap) {
+        return (O) new DebuggingArchiveOutputStream(super.newInstance(packageOptions, toWrap));
     }
 }

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/assembler/DefaultStreamWriterImpl.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/assembler/DefaultStreamWriterImpl.java
@@ -48,7 +48,7 @@ public class DefaultStreamWriterImpl implements StreamWriter {
     private final List<DepositFileResource> packageFiles;
     private final ResourceBuilderFactory rbf;
     private final DepositSubmission submission;
-    protected ArchiveOutputStream archiveOut;
+    protected ArchiveOutputStream<ArchiveEntry> archiveOut;
     protected Map<String, Object> packageOptions;
     protected PackageProvider packageProvider;
 
@@ -75,7 +75,8 @@ public class DefaultStreamWriterImpl implements StreamWriter {
     }
 
     @Override
-    public void start(List<DepositFileResource> custodialFiles, ArchiveOutputStream archiveOut) throws IOException {
+    public void start(List<DepositFileResource> custodialFiles, ArchiveOutputStream<ArchiveEntry> archiveOut)
+        throws IOException {
         this.archiveOut = archiveOut;
         List<PackageStream.Resource> assembledResources = new ArrayList<>();
 
@@ -118,7 +119,7 @@ public class DefaultStreamWriterImpl implements StreamWriter {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() throws IOException {
         archiveOut.close();
     }
 
@@ -215,7 +216,8 @@ public class DefaultStreamWriterImpl implements StreamWriter {
      * @param archiveEntryIn the bytes to be written
      * @throws IOException if there is an error encountered writing the bytes
      */
-    private void writeResource(ArchiveOutputStream archiveOut, ArchiveEntry archiveEntry, InputStream archiveEntryIn)
+    private void writeResource(ArchiveOutputStream<ArchiveEntry> archiveOut, ArchiveEntry archiveEntry,
+                               InputStream archiveEntryIn)
         throws IOException {
         archiveOut.putArchiveEntry(archiveEntry);
         int bytesWritten = IOUtils.copy(archiveEntryIn, archiveOut);

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/assembler/StreamWriter.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/assembler/StreamWriter.java
@@ -18,6 +18,7 @@ package org.eclipse.pass.deposit.assembler;
 import java.io.IOException;
 import java.util.List;
 
+import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.ArchiveOutputStream;
 import org.eclipse.pass.deposit.model.DepositSubmission;
 import org.springframework.core.io.Resource;
@@ -45,7 +46,8 @@ interface StreamWriter extends AutoCloseable {
      * @param archiveOut     the {@code OutputStream} to be written to
      * @throws IOException if there are any errors encountered initializing state
      */
-    void start(List<DepositFileResource> custodialFiles, ArchiveOutputStream archiveOut) throws IOException;
+    void start(List<DepositFileResource> custodialFiles, ArchiveOutputStream<ArchiveEntry> archiveOut)
+        throws IOException;
 
     /**
      * Writes the {@code Resource} and returns metadata describing the {@code custodialFile}.
@@ -70,4 +72,5 @@ interface StreamWriter extends AutoCloseable {
      */
     void finish(DepositSubmission submission, List<PackageStream.Resource> custodialResources) throws IOException;
 
+    void close() throws IOException;
 }

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/builder/DepositSubmissionMapper.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/builder/DepositSubmissionMapper.java
@@ -91,7 +91,7 @@ public class DepositSubmissionMapper {
         // Prepare for Metadata
         DepositMetadata metadata = new DepositMetadata();
         submission.setMetadata(metadata);
-        submission.setSubmissionMeta(new JsonParser().parse(submissionEntity.getMetadata()).getAsJsonObject());
+        submission.setSubmissionMeta(JsonParser.parseString(submissionEntity.getMetadata()).getAsJsonObject());
         DepositMetadata.Manuscript manuscript = new DepositMetadata.Manuscript();
         metadata.setManuscriptMetadata(manuscript);
         DepositMetadata.Article article = new DepositMetadata.Article();
@@ -328,7 +328,7 @@ public class DepositSubmissionMapper {
      * @param metadataStr
      */
     void processMetadata(DepositMetadata depositMetadata, String metadataStr) {
-        JsonObject json = new JsonParser().parse(metadataStr).getAsJsonObject();
+        JsonObject json = JsonParser.parseString(metadataStr).getAsJsonObject();
         processCommonMetadata(depositMetadata, json);
         processPmcMetadata(depositMetadata, json);
         processCrossrefMetadata(depositMetadata, json);

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/config/repository/SpringEnvironmentDeserializer.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/config/repository/SpringEnvironmentDeserializer.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.deser.std.StringDeserializer;
 import org.springframework.core.env.Environment;
 
 public class SpringEnvironmentDeserializer extends StringDeserializer {
+    private static final long serialVersionUID = 1L;
 
     private Environment env;
 

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/transport/TransportSession.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/transport/TransportSession.java
@@ -16,6 +16,7 @@
 
 package org.eclipse.pass.deposit.transport;
 
+import java.io.IOException;
 import java.util.Map;
 
 import org.eclipse.pass.deposit.assembler.PackageStream;
@@ -49,5 +50,7 @@ public interface TransportSession extends AutoCloseable {
     TransportResponse send(PackageStream packageStream, Map<String, String> metadata);
 
     boolean closed();
+
+    void close() throws IOException;
 
 }

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/transport/devnull/DevNullTransport.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/transport/devnull/DevNullTransport.java
@@ -15,6 +15,7 @@
  */
 package org.eclipse.pass.deposit.transport.devnull;
 
+import java.io.IOException;
 import java.net.URI;
 import java.util.Map;
 
@@ -120,7 +121,7 @@ public class DevNullTransport implements Transport {
         }
 
         @Override
-        public void close() throws Exception {
+        public void close() throws IOException {
             // no-op
         }
 

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/transport/fs/FilesystemTransport.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/transport/fs/FilesystemTransport.java
@@ -193,7 +193,7 @@ public class FilesystemTransport implements Transport {
         }
 
         @Override
-        public void close() throws Exception {
+        public void close() throws IOException {
             // no-op
         }
 

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/transport/ftp/FtpTransportSession.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/transport/ftp/FtpTransportSession.java
@@ -137,7 +137,7 @@ public class FtpTransportSession implements TransportSession {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() throws IOException {
         LOG.debug("Closing {}@{}...",
                   this.getClass().getSimpleName(), toHexString(identityHashCode(this)));
         if (transfer != null && !transfer.isDone()) {

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/transport/ftp/FtpUtil.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/transport/ftp/FtpUtil.java
@@ -94,7 +94,7 @@ public class FtpUtil {
      * @param clientCommand the command to perform
      * @throws RuntimeException if the command throw a checked exception
      */
-    static void performSilently(ExceptionThrowingVoidCommand clientCommand) {
+    static <T> void performSilently(ExceptionThrowingVoidCommand<T> clientCommand) {
         try {
             clientCommand.perform();
         } catch (Exception e) {

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/transport/inveniordm/InvenioRdmSession.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/transport/inveniordm/InvenioRdmSession.java
@@ -15,6 +15,7 @@
  */
 package org.eclipse.pass.deposit.transport.inveniordm;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
@@ -104,7 +105,7 @@ class InvenioRdmSession implements TransportSession {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() throws IOException {
         // no-op resources are closed with try-with-resources
     }
 

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/transport/sftp/SftpTransportSession.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/transport/sftp/SftpTransportSession.java
@@ -148,7 +148,7 @@ class SftpTransportSession implements TransportSession {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() throws IOException {
         // no-op resources are closed with try-with-resources
     }
 }

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/transport/sword2/InvalidCollectionUrl.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/transport/sword2/InvalidCollectionUrl.java
@@ -21,6 +21,7 @@ package org.eclipse.pass.deposit.transport.sword2;
  * For example, when the Collection URL is no present in the SWORD service document.
  */
 class InvalidCollectionUrl extends RuntimeException {
+    private static final long serialVersionUID = 1L;
 
     InvalidCollectionUrl(String message) {
         super(message);

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/transport/sword2/Sword2TransportSession.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/transport/sword2/Sword2TransportSession.java
@@ -192,7 +192,7 @@ public class Sword2TransportSession implements TransportSession {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() throws IOException {
         if (this.closed()) {
             return;
         }

--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/transport/sword2/SwordErrorMessageWrapper.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/transport/sword2/SwordErrorMessageWrapper.java
@@ -22,6 +22,7 @@ import org.swordapp.client.SWORDError;
  * Wraps a {@link SWORDError} for the purpose of providing a non-null response to {@link Throwable#getMessage()}.
  */
 class SwordErrorMessageWrapper extends Exception {
+    private static final long serialVersionUID = 1L;
 
     private SWORDError wrapped;
 

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/DepositMessagingTestUtil.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/DepositMessagingTestUtil.java
@@ -181,6 +181,7 @@ public class DepositMessagingTestUtil {
      * @return
      */
     @SafeVarargs
+    @SuppressWarnings( "varargs" )
     public static <T extends Enum<T>> T random(Class<T> clazz, T... excludes) {
         Predicate<String> excludesPredicate =
             (statusName) -> Stream.of(excludes).anyMatch(toExclude -> toExclude.name().equals(statusName));

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/assembler/AssemblerSupportTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/assembler/AssemblerSupportTest.java
@@ -100,7 +100,10 @@ public class AssemblerSupportTest {
     public void testResetStreamWhenMarkSupported() throws IOException {
         Detector spy = spy(detector);
         CharSequence cs = "Hello, world!";
-        CharSequenceInputStream markSupportedIn = new CharSequenceInputStream(cs, UTF_8);
+        CharSequenceInputStream markSupportedIn = CharSequenceInputStream.builder()
+            .setCharSequence(cs)
+            .setCharset(UTF_8)
+            .get();
 
         MediaType result = AssemblerSupport.detectMediaType(markSupportedIn, spy);
 

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/assembler/PackageVerifier.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/assembler/PackageVerifier.java
@@ -92,8 +92,10 @@ public interface PackageVerifier {
      * @param packageFileMapper maps the custodial file in the package back to the DepositFile in the
      *                          submission
      */
+    // TODO Replace deprecated DirectoryWalker
+    @SuppressWarnings("deprecation")
     default void verifyCustodialFiles(DepositSubmission submission, File packageDir, FileFilter custodialFilter,
-                                      BiFunction<File, File, DepositFile> packageFileMapper) throws Exception {
+                                      BiFunction<File, File, DepositFile> packageFileMapper) {
 
         List<File> supplementalFiles = new ArrayList<>();
         List<File> custodialFiles = new ArrayList<>();
@@ -108,7 +110,7 @@ public interface PackageVerifier {
             }
 
             @Override
-            protected void handleFile(File file, int depth, Collection ignored) throws IOException {
+            protected void handleFile(File file, int depth, Collection<File> ignored) {
                 if (custodialFilter.accept(file)) {
                     custodialFiles.add(file);
                     DepositFile depositFile = packageFileMapper.andThen(df -> {

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/provider/nihms/NihmsAssemblerIT.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/provider/nihms/NihmsAssemblerIT.java
@@ -187,12 +187,13 @@ public class NihmsAssemblerIT extends AbstractAssemblerIT {
     @Test
     public void testPackageManifest() throws Exception {
         int lineCount = 0;
-        LineIterator lines = FileUtils.lineIterator(manifest);
         List<String> entries = new ArrayList<>();
-        while (lines.hasNext()) {
-            String line = lines.nextLine();
-            entries.add(line);
-            new ManifestLine(manifest, line, lineCount++).assertAll();
+        try (LineIterator lines = FileUtils.lineIterator(manifest)) {
+            while (lines.hasNext()) {
+                String line = lines.next();
+                entries.add(line);
+                new ManifestLine(manifest, line, lineCount++).assertAll();
+            }
         }
         assertEquals(submission.getFiles().size() + 1, lineCount);
 

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/AbstractDepositIT.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/AbstractDepositIT.java
@@ -100,6 +100,7 @@ public abstract class AbstractDepositIT extends AbstractSubmissionIT {
 
     }
 
+    @SuppressWarnings("unchecked")
     protected void mockSword() throws Exception {
         ServiceDocument mockServiceDoc = mock(ServiceDocument.class);
         SWORDWorkspace mockSwordWorkspace = mock(SWORDWorkspace.class);
@@ -126,11 +127,11 @@ public abstract class AbstractDepositIT extends AbstractSubmissionIT {
         when(mockResource.getInputStream()).thenReturn(mock(InputStream.class));
         doReturn(mockResource).when(resourceResolver).resolve(any(), any());
 
-        Document mockParserDoc = mock(Document.class);
+        Document<Feed> mockParserDoc = (Document<Feed>) mock(Document.class);
         when(mockParserDoc.getRoot()).thenReturn(mock(Feed.class));
         Category category = mock(Category.class);
         when(category.getTerm()).thenReturn("http://dspace.org/state/archived");
-        when(((Feed) mockParserDoc.getRoot()).getCategories(any())).thenReturn(List.of(category));
+        when((mockParserDoc.getRoot()).getCategories(any())).thenReturn(List.of(category));
         doReturn(mockParserDoc).when(mockParser).parse(any(InputStream.class));
     }
 

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/util/DepositTestUtil.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/util/DepositTestUtil.java
@@ -72,6 +72,7 @@ public class DepositTestUtil {
      * @return the directory that the package file was extracted to
      * @throws IOException if an error occurs opening the file or extracting its contents
      */
+    @SuppressWarnings("unchecked")
     public static File openArchive(File packageFile, Archive.OPTS archive, Compression.OPTS compression)
         throws IOException {
         File tmpDir = tmpDir();
@@ -79,15 +80,15 @@ public class DepositTestUtil {
         LOG.debug(">>>> Extracting {} to {} ...", packageFile, tmpDir);
 
         try (InputStream packageFileIn = Files.newInputStream(packageFile.toPath())) {
-            ArchiveInputStream zipIn = null;
+            ArchiveInputStream<?> zipIn;
             if (archive.equals(Archive.OPTS.TAR)) {
-                if (compression.equals(Compression.OPTS.GZIP)) {
-                    zipIn = new TarArchiveInputStream(new GzipCompressorInputStream(packageFileIn));
-                } else {
-                    zipIn = new TarArchiveInputStream(packageFileIn);
-                }
+                zipIn = compression.equals(Compression.OPTS.GZIP)
+                    ? new TarArchiveInputStream(new GzipCompressorInputStream(packageFileIn))
+                    : new TarArchiveInputStream(packageFileIn);
             } else if (archive.equals(Archive.OPTS.ZIP)) {
                 zipIn = new ZipArchiveInputStream(packageFileIn);
+            } else {
+                throw new IllegalArgumentException("Unsupported archive type: " + archive);
             }
 
             ArchiveEntry entry;

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/util/SubmissionTestUtil.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/util/SubmissionTestUtil.java
@@ -79,6 +79,7 @@ public class SubmissionTestUtil {
         passClient.updateObject(submission);
     }
 
+    @SuppressWarnings("unchecked")
     public Submission createSubmissionFromJson(InputStream is, List<PassEntity> entities) {
         Submission submission = null;
         try {

--- a/pass-deposit-services/deposit-util/src/main/java/org/eclipse/deposit/util/spring/EncodingClassPathResource.java
+++ b/pass-deposit-services/deposit-util/src/main/java/org/eclipse/deposit/util/spring/EncodingClassPathResource.java
@@ -25,7 +25,6 @@ import java.net.URLEncoder;
 
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
-import org.springframework.lang.Nullable;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
 
@@ -47,17 +46,15 @@ public class EncodingClassPathResource extends ClassPathResource {
 
     private String decodedPath;
 
-    @Nullable
     private ClassLoader classLoader;
 
-    @Nullable
     private Class<?> clazz;
 
     public EncodingClassPathResource(String encodedPath) {
         this(encodedPath, (ClassLoader) null);
     }
 
-    public EncodingClassPathResource(String encodedPath, @Nullable ClassLoader classLoader) {
+    public EncodingClassPathResource(String encodedPath, ClassLoader classLoader) {
         super(encodedPath, classLoader);
         this.classLoader = (classLoader != null ? classLoader : ClassUtils.getDefaultClassLoader());
         this.encodedPath = StringUtils.cleanPath(encodedPath);
@@ -67,7 +64,7 @@ public class EncodingClassPathResource extends ClassPathResource {
         this.decodedPath = decodePath(this.encodedPath);
     }
 
-    public EncodingClassPathResource(String encodedPath, @Nullable Class<?> clazz) {
+    public EncodingClassPathResource(String encodedPath, Class<?> clazz) {
         super(encodedPath, clazz);
         this.clazz = clazz;
         this.encodedPath = StringUtils.cleanPath(encodedPath);
@@ -83,7 +80,6 @@ public class EncodingClassPathResource extends ClassPathResource {
      *
      * @return the URL which
      */
-    @Nullable
     @Override
     protected URL resolveURL() {
         if (this.clazz != null) {
@@ -118,7 +114,6 @@ public class EncodingClassPathResource extends ClassPathResource {
                 new EncodingClassPathResource(pathToUse, this.classLoader));
     }
 
-    @Nullable
     @Override
     public String getFilename() {
         return StringUtils.getFilename(this.encodedPath);

--- a/pass-deposit-services/deposit-util/src/test/java/org/eclipse/deposit/util/spring/EncodingClassPathResourceTest.java
+++ b/pass-deposit-services/deposit-util/src/test/java/org/eclipse/deposit/util/spring/EncodingClassPathResourceTest.java
@@ -24,7 +24,7 @@ import java.security.MessageDigest;
 
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.io.input.MessageDigestCalculatingInputStream;
+import org.apache.commons.io.input.MessageDigestInputStream;
 import org.apache.commons.io.output.NullOutputStream;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -218,8 +218,10 @@ public class EncodingClassPathResourceTest {
                                        String expectedUrlPath, String expectedChecksum) throws Exception {
         try (InputStream in = underTest.getInputStream()) {
             assertNotNull(in);
-            try (MessageDigestCalculatingInputStream digestIn = new MessageDigestCalculatingInputStream(in, "SHA-1")) {
-                IOUtils.copy(digestIn, new NullOutputStream());
+            MessageDigestInputStream.Builder builder = MessageDigestInputStream.builder()
+                .setInputStream(in).setMessageDigest("SHA-1");
+            try (MessageDigestInputStream digestIn = builder.get()) {
+                IOUtils.copy(digestIn, NullOutputStream.INSTANCE);
                 MessageDigest md = digestIn.getMessageDigest();
                 assertEquals(expectedChecksum, Hex.encodeHexString(md.digest()));
             }

--- a/pass-deposit-services/pom.xml
+++ b/pass-deposit-services/pom.xml
@@ -322,6 +322,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <doclint>all,-missing</doclint>
+        </configuration>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
This PR:

- Fixes all compile warnings.
- Disables javadoc "missing message" warning.  I'll create a separate issue to address the missing javadoc comments.