### PR TITLE
Migrate maven publishing to Central Portal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,9 +110,12 @@
 
   <repositories>
     <repository>
-      <id>sonatype-nexus-snapshots</id>
-      <name>Sonatype Nexus Snapshots</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+      <name>Central Portal Snapshots</name>
+      <id>central-portal-snapshots</id>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>


### PR DESCRIPTION
Part of https://github.com/eclipse-pass/main/pull/1184

Build will fail until Part of https://github.com/eclipse-pass/main/pull/1184 is merged.