### PR TITLE
Clean up of dependencies with convergence issues

### DIFF
--- a/pass-data-client/pom.xml
+++ b/pass-data-client/pom.xml
@@ -24,6 +24,24 @@
     <maven-model.version>3.9.9</maven-model.version>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <!-- The following are transitive deps with convergence issues. -->
+      <!-- These should all be checked whenever deps are upgraded. -->
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>${logback.version}</version>
+      </dependency>
+      <!-- End of transitive deps with convergence issues. -->
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>com.markomilos.jsonapi</groupId>
@@ -40,13 +58,11 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
     </dependency>
 
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>${logback.version}</version>
     </dependency>
 
     <dependency>
@@ -126,13 +142,7 @@
             </goals>
             <configuration>
               <rules>
-                <dependencyConvergence>
-                  <excludes>
-                    <exclude>com.squareup.okio:okio:*</exclude>
-                    <exclude>org.jetbrains.kotlin:kotlin-stdlib-jdk8:*</exclude>
-                    <exclude>org.slf4j:slf4j-api:*</exclude>
-                  </excludes>
-                </dependencyConvergence>
+                <dependencyConvergence/>
               </rules>
             </configuration>
           </execution>

--- a/pass-deposit-services/pom.xml
+++ b/pass-deposit-services/pom.xml
@@ -201,9 +201,30 @@
         <artifactId>joda-time</artifactId>
         <version>${joda-time.version}</version>
       </dependency>
-
+      <!-- The following are transitive deps with convergence issues. -->
+      <!-- These should all be checked whenever deps are upgraded. -->
+      <dependency>
+        <groupId>org.ow2.asm</groupId>
+        <artifactId>asm</artifactId>
+        <version>9.6</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jsoup</groupId>
+        <artifactId>jsoup</artifactId>
+        <version>1.18.1</version>
+      </dependency>
+      <dependency>
+        <groupId>xerces</groupId>
+        <artifactId>xercesImpl</artifactId>
+        <version>2.12.2</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.woodstox</groupId>
+        <artifactId>wstx-asl</artifactId>
+        <version>3.2.9</version>
+      </dependency>
+      <!-- End of transitive deps with convergence issues. -->
     </dependencies>
-
   </dependencyManagement>
 
   <build>
@@ -307,18 +328,7 @@
             </goals>
             <configuration>
               <rules>
-                <dependencyConvergence>
-                  <excludes>
-                    <!-- Transitive deps from sword2-client-->
-                    <exclude>xerces:xercesImpl:</exclude>
-                    <exclude>org.codehaus.woodstox:wstx-asl:</exclude>
-                    <exclude>org.jsoup:jsoup:</exclude>
-                    <!-- Transitive deps from pass-data-client -->
-                    <exclude>com.squareup.okio:okio:</exclude>
-                    <exclude>org.ow2.asm:asm:</exclude>
-                    <exclude>com.google.errorprone:error_prone_annotations:</exclude>
-                  </excludes>
-                </dependencyConvergence>
+                <dependencyConvergence/>
               </rules>
             </configuration>
           </execution>

--- a/pass-grant-loader/pom.xml
+++ b/pass-grant-loader/pom.xml
@@ -235,14 +235,7 @@
               </goals>
               <configuration>
                 <rules>
-                  <dependencyConvergence>
-                    <excludes>
-                      <exclude>com.squareup.okio:okio:*</exclude>
-                      <exclude>org.jetbrains.kotlin:kotlin-stdlib-jdk8:*</exclude>
-                      <!-- TODO try removing, strange conflict with pass-data-client -->
-                      <exclude>org.apache.commons:commons-lang3:*</exclude>
-                    </excludes>
-                  </dependencyConvergence>
+                  <dependencyConvergence/>
                 </rules>
               </configuration>
             </execution>

--- a/pass-journal-loader/pom.xml
+++ b/pass-journal-loader/pom.xml
@@ -94,12 +94,7 @@
               </goals>
               <configuration>
                 <rules>
