### PR TITLE
Setup SonarQube Code Coverage Analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,5 +7,4 @@ jobs:
     uses: eclipse-pass/main/.github/workflows/ci.yml@1089-test-ci-yml-NO-MERGE-DELETE-AFTER-TESTING
     with:
       run_acceptance_tests: false
-      project-key: 'eclipse-pass_pass-support'
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,6 @@ on: [pull_request, workflow_dispatch]
 jobs:
   test:
     name: "Run Unit & Integration Tests"
-    uses: eclipse-pass/main/.github/workflows/ci.yml@main
+    uses: eclipse-pass/main/.github/workflows/ci.yml@1089-setup-jacoco-sonarqube-integration
     with:
       run_acceptance_tests: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,5 +5,6 @@ jobs:
   test:
     name: "Run Unit & Integration Tests"
     uses: eclipse-pass/main/.github/workflows/ci.yml@1089-setup-jacoco-sonarqube-integration
+    secrets: inherit
     with:
       run_acceptance_tests: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
   test:
     name: "Run Unit & Integration Tests"
-    uses: eclipse-pass/main/.github/workflows/ci.yml@1089-setup-jacoco-sonarqube-integration
+    uses: eclipse-pass/main/.github/workflows/ci.yml@main
     secrets: inherit
     with:
       run_acceptance_tests: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,4 +7,3 @@ jobs:
     uses: eclipse-pass/main/.github/workflows/ci.yml@main
     with:
       run_acceptance_tests: false
-    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on: [pull_request, workflow_dispatch]
 jobs:
   test:
     name: "Run Unit & Integration Tests"
-    uses: eclipse-pass/main/.github/workflows/ci.yml@main
+    uses: eclipse-pass/main/.github/workflows/ci.yml@1089-test-ci-yml-NO-MERGE-DELETE-AFTER-TESTING
     with:
       run_acceptance_tests: false
+      project-key: 'eclipse-pass_pass-support'
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
   test:
     name: "Run Unit & Integration Tests"
-    uses: eclipse-pass/main/.github/workflows/ci.yml@1089-test-ci-yml-NO-MERGE-DELETE-AFTER-TESTING
+    uses: eclipse-pass/main/.github/workflows/ci.yml@main
     with:
       run_acceptance_tests: false
     secrets: inherit

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   snapshot:
     if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
-    uses: eclipse-pass/main/.github/workflows/snapshot.yml@1089-test-ci-yml-NO-MERGE-DELETE-AFTER-TESTING
+    uses: eclipse-pass/main/.github/workflows/snapshot.yml@main
     secrets: inherit
     with:
       images: ghcr.io/eclipse-pass/deposit-services-core ghcr.io/eclipse-pass/pass-notification-service ghcr.io/eclipse-pass/jhu-grant-loader ghcr.io/eclipse-pass/pass-journal-loader ghcr.io/eclipse-pass/pass-nihms-loader ghcr.io/eclipse-pass/pass-nihms-token-refresh

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   snapshot:
     if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
-    uses: eclipse-pass/main/.github/workflows/snapshot.yml@main
+    uses: eclipse-pass/main/.github/workflows/snapshot.yml@1089-test-ci-yml-NO-MERGE-DELETE-AFTER-TESTING
     secrets: inherit
     with:
       images: ghcr.io/eclipse-pass/deposit-services-core ghcr.io/eclipse-pass/pass-notification-service ghcr.io/eclipse-pass/jhu-grant-loader ghcr.io/eclipse-pass/pass-journal-loader ghcr.io/eclipse-pass/pass-nihms-loader ghcr.io/eclipse-pass/pass-nihms-token-refresh

