### PR TITLE
Add pom elements in child modules for publish

### DIFF
--- a/jacoco-aggregate-report-pass-support/pom.xml
+++ b/jacoco-aggregate-report-pass-support/pom.xml
@@ -11,6 +11,56 @@
 
     <artifactId>jacoco-aggregate-report-pass-support</artifactId>
 
+    <name>PASS support-jacoco-aggregate-report</name>
+    <description>PASS Support jacoco-aggregate-report</description>
+    <url>https://github.com/eclipse-pass/pass-support</url>
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <name>Jim Martino</name>
+            <email>jrm.jhu@jhu.edu</email>
+            <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+            <organizationUrl>https://library.jhu.edu/</organizationUrl>
+        </developer>
+        <developer>
+            <name>Mark Patton</name>
+            <email>mpatton@jhu.edu</email>
+            <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+            <organizationUrl>https://library.jhu.edu/</organizationUrl>
+        </developer>
+        <developer>
+            <name>John Abrahams</name>
+            <email>jabrah20@jhu.edu</email>
+            <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+            <organizationUrl>https://library.jhu.edu/</organizationUrl>
+        </developer>
+        <developer>
+            <name>Tim Sanders</name>
+            <email>tsande16@jhu.edu</email>
+            <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+            <organizationUrl>https://library.jhu.edu/</organizationUrl>
+        </developer>
+        <developer>
+            <name>Russ Poetker</name>
+            <email>rpoetke1@jhu.edu</email>
+            <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+            <organizationUrl>https://library.jhu.edu/</organizationUrl>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:https://github.com/eclipse-pass/pass-support.git</connection>
+        <developerConnection>scm:git:https://github.com/eclipse-pass/pass-support.git</developerConnection>
+        <url>https://github.com/eclipse-pass/pass-support</url>
+        <tag>HEAD</tag>
+    </scm>
+
     <properties>
     </properties>
 

--- a/pass-data-client/pom.xml
+++ b/pass-data-client/pom.xml
@@ -8,7 +8,56 @@
   </parent>
 
   <artifactId>pass-data-client</artifactId>
+
+  <name>PASS support-data-client</name>
   <description>PASS Data Client</description>
+  <url>https://github.com/eclipse-pass/pass-support</url>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Jim Martino</name>
+      <email>jrm.jhu@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Mark Patton</name>
+      <email>mpatton@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>John Abrahams</name>
+      <email>jabrah20@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Tim Sanders</name>
+      <email>tsande16@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Russ Poetker</name>
+      <email>rpoetke1@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:https://github.com/eclipse-pass/pass-support.git</connection>
+    <developerConnection>scm:git:https://github.com/eclipse-pass/pass-support.git</developerConnection>
+    <url>https://github.com/eclipse-pass/pass-support</url>
+    <tag>HEAD</tag>
+  </scm>
 
   <properties>
     <!-- Properties for dependency versions -->

--- a/pass-deposit-services/deposit-core/pom.xml
+++ b/pass-deposit-services/deposit-core/pom.xml
@@ -25,8 +25,55 @@
 
   <artifactId>deposit-core</artifactId>
 
-  <name>PASS Deposit Services Core</name>
-  <description>PASS Deposit Services</description>
+  <name>PASS support-deposit-services-core</name>
+  <description>PASS Deposit Services Core</description>
+  <url>https://github.com/eclipse-pass/pass-support</url>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Jim Martino</name>
+      <email>jrm.jhu@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Mark Patton</name>
+      <email>mpatton@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>John Abrahams</name>
+      <email>jabrah20@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Tim Sanders</name>
+      <email>tsande16@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Russ Poetker</name>
+      <email>rpoetke1@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:https://github.com/eclipse-pass/pass-support.git</connection>
+    <developerConnection>scm:git:https://github.com/eclipse-pass/pass-support.git</developerConnection>
+    <url>https://github.com/eclipse-pass/pass-support</url>
+    <tag>HEAD</tag>
+  </scm>
 
   <properties>
     <amazon.sqs.version>2.1.3</amazon.sqs.version>

--- a/pass-deposit-services/deposit-cri/pom.xml
+++ b/pass-deposit-services/deposit-cri/pom.xml
@@ -25,7 +25,55 @@
 
   <artifactId>deposit-cri</artifactId>
 