-                  <dependencyConvergence>
-                    <excludes>
-                      <exclude>com.squareup.okio:okio:</exclude>
-                      <exclude>org.jetbrains.kotlin:kotlin-stdlib*:</exclude>
-                    </excludes>
-                  </dependencyConvergence>
+                  <dependencyConvergence/>
                 </rules>
               </configuration>
             </execution>

--- a/pass-nihms-loader/nihms-data-harvest/pom.xml
+++ b/pass-nihms-loader/nihms-data-harvest/pom.xml
@@ -46,7 +46,6 @@
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
-      <version>${joda-time.version}</version>
     </dependency>
 
     <dependency>

--- a/pass-nihms-loader/pom.xml
+++ b/pass-nihms-loader/pom.xml
@@ -68,6 +68,12 @@
                 <version>${okhttp.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>joda-time</groupId>
+                <artifactId>joda-time</artifactId>
+                <version>${joda-time.version}</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 
@@ -112,16 +118,7 @@
                         </goals>
                         <configuration>
                             <rules>
-                                <dependencyConvergence>
-                                    <excludes>
-                                        <!-- Transitive deps -->
-                                        <exclude>commons-io:commons-io:</exclude>
-                                        <exclude>com.squareup.okio:okio:</exclude>
-                                        <exclude>org.jetbrains.kotlin:kotlin-stdlib*:</exclude>
-                                        <!-- Omitted from handy uri transitive dep -->
-                                        <exclude>joda-time:joda-time:2.10.2</exclude>
-                                    </excludes>
-                                </dependencyConvergence>
+                                <dependencyConvergence/>
                             </rules>
                         </configuration>
                     </execution>

--- a/pass-notification-service/pom.xml
+++ b/pass-notification-service/pom.xml
@@ -279,25 +279,7 @@
                         </goals>
                         <configuration>
                             <rules>
-                                <dependencyConvergence>
-                                    <excludes>
-                                        <!-- These are all transitive dependencies  -->
-                                        <exclude>io.netty::</exclude>
-                                        <exclude>jakarta.xml.bind:jakarta.xml.bind-api:</exclude>
-                                        <exclude>org.jetbrains.kotlin:kotlin-stdlib:</exclude>
-                                        <exclude>org.jetbrains.kotlin:kotlin-stdlib-jdk8:</exclude>
-                                        <exclude>org.junit.jupiter:junit-jupiter-api:</exclude>
-                                        <exclude>org.hamcrest:hamcrest:</exclude>
-                                        <exclude>net.minidev:json-smart:</exclude>
-                                        <exclude>commons-codec:commons-codec:</exclude>
-                                        <exclude>com.squareup.okio:okio:</exclude>
-                                        <exclude>net.bytebuddy:byte-buddy:</exclude>
-                                        <!-- These are all transitive dependencies, but 2.0.7 is closest -->
-                                        <exclude>org.slf4j:slf4j-api:</exclude>
-                                        <!-- TODO try removing, strange conflict with pass-data-client -->
-                                        <exclude>org.apache.commons:commons-lang3:*</exclude>
-                                    </excludes>
-                                </dependencyConvergence>
+                                <dependencyConvergence/>
                             </rules>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -74,10 +74,34 @@
   <properties>
     <maven-dependency-plugin.version>3.8.1</maven-dependency-plugin.version>
     <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
+    <kotlin.version>1.9.25</kotlin.version>
   </properties>
 
   <dependencyManagement>
     <dependencies>
+      <!-- The following are transitive deps with convergence issues. -->
+      <!-- These should all be checked whenever deps are upgraded. -->
+      <dependency>
+        <groupId>com.squareup.okio</groupId>
+        <artifactId>okio</artifactId>
+        <version>3.6.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib</artifactId>
+        <version>${kotlin.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib-jdk8</artifactId>
+        <version>${kotlin.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib-common</artifactId>
+        <version>${kotlin.version}</version>
+      </dependency>
+      <!-- End of transitive deps with convergence issues. -->
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
This PR declares all the dependencies previously excluded from dependency convergence, so that the version used by the application is predictable. The highest version of each dependency was declared.