### PR TITLE
Failed deposit retry bug fix

### DIFF
--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/FailedDepositRetry.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/service/FailedDepositRetry.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
+import org.eclipse.pass.deposit.DepositServiceErrorHandler;
 import org.eclipse.pass.deposit.builder.DepositSubmissionModelBuilder;
 import org.eclipse.pass.deposit.model.DepositFile;
 import org.eclipse.pass.deposit.model.DepositSubmission;
@@ -48,14 +49,17 @@ public class FailedDepositRetry {
     private final DepositSubmissionModelBuilder depositSubmissionModelBuilder;
     private final DepositTaskHelper depositTaskHelper;
     private final Registry<Packager> packagerRegistry;
+    private final DepositServiceErrorHandler depositServiceErrorHandler;
 
     public FailedDepositRetry(PassClient passClient, DepositTaskHelper depositTaskHelper,
                               Registry<Packager> packagerRegistry,
-                              DepositSubmissionModelBuilder depositSubmissionModelBuilder) {
+                              DepositSubmissionModelBuilder depositSubmissionModelBuilder,
+                              DepositServiceErrorHandler depositServiceErrorHandler) {
         this.passClient = passClient;
         this.depositTaskHelper = depositTaskHelper;
         this.packagerRegistry = packagerRegistry;
         this.depositSubmissionModelBuilder = depositSubmissionModelBuilder;
+        this.depositServiceErrorHandler = depositServiceErrorHandler;
     }
 
     public void retryFailedDeposit(Deposit failedDeposit) {
@@ -94,6 +98,7 @@ public class FailedDepositRetry {
 
         } catch (Exception e) {
             LOG.warn(FAILED_TO_PROCESS, failedDeposit.getId(), e.getMessage(), e);
+            depositServiceErrorHandler.handleError(e);
         }
     }
 

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/util/SubmissionTestUtil.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/util/SubmissionTestUtil.java
@@ -66,7 +66,9 @@ public class SubmissionTestUtil {
         resultDeposits.getObjects().forEach(deposit -> {
             try {
                 passClient.deleteObject(deposit);
-                passClient.deleteObject(deposit.getRepositoryCopy());
+                if (Objects.nonNull(deposit.getRepositoryCopy())) {
+                    passClient.deleteObject(deposit.getRepositoryCopy());
+                }
             } catch (Exception ex) {
                 throw new RuntimeException(ex);
             }
@@ -114,13 +116,8 @@ public class SubmissionTestUtil {
             return submission;
 
         } catch (Exception e) {
-            // TODO re-throw?
-            System.out.println("Error building Submission from stream.");
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
-
-        entities.clear();
-        return null;
     }
 
     private Submission createEntitiesInPass(List<PassEntity> entities) {
@@ -132,8 +129,8 @@ public class SubmissionTestUtil {
             }
         });
 
-        return entities.stream().filter(entity -> entity instanceof Submission)
-            .map(passEntity -> (Submission) passEntity)
+        return entities.stream().filter(Submission.class::isInstance)
+            .map(Submission.class::cast)
             .findFirst()
             .orElseThrow(() -> new RuntimeException("Submission not found"));
     }


### PR DESCRIPTION
This PR fixes two bugs:

- There was a bug where if a failed deposit is retried, and the retry fails, the Deposit status is saved as Submitted instead of Failed.  This is fixed.
- There is a scenario where a Deposit from the deployment tests may not have a RepositoryCopy.  This was causing a NPE when deleting deployment test data.  This is fixed.

There are few other minor cleanup changes made too.