-  <name>Critical Repository Interaction</name>
+  <name>PASS support-deposit-services-cri</name>
+  <description>PASS Deposit Services CRI</description>
+  <url>https://github.com/eclipse-pass/pass-support</url>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Jim Martino</name>
+      <email>jrm.jhu@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Mark Patton</name>
+      <email>mpatton@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>John Abrahams</name>
+      <email>jabrah20@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Tim Sanders</name>
+      <email>tsande16@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Russ Poetker</name>
+      <email>rpoetke1@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:https://github.com/eclipse-pass/pass-support.git</connection>
+    <developerConnection>scm:git:https://github.com/eclipse-pass/pass-support.git</developerConnection>
+    <url>https://github.com/eclipse-pass/pass-support</url>
+    <tag>HEAD</tag>
+  </scm>
 
   <dependencies>
 

--- a/pass-deposit-services/deposit-model/pom.xml
+++ b/pass-deposit-services/deposit-model/pom.xml
@@ -25,7 +25,55 @@
 
   <artifactId>deposit-model</artifactId>
 
-  <name>Submission Model</name>
+  <name>PASS support-deposit-services-model</name>
+  <description>PASS Deposit Services Model</description>
+  <url>https://github.com/eclipse-pass/pass-support</url>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Jim Martino</name>
+      <email>jrm.jhu@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Mark Patton</name>
+      <email>mpatton@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>John Abrahams</name>
+      <email>jabrah20@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Tim Sanders</name>
+      <email>tsande16@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Russ Poetker</name>
+      <email>rpoetke1@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:https://github.com/eclipse-pass/pass-support.git</connection>
+    <developerConnection>scm:git:https://github.com/eclipse-pass/pass-support.git</developerConnection>
+    <url>https://github.com/eclipse-pass/pass-support</url>
+    <tag>HEAD</tag>
+  </scm>
 
   <dependencies>
     <dependency>

--- a/pass-deposit-services/deposit-util/pom.xml
+++ b/pass-deposit-services/deposit-util/pom.xml
@@ -25,7 +25,55 @@
 
   <artifactId>deposit-util</artifactId>
 
-  <name>Utility Classes</name>
+  <name>PASS support-deposit-services-util</name>
+  <description>PASS Deposit Services Util</description>
+  <url>https://github.com/eclipse-pass/pass-support</url>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Jim Martino</name>
+      <email>jrm.jhu@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Mark Patton</name>
+      <email>mpatton@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>John Abrahams</name>
+      <email>jabrah20@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Tim Sanders</name>
+      <email>tsande16@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Russ Poetker</name>
+      <email>rpoetke1@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:https://github.com/eclipse-pass/pass-support.git</connection>
+    <developerConnection>scm:git:https://github.com/eclipse-pass/pass-support.git</developerConnection>
+    <url>https://github.com/eclipse-pass/pass-support</url>
+    <tag>HEAD</tag>
+  </scm>
 
   <dependencies>
 

--- a/pass-deposit-services/pom.xml
+++ b/pass-deposit-services/pom.xml
@@ -27,6 +27,56 @@
   <artifactId>deposit-parent</artifactId>
   <packaging>pom</packaging>
 
+  <name>PASS support-deposit-services</name>
+  <description>PASS Deposit Services</description>
+  <url>https://github.com/eclipse-pass/pass-support</url>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Jim Martino</name>
+      <email>jrm.jhu@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Mark Patton</name>
+      <email>mpatton@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>John Abrahams</name>
+      <email>jabrah20@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Tim Sanders</name>
+      <email>tsande16@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Russ Poetker</name>
+      <email>rpoetke1@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:https://github.com/eclipse-pass/pass-support.git</connection>
+    <developerConnection>scm:git:https://github.com/eclipse-pass/pass-support.git</developerConnection>
+    <url>https://github.com/eclipse-pass/pass-support</url>
+    <tag>HEAD</tag>
+  </scm>
+
   <modules>
     <module>deposit-model</module>
     <module>deposit-util</module>

