### PR TITLE
Change journal loader to update journal name if not equal

### DIFF
--- a/pass-journal-loader/pass-journal-loader-nih/src/main/java/org/eclipse/pass/loader/journal/nih/LoaderEngine.java
+++ b/pass-journal-loader/pass-journal-loader-nih/src/main/java/org/eclipse/pass/loader/journal/nih/LoaderEngine.java
@@ -17,6 +17,7 @@
 package org.eclipse.pass.loader.journal.nih;
 
 import java.io.IOException;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
@@ -121,14 +122,19 @@ public class LoaderEngine implements AutoCloseable {
                     update = true;
                 }
 
-                if (j.getIssns() != null && (toUpdate.getIssns() == null || !toUpdate.getIssns()
-                        .containsAll(j.getIssns()))) {
+                if (j.getIssns() != null && (toUpdate.getIssns() == null ||
+                    !toUpdate.getIssns().containsAll(j.getIssns()))) {
                     toUpdate.setIssns(j.getIssns());
                     update = true;
                 }
 
-                if (toUpdate.getNlmta() == null && j.getNlmta() != null) {
+                if (!Objects.equals(toUpdate.getNlmta(), j.getNlmta())) {
                     toUpdate.setNlmta(j.getNlmta());
+                    update = true;
+                }
+
+                if (!Objects.equals(toUpdate.getJournalName(), j.getJournalName())) {
+                    toUpdate.setJournalName(j.getJournalName());
                     update = true;
                 }
 

--- a/pass-journal-loader/pass-journal-loader-nih/src/test/java/org/eclipse/pass/loader/journal/nih/LoaderEngineTest.java
+++ b/pass-journal-loader/pass-journal-loader-nih/src/test/java/org/eclipse/pass/loader/journal/nih/LoaderEngineTest.java
@@ -18,7 +18,6 @@ package org.eclipse.pass.loader.journal.nih;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -44,7 +43,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  */
 
 @ExtendWith(MockitoExtension.class)
-public class LoaderEngineTest {
+class LoaderEngineTest {
     @Mock
     PassClient client;
 
@@ -63,7 +62,7 @@ public class LoaderEngineTest {
     }
 
     @Test
-    public void testLoadUpdateJournal() throws IOException {
+    void testLoadUpdateJournal() throws IOException {
 
         final Journal existing = new Journal();
         existing.setId("test:journalId");
@@ -78,7 +77,7 @@ public class LoaderEngineTest {
         toAdd.setNlmta("UpdatedTestNlmta");
         toAdd.setPmcParticipation(PmcParticipation.B);
 
-        when(client.getObject(eq(Journal.class), eq(existing.getId()))).thenReturn(existing);
+        when(client.getObject(Journal.class, existing.getId())).thenReturn(existing);
         when(finder.find("UpdatedTestNlmta", "UpdatedTestJournalName",
             List.of("000-123", "000-456", "000-789"))).thenReturn("test:journalId");
 
@@ -95,14 +94,14 @@ public class LoaderEngineTest {
     }
 
     @Test
-    public void addPmcParticipationUpdateTest() throws IOException {
+    void addPmcParticipationUpdateTest() throws IOException {
 
         final Journal existing = new Journal();
         existing.setId("test:addPmcParticipation");
         existing.setJournalName("My Journal");
         existing.getIssns().add("000-123");
 
-        when(client.getObject(eq(Journal.class), eq(existing.getId()))).thenReturn(existing);
+        when(client.getObject(Journal.class, existing.getId())).thenReturn(existing);
         when(finder.find(existing.getNlmta(), existing.getJournalName(), existing.getIssns())).thenReturn(
             existing.getId().toString());
 
@@ -124,14 +123,14 @@ public class LoaderEngineTest {
     }
 
     @Test
-    public void removePmcParticipationTest() throws IOException {
+    void removePmcParticipationTest() throws IOException {
         final Journal existing = new Journal();
         existing.setId("test:removePmcParticipation");
         existing.setJournalName("My Journal");
         existing.getIssns().add("000-123");
         existing.setPmcParticipation(PmcParticipation.A);
 
-        when(client.getObject(eq(Journal.class), eq(existing.getId()))).thenReturn(existing);
+        when(client.getObject(Journal.class, existing.getId())).thenReturn(existing);
         when(finder.find(existing.getNlmta(), existing.getJournalName(), existing.getIssns())).thenReturn(
             existing.getId().toString());
 
@@ -152,14 +151,14 @@ public class LoaderEngineTest {
     }
 
     @Test
-    public void noUpdateTest() throws IOException {
+    void noUpdateTest() throws IOException {
         final Journal existing = new Journal();
         existing.setId("test:noUpdateTest");
         existing.setJournalName("My Journal");
         existing.getIssns().add("000-123");
         existing.setPmcParticipation(PmcParticipation.A);
 
-        when(client.getObject(eq(Journal.class), eq(existing.getId()))).thenReturn(existing);
+        when(client.getObject(Journal.class, existing.getId())).thenReturn(existing);
         when(finder.find(existing.getNlmta(), existing.getJournalName(), existing.getIssns())).thenReturn(
             existing.getId().toString());
 
@@ -173,7 +172,7 @@ public class LoaderEngineTest {
     }
 
     @Test
-    public void createSkipDuplicatesTest() throws IOException {
+    void createSkipDuplicatesTest() throws IOException {
 
         final Journal newJournal = new Journal();
 
@@ -191,7 +190,7 @@ public class LoaderEngineTest {
 
         toTest.load(Stream.of(newJournal, newJournal), true);
 
-        verify(client, times(1)).createObject(eq(newJournal));
+        verify(client, times(1)).createObject(newJournal);
         verify(client, times(0)).updateObject(any());
     }
 }

--- a/pass-journal-loader/pass-journal-loader-nih/src/test/java/org/eclipse/pass/loader/journal/nih/LoaderEngineTest.java
+++ b/pass-journal-loader/pass-journal-loader-nih/src/test/java/org/eclipse/pass/loader/journal/nih/LoaderEngineTest.java
@@ -70,6 +70,7 @@ public class LoaderEngineTest {
         existing.setJournalName("TestJournalName");
         existing.setNlmta("TestNlmta");
         existing.setIssns(List.of("000-123", "000-456"));
+        existing.setPmcParticipation(PmcParticipation.A);
 
         Journal toAdd = new Journal();
         toAdd.setIssns(List.of("000-123", "000-456", "000-789"));


### PR DESCRIPTION
Now the journal loader will update the PASS `Journal.journalName` with the loaded journal info if they are not equal.

Note that I also changed the condition for updating `Journal.nltma` to not equal instead of only updating if PASS Journal name is null and loaded journal nltma is not null.