### PR TITLE
Fix notification email error

### DIFF
--- a/pass-notification-service/pom.xml
+++ b/pass-notification-service/pom.xml
@@ -97,6 +97,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.eclipse.angus</groupId>
+            <artifactId>jakarta.mail</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-aop</artifactId>
         </dependency>
@@ -162,12 +167,6 @@
             <groupId>com.icegreen</groupId>
             <artifactId>greenmail-junit5</artifactId>
             <version>${greenmail-junit5.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.eclipse.angus</groupId>
-            <artifactId>jakarta.mail</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -328,6 +327,10 @@
                                 <!-- Used by ITs via classpath -->
                                 <ignoredUnusedDeclaredDependency>org.eclipse.pass:pass-core-test-config::</ignoredUnusedDeclaredDependency>
                             </ignoredUnusedDeclaredDependencies>
+                            <ignoredNonTestScopedDependencies>
+                                <!-- org.eclipse.angus:jakarta.mail is required for runtime javamail impl -->
+                                <ignoredNonTestScopedDependency>org.eclipse.angus:jakarta.mail:</ignoredNonTestScopedDependency>
+                            </ignoredNonTestScopedDependencies>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Makes angus jakarta.mail dependency compile scope so javamail implementation is in classpath.