--- a/pass-grant-loader/pom.xml
+++ b/pass-grant-loader/pom.xml
@@ -25,7 +25,56 @@
   </parent>
 
   <artifactId>pass-grant-loader</artifactId>
+
+  <name>PASS support-grant-loader</name>
   <description>PASS Grant Data Loader</description>
+  <url>https://github.com/eclipse-pass/pass-support</url>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Jim Martino</name>
+      <email>jrm.jhu@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Mark Patton</name>
+      <email>mpatton@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>John Abrahams</name>
+      <email>jabrah20@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Tim Sanders</name>
+      <email>tsande16@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Russ Poetker</name>
+      <email>rpoetke1@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:https://github.com/eclipse-pass/pass-support.git</connection>
+    <developerConnection>scm:git:https://github.com/eclipse-pass/pass-support.git</developerConnection>
+    <url>https://github.com/eclipse-pass/pass-support</url>
+    <tag>HEAD</tag>
+  </scm>
 
   <properties>
     <spring-boot-maven-plugin.version>3.4.2</spring-boot-maven-plugin.version>

--- a/pass-journal-loader/pass-journal-loader-nih/pom.xml
+++ b/pass-journal-loader/pass-journal-loader-nih/pom.xml
@@ -9,7 +9,56 @@
   </parent>
 
   <artifactId>pass-journal-loader-nih</artifactId>
-  <description>PASS Journal Data Loader</description>
+
+  <name>PASS support-journal-loader-nih</name>
+  <description>PASS Journal Loader NIH</description>
+  <url>https://github.com/eclipse-pass/pass-support</url>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Jim Martino</name>
+      <email>jrm.jhu@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Mark Patton</name>
+      <email>mpatton@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>John Abrahams</name>
+      <email>jabrah20@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Tim Sanders</name>
+      <email>tsande16@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Russ Poetker</name>
+      <email>rpoetke1@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:https://github.com/eclipse-pass/pass-support.git</connection>
+    <developerConnection>scm:git:https://github.com/eclipse-pass/pass-support.git</developerConnection>
+    <url>https://github.com/eclipse-pass/pass-support</url>
+    <tag>HEAD</tag>
+  </scm>
 
   <properties>
     <!-- Properties for dependency versions -->

--- a/pass-journal-loader/pom.xml
+++ b/pass-journal-loader/pom.xml
@@ -11,6 +11,56 @@
   <artifactId>pass-journal-loader</artifactId>
   <packaging>pom</packaging>
 
+  <name>PASS support-journal-loader</name>
+  <description>PASS Journal Loader</description>
+  <url>https://github.com/eclipse-pass/pass-support</url>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Jim Martino</name>
+      <email>jrm.jhu@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Mark Patton</name>
+      <email>mpatton@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>John Abrahams</name>
+      <email>jabrah20@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Tim Sanders</name>
+      <email>tsande16@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Russ Poetker</name>
+      <email>rpoetke1@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:https://github.com/eclipse-pass/pass-support.git</connection>
+    <developerConnection>scm:git:https://github.com/eclipse-pass/pass-support.git</developerConnection>
+    <url>https://github.com/eclipse-pass/pass-support</url>
+    <tag>HEAD</tag>
+  </scm>
+
   <modules>
     <module>pass-journal-loader-nih</module>
   </modules>

--- a/pass-nihms-loader/nihms-data-harvest/pom.xml
+++ b/pass-nihms-loader/nihms-data-harvest/pom.xml
@@ -10,8 +10,55 @@
 
   <artifactId>nihms-data-harvest</artifactId>
 
-  <name>NIHMS Data Harvester</name>
+  <name>PASS support-nihms-data-harvest</name>
   <description>PASS NIHMS Harvester Data Loader</description>
+  <url>https://github.com/eclipse-pass/pass-support</url>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Jim Martino</name>
+      <email>jrm.jhu@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Mark Patton</name>
+      <email>mpatton@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>John Abrahams</name>
+      <email>jabrah20@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Tim Sanders</name>
+      <email>tsande16@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Russ Poetker</name>
+      <email>rpoetke1@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:https://github.com/eclipse-pass/pass-support.git</connection>
+    <developerConnection>scm:git:https://github.com/eclipse-pass/pass-support.git</developerConnection>
+    <url>https://github.com/eclipse-pass/pass-support</url>
+    <tag>HEAD</tag>
+  </scm>
 
   <dependencies>
 

