### PR TITLE
Fix DSpace deposit with an embargo

### DIFF
--- a/pass-deposit-services/deposit-core/src/main/resources/application.properties
+++ b/pass-deposit-services/deposit-core/src/main/resources/application.properties
@@ -33,8 +33,6 @@ dspace.website.url=${DSPACE_WEBSITE_URL}
 dspace.user=${DSPACE_USER}
 dspace.password=${DSPACE_PASSWORD}
 dspace.collection.handle=${DSPACE_COLLECTION_HANDLE}
-dspace.field.embargo.lift=${DSPACE_FIELD_EMBARGO_LIFT:local.embargo.lift}
-dspace.field.embargo.terms=${DSPACE_FIELD_EMBARGO_TERMS:local.embargo.terms}
 
 inveniordm.api.baseUrl=${INVENIORDM_API_BASE_URL:}
 inveniordm.api.token=${INVENIORDM_API_TOKEN}

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/provider/dspace/DSpaceMetadataMapperTest.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/provider/dspace/DSpaceMetadataMapperTest.java
@@ -15,6 +15,7 @@
  */
 package org.eclipse.pass.deposit.provider.dspace;
 
+import static org.eclipse.pass.deposit.provider.dspace.DSpaceMetadataMapper.SECTION_ITEM_ACCESS;
 import static org.eclipse.pass.deposit.provider.dspace.DSpaceMetadataMapper.SECTION_ONE;
 import static org.eclipse.pass.deposit.provider.dspace.DSpaceMetadataMapper.SECTION_TWO;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -41,7 +42,7 @@ import org.junit.jupiter.api.Test;
 public class DSpaceMetadataMapperTest {
     @Test
     public void testPatchWorkspaceItem() {
-        DSpaceMetadataMapper mapper = new DSpaceMetadataMapper("test.embargo.lift", "test.embargo.terms");
+        DSpaceMetadataMapper mapper = new DSpaceMetadataMapper();
 
         DepositSubmission ds = new DepositSubmission();
         DepositManifest manifest = new DepositManifest();
@@ -102,10 +103,12 @@ public class DSpaceMetadataMapperTest {
         checkValue(jsonContext, SECTION_ONE, "dc.contributor.author", "P1 Person", "P2 Person");
         checkValue(jsonContext, SECTION_ONE, "dc.date.issued",
                 journal.getPublicationDate().format(DateTimeFormatter.ISO_LOCAL_DATE));
-        checkValue(jsonContext, SECTION_ONE, "test.embargo.lift",
-                article.getEmbargoLiftDate().format(DateTimeFormatter.ISO_LOCAL_DATE));
-        checkValue(jsonContext, SECTION_ONE, "test.embargo.terms",
-                article.getEmbargoLiftDate().format(DateTimeFormatter.ISO_LOCAL_DATE));
+
+        List<String> embargoDates = jsonContext.read("$[?(@.path == '/sections/" + SECTION_ITEM_ACCESS + "/" +
+                "accessConditions" + "')].value[?(@.name == 'embargo')].startDate");
+
+        assertEquals(List.of(article.getEmbargoLiftDate().format(DateTimeFormatter.ISO_LOCAL_DATE)),
+                embargoDates);
     }
 
     private void checkValue(DocumentContext context, String section, String key, String... expected) {
@@ -118,7 +121,7 @@ public class DSpaceMetadataMapperTest {
 
     @Test
     public void testPatchWorkspaceItemMinimalMetadata() {
-        DSpaceMetadataMapper mapper = new DSpaceMetadataMapper("test.embargo.lift", "test.embargo.terms");
+        DSpaceMetadataMapper mapper = new DSpaceMetadataMapper();
 
         DepositSubmission ds = new DepositSubmission();
         DepositManifest manifest = new DepositManifest();

--- a/pass-deposit-services/deposit-core/src/test/resources/test-application.properties
+++ b/pass-deposit-services/deposit-core/src/test/resources/test-application.properties
@@ -27,5 +27,3 @@ dspace.password=test
 dspace.api.url=http://localhost:8000/api
 dspace.website.url=http://localhost:8000/website
 dspace.collection.handle=1234/1
-dspace.field.embargo.lift=local.embargo.lift
-dspace.field.embargo.terms=local.embargo.terms


### PR DESCRIPTION
DSpace deposit was trying to set metadata during the workflow to enable an embargo. This only works for SWORD deposit. Instead use itemAccessConditions.

Note that DSpace must have the itemAccessConditions step enabled in the traditional workflow.

This needs https://github.com/eclipse-pass/pass-docker/pull/397.

In order to test, do a submission to DSpace with an embargo set. Then verify the submission succeeds and that it can only be viewed by a logged in user.  As a logged in user, edit the item, go to the status stab and look at the authorizations to see the date of the embargo end is correct.
