### PR TITLE
Upgrade dependencies

### DIFF
--- a/pass-data-client/pom.xml
+++ b/pass-data-client/pom.xml
@@ -16,7 +16,7 @@
     <moshi.version>4.12.0</moshi.version>
     <jsonapi-adapters.version>1.1.0</jsonapi-adapters.version>
     <slf4j.version>2.0.16</slf4j.version>
-    <logback.version>1.5.11</logback.version>
+    <logback.version>1.5.16</logback.version>
     <commons-lang3.version>3.14.0</commons-lang3.version>
     <junit.jupiter.version>5.10.5</junit.jupiter.version>
     <mockito.version>5.11.0</mockito.version>

--- a/pass-deposit-services/pom.xml
+++ b/pass-deposit-services/pom.xml
@@ -35,7 +35,7 @@
   </modules>
 
   <properties>
-    <spring-boot-maven-plugin.version>3.3.5</spring-boot-maven-plugin.version>
+    <spring-boot-maven-plugin.version>3.4.2</spring-boot-maven-plugin.version>
     <awsspring.version>3.2.1</awsspring.version>
     <commons-compress.version>1.27.1</commons-compress.version>
     <commons-io.version>2.17.0</commons-io.version>
@@ -81,6 +81,12 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-artemis</artifactId>
         <version>${spring-boot-maven-plugin.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-jakarta-client</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
@@ -237,6 +243,21 @@
         <version>3.2.9</version>
       </dependency>
       <!-- End of transitive deps with convergence issues. -->
+
+      <!-- The following deps were declared to resolve CVEs from transitive deps. -->
+      <!-- These should all be checked whenever deps are upgraded. Should be removed if possible once parent -->
+      <!-- dep updates with fixed version. -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler</artifactId>
+        <version>4.1.118.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-common</artifactId>
+        <version>4.1.118.Final</version>
+      </dependency>
+      <!-- End of transitive deps with CVE issues. -->
     </dependencies>
   </dependencyManagement>
 

--- a/pass-grant-loader/pom.xml
+++ b/pass-grant-loader/pom.xml
@@ -28,7 +28,7 @@
   <description>PASS Grant Data Loader</description>
 
   <properties>
-    <spring-boot-maven-plugin.version>3.3.5</spring-boot-maven-plugin.version>
+    <spring-boot-maven-plugin.version>3.4.2</spring-boot-maven-plugin.version>
     <awsspring.version>3.2.1</awsspring.version>
     <args4j.version>2.37</args4j.version>
     <commons.csv.version>1.12.0</commons.csv.version>
@@ -52,6 +52,21 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+
+      <!-- The following deps were declared to resolve CVEs from transitive deps. -->
+      <!-- These should all be checked whenever deps are upgraded. Should be removed if possible once parent -->
+      <!-- dep updates with fixed version. -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler</artifactId>
+        <version>4.1.118.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-common</artifactId>
+        <version>4.1.118.Final</version>
+      </dependency>
+      <!-- End of transitive deps with CVE issues. -->
     </dependencies>
   </dependencyManagement>
 

--- a/pass-journal-loader/pom.xml
+++ b/pass-journal-loader/pom.xml
@@ -20,7 +20,7 @@
     <commons.csv.version>1.12.0</commons.csv.version>
     <commons-lang.version>3.14.0</commons-lang.version>
     <slf4j.version>2.0.16</slf4j.version>
-    <logback.version>1.5.11</logback.version>
+    <logback.version>1.5.16</logback.version>
     <junit.jupiter.version>5.10.5</junit.jupiter.version>
     <mockito.version>5.11.0</mockito.version>
   </properties>

--- a/pass-nihms-loader/pom.xml
+++ b/pass-nihms-loader/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <!-- Properties for dependency versions -->
-        <spring-boot-maven-plugin.version>3.3.5</spring-boot-maven-plugin.version>
+        <spring-boot-maven-plugin.version>3.4.2</spring-boot-maven-plugin.version>
         <awsspring.version>3.2.1</awsspring.version>
         <org-json.version>20240303</org-json.version>
         <commons.csv.version>1.12.0</commons.csv.version>
@@ -73,6 +73,21 @@
                 <artifactId>joda-time</artifactId>
                 <version>${joda-time.version}</version>
             </dependency>
+
+            <!-- The following deps were declared to resolve CVEs from transitive deps. -->
+            <!-- These should all be checked whenever deps are upgraded. Should be removed if possible once parent -->
+            <!-- dep updates with fixed version. -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-handler</artifactId>
+                <version>4.1.118.Final</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-common</artifactId>
+                <version>4.1.118.Final</version>
+            </dependency>
+            <!-- End of transitive deps with CVE issues. -->
 
         </dependencies>
     </dependencyManagement>

--- a/pass-notification-service/pom.xml
+++ b/pass-notification-service/pom.xml
@@ -28,7 +28,7 @@
 
     <properties>
         <!-- Properties for dependency versions -->
-        <spring-boot-maven-plugin.version>3.3.5</spring-boot-maven-plugin.version>
+        <spring-boot-maven-plugin.version>3.4.2</spring-boot-maven-plugin.version>
         <awsspring.version>3.2.1</awsspring.version>
         <commons-io.version>2.17.0</commons-io.version>
         <handlebars.version>4.4.0</handlebars.version>
@@ -55,6 +55,21 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+
+            <!-- The following deps were declared to resolve CVEs from transitive deps. -->
+            <!-- These should all be checked whenever deps are upgraded. Should be removed if possible once parent -->
+            <!-- dep updates with fixed version. -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-handler</artifactId>
+                <version>4.1.118.Final</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-common</artifactId>
+                <version>4.1.118.Final</version>
+            </dependency>
+            <!-- End of transitive deps with CVE issues. -->
         </dependencies>
     </dependencyManagement>
 
@@ -89,6 +104,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-artemis</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.activemq</groupId>
+                    <artifactId>artemis-jakarta-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Upgrade dependencies to resolve Security Vulnerabilities identified in https://github.com/eclipse-pass/main/issues/1109.

The only vulnerabilities remaining are in deposit-services for transitive dependencies from `org.swordapp:sword2-client` which is slated for removal. 