--- a/pass-nihms-loader/nihms-data-transform-load/pom.xml
+++ b/pass-nihms-loader/nihms-data-transform-load/pom.xml
@@ -10,8 +10,55 @@
 
   <artifactId>nihms-data-transform-load</artifactId>
 
-  <name>NIHMS Data Transform/Load</name>
+  <name>PASS support-nihms-data-transform-load</name>
   <description>PASS NIHMS Transform/Load Data Loader</description>
+  <url>https://github.com/eclipse-pass/pass-support</url>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Jim Martino</name>
+      <email>jrm.jhu@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Mark Patton</name>
+      <email>mpatton@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>John Abrahams</name>
+      <email>jabrah20@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Tim Sanders</name>
+      <email>tsande16@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Russ Poetker</name>
+      <email>rpoetke1@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:https://github.com/eclipse-pass/pass-support.git</connection>
+    <developerConnection>scm:git:https://github.com/eclipse-pass/pass-support.git</developerConnection>
+    <url>https://github.com/eclipse-pass/pass-support</url>
+    <tag>HEAD</tag>
+  </scm>
 
   <properties>
     <wiremock-version>3.9.2</wiremock-version>

--- a/pass-nihms-loader/nihms-docker/pom.xml
+++ b/pass-nihms-loader/nihms-docker/pom.xml
@@ -10,7 +10,55 @@
 
   <artifactId>nihms-docker</artifactId>
 
-  <name>NIHMS Docker</name>
+  <name>PASS support-nihms-data-docker</name>
+  <description>PASS NIHMS Docker</description>
+  <url>https://github.com/eclipse-pass/pass-support</url>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Jim Martino</name>
+      <email>jrm.jhu@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Mark Patton</name>
+      <email>mpatton@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>John Abrahams</name>
+      <email>jabrah20@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Tim Sanders</name>
+      <email>tsande16@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Russ Poetker</name>
+      <email>rpoetke1@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:https://github.com/eclipse-pass/pass-support.git</connection>
+    <developerConnection>scm:git:https://github.com/eclipse-pass/pass-support.git</developerConnection>
+    <url>https://github.com/eclipse-pass/pass-support</url>
+    <tag>HEAD</tag>
+  </scm>
 
   <build>
     <plugins>

--- a/pass-nihms-loader/nihms-etl-model/pom.xml
+++ b/pass-nihms-loader/nihms-etl-model/pom.xml
@@ -10,6 +10,54 @@
 
   <artifactId>nihms-etl-model</artifactId>
 
-  <name>NIHMS ETL Model</name>
+  <name>PASS support-nihms-data-etl-model</name>
+  <description>PASS NIHMS ETL Model</description>
+  <url>https://github.com/eclipse-pass/pass-support</url>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Jim Martino</name>
+      <email>jrm.jhu@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Mark Patton</name>
+      <email>mpatton@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>John Abrahams</name>
+      <email>jabrah20@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Tim Sanders</name>
+      <email>tsande16@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Russ Poetker</name>
+      <email>rpoetke1@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:https://github.com/eclipse-pass/pass-support.git</connection>
+    <developerConnection>scm:git:https://github.com/eclipse-pass/pass-support.git</developerConnection>
+    <url>https://github.com/eclipse-pass/pass-support</url>
+    <tag>HEAD</tag>
+  </scm>
 
 </project>

--- a/pass-nihms-loader/nihms-token-refresh/pom.xml
+++ b/pass-nihms-loader/nihms-token-refresh/pom.xml
@@ -10,7 +10,55 @@
 
   <artifactId>nihms-token-refresh</artifactId>
 