--- a/pass-nihms-loader/nihms-data-transform-load/src/main/java/org/eclipse/pass/loader/nihms/NihmsPublicationToSubmission.java
+++ b/pass-nihms-loader/nihms-data-transform-load/src/main/java/org/eclipse/pass/loader/nihms/NihmsPublicationToSubmission.java
@@ -148,6 +148,9 @@ public class NihmsPublicationToSubmission {
                         deposit.setDepositStatus(DepositStatus.ACCEPTED);
                         break;
                     case IN_PROCESS:
+                        //TODO: testing SQ
+                        deposit.setDepositStatus(DepositStatus.REJECTED);
+                        //TODO: remove when done
                         deposit.setDepositStatus(DepositStatus.SUBMITTED);
                         break;
                     case NON_COMPLIANT:

--- a/pass-nihms-loader/nihms-data-transform-load/src/main/java/org/eclipse/pass/loader/nihms/NihmsPublicationToSubmission.java
+++ b/pass-nihms-loader/nihms-data-transform-load/src/main/java/org/eclipse/pass/loader/nihms/NihmsPublicationToSubmission.java
@@ -100,6 +100,9 @@ public class NihmsPublicationToSubmission {
 
         //this stage will be all about building up the DTO
         SubmissionDTO submissionDTO = new SubmissionDTO();
+        //todo: TEST SONARQUBE COVERAGE
+        submissionDTO.setGrantId("1");
+        //todo: END TEST
         submissionDTO.setGrantId(grant.getId());
 
         Publication publication = retrieveOrCreatePublication(pub, submissionDTO);

--- a/pass-nihms-loader/nihms-data-transform-load/src/main/java/org/eclipse/pass/loader/nihms/NihmsPublicationToSubmission.java
+++ b/pass-nihms-loader/nihms-data-transform-load/src/main/java/org/eclipse/pass/loader/nihms/NihmsPublicationToSubmission.java
@@ -100,9 +100,6 @@ public class NihmsPublicationToSubmission {
 
         //this stage will be all about building up the DTO
         SubmissionDTO submissionDTO = new SubmissionDTO();
-        //todo: TEST SONARQUBE COVERAGE
-        submissionDTO.setGrantId("1");
-        //todo: END TEST
         submissionDTO.setGrantId(grant.getId());
 
         Publication publication = retrieveOrCreatePublication(pub, submissionDTO);
@@ -148,9 +145,6 @@ public class NihmsPublicationToSubmission {
                         deposit.setDepositStatus(DepositStatus.ACCEPTED);
                         break;
                     case IN_PROCESS:
-                        //TODO: testing SQ
-                        deposit.setDepositStatus(DepositStatus.REJECTED);
-                        //TODO: remove when done
                         deposit.setDepositStatus(DepositStatus.SUBMITTED);
                         break;
                     case NON_COMPLIANT:

--- a/pom.xml
+++ b/pom.xml
@@ -75,10 +75,7 @@
     <maven-dependency-plugin.version>3.8.1</maven-dependency-plugin.version>
     <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
     <kotlin.version>1.9.25</kotlin.version>
-    <sonar-maven-plugin.version>5.0.0.4389</sonar-maven-plugin.version>
     <sonar.projectName>pass-support</sonar.projectName>
-    <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-    <sonar.organization>eclipse-pass</sonar.organization>
     <sonar.projectKey>eclipse-pass_pass-support</sonar.projectKey>
     <sonar.coverage.jacoco.xmlReportPaths>${maven.multiModuleProjectDirectory}/jacoco-aggregate-report-pass-support/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
   </properties>
@@ -157,7 +154,6 @@
       <plugin>
         <groupId>org.sonarsource.scanner.maven</groupId>
         <artifactId>sonar-maven-plugin</artifactId>
-        <version>${sonar-maven-plugin.version}</version>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
     <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
     <kotlin.version>1.9.25</kotlin.version>
     <sonar-maven-plugin.version>5.0.0.4389</sonar-maven-plugin.version>
+    <sonar.projectName>pass-support</sonar.projectName>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <sonar.organization>eclipse-pass</sonar.organization>
     <sonar.projectKey>eclipse-pass_pass-support</sonar.projectKey>

--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,12 @@
         <artifactId>maven-dependency-plugin</artifactId>
         <version>${maven-dependency-plugin.version}</version>
       </plugin>
+
+      <plugin>
+        <groupId>org.sonarsource.scanner.maven</groupId>
+        <artifactId>sonar-maven-plugin</artifactId>
+        <version>${sonar-maven-plugin.version}</version>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,11 @@
     <maven-dependency-plugin.version>3.8.1</maven-dependency-plugin.version>
     <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
     <kotlin.version>1.9.25</kotlin.version>
+    <sonar-maven-plugin.version>5.0.0.4389</sonar-maven-plugin.version>
+    <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+    <sonar.organization>eclipse-pass</sonar.organization>
+    <sonar.projectKey>eclipse-pass_pass-core</sonar.projectKey>
+    <sonar.coverage.jacoco.xmlReportPaths>${maven.multiModuleProjectDirectory}/jacoco-aggregate-report-pass-support/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
     <sonar-maven-plugin.version>5.0.0.4389</sonar-maven-plugin.version>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <sonar.organization>eclipse-pass</sonar.organization>
-    <sonar.projectKey>eclipse-pass_pass-core</sonar.projectKey>
+    <sonar.projectKey>eclipse-pass_pass-support</sonar.projectKey>
     <sonar.coverage.jacoco.xmlReportPaths>${maven.multiModuleProjectDirectory}/jacoco-aggregate-report-pass-support/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
   </properties>
 


### PR DESCRIPTION
This PR introduces the SonarQube scanner to run on the `ci.yml` and `snapshot.yml` workflows and push the JaCoCo code coverage reports to SonarQube Cloud.

Notable changes:
- Add SonarQube properties and plugin in the POM
- Add the SonarQube scanner to the verify and deploy maven phase in the `ci.yml` and `snapshot.yml`.
- Add a deep checkout of the git history on the GH checkout action.

To test run the `ci.yml` or `snapshot.yml`. These workflows will pass the SonarQube login secret to the `ci.yml`/`snapshot.yml` workflow in the `main` repo.