-  <name>NIHMS Token Refresh</name>
+  <name>PASS support-nihms-token-refresh</name>
+  <description>PASS NIHMS Token Refresh</description>
+  <url>https://github.com/eclipse-pass/pass-support</url>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Jim Martino</name>
+      <email>jrm.jhu@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Mark Patton</name>
+      <email>mpatton@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>John Abrahams</name>
+      <email>jabrah20@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Tim Sanders</name>
+      <email>tsande16@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Russ Poetker</name>
+      <email>rpoetke1@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:https://github.com/eclipse-pass/pass-support.git</connection>
+    <developerConnection>scm:git:https://github.com/eclipse-pass/pass-support.git</developerConnection>
+    <url>https://github.com/eclipse-pass/pass-support</url>
+    <tag>HEAD</tag>
+  </scm>
 
   <build>
     <plugins>

--- a/pass-nihms-loader/pom.xml
+++ b/pass-nihms-loader/pom.xml
@@ -10,6 +10,56 @@
     <artifactId>pass-nihms-loader</artifactId>
     <packaging>pom</packaging>
 
+    <name>PASS support-nihms-loader</name>
+    <description>PASS NIHMS Loader</description>
+    <url>https://github.com/eclipse-pass/pass-support</url>
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <name>Jim Martino</name>
+            <email>jrm.jhu@jhu.edu</email>
+            <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+            <organizationUrl>https://library.jhu.edu/</organizationUrl>
+        </developer>
+        <developer>
+            <name>Mark Patton</name>
+            <email>mpatton@jhu.edu</email>
+            <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+            <organizationUrl>https://library.jhu.edu/</organizationUrl>
+        </developer>
+        <developer>
+            <name>John Abrahams</name>
+            <email>jabrah20@jhu.edu</email>
+            <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+            <organizationUrl>https://library.jhu.edu/</organizationUrl>
+        </developer>
+        <developer>
+            <name>Tim Sanders</name>
+            <email>tsande16@jhu.edu</email>
+            <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+            <organizationUrl>https://library.jhu.edu/</organizationUrl>
+        </developer>
+        <developer>
+            <name>Russ Poetker</name>
+            <email>rpoetke1@jhu.edu</email>
+            <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+            <organizationUrl>https://library.jhu.edu/</organizationUrl>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:https://github.com/eclipse-pass/pass-support.git</connection>
+        <developerConnection>scm:git:https://github.com/eclipse-pass/pass-support.git</developerConnection>
+        <url>https://github.com/eclipse-pass/pass-support</url>
+        <tag>HEAD</tag>
+    </scm>
+
     <modules>
         <module>nihms-data-harvest</module>
         <module>nihms-data-transform-load</module>

--- a/pass-notification-service/pom.xml
+++ b/pass-notification-service/pom.xml
@@ -24,7 +24,56 @@
     </parent>
 
     <artifactId>pass-notification-service</artifactId>
+
+    <name>PASS support-notification-service</name>
     <description>PASS Notification Services</description>
+    <url>https://github.com/eclipse-pass/pass-support</url>
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <name>Jim Martino</name>
+            <email>jrm.jhu@jhu.edu</email>
+            <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+            <organizationUrl>https://library.jhu.edu/</organizationUrl>
+        </developer>
+        <developer>
+            <name>Mark Patton</name>
+            <email>mpatton@jhu.edu</email>
+            <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+            <organizationUrl>https://library.jhu.edu/</organizationUrl>
+        </developer>
+        <developer>
+            <name>John Abrahams</name>
+            <email>jabrah20@jhu.edu</email>
+            <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+            <organizationUrl>https://library.jhu.edu/</organizationUrl>
+        </developer>
+        <developer>
+            <name>Tim Sanders</name>
+            <email>tsande16@jhu.edu</email>
+            <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+            <organizationUrl>https://library.jhu.edu/</organizationUrl>
+        </developer>
+        <developer>
+            <name>Russ Poetker</name>
+            <email>rpoetke1@jhu.edu</email>
+            <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+            <organizationUrl>https://library.jhu.edu/</organizationUrl>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:https://github.com/eclipse-pass/pass-support.git</connection>
+        <developerConnection>scm:git:https://github.com/eclipse-pass/pass-support.git</developerConnection>
+        <url>https://github.com/eclipse-pass/pass-support</url>
+        <tag>HEAD</tag>
+    </scm>
 
     <properties>
         <!-- Properties for dependency versions -->

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>
 


### PR DESCRIPTION
Apparently it is now required by sonatype central repo to duplicate a set of POM attributes in child POM files in order to publish.