### PR TITLE
Update deposit services for DSpace 9

### DIFF
--- a/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/support/dspace/DSpaceDepositService.java
+++ b/pass-deposit-services/deposit-core/src/main/java/org/eclipse/pass/deposit/support/dspace/DSpaceDepositService.java
@@ -265,7 +265,7 @@ public class DSpaceDepositService {
         String uuid = getUuidForHandle(dspaceCollectionHandle, authContext);
 
         return restClient.post()
-            .uri("/submission/workspaceitems?owningCollection={collectionUuid}", uuid)
+            .uri("/submission/workspaceitems?owningCollection={collectionUuid}&embed=item", uuid)
             .header(AUTHORIZATION, authContext.authToken())
             .header(X_XSRF_TOKEN, authContext.xsrfToken())
             .header(COOKIE, DSPACE_XSRF_COOKIE + authContext.xsrfToken())

--- a/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/AbstractSubmissionIT.java
+++ b/pass-deposit-services/deposit-core/src/test/java/org/eclipse/pass/deposit/service/AbstractSubmissionIT.java
@@ -65,7 +65,7 @@ public abstract class AbstractSubmissionIT extends AbstractDepositSubmissionIT {
         stubFor(get("/dspace/api/discover/search/objects?query=handle:collectionhandle")
             .willReturn(ok(searchJson)));
 
-        stubFor(post("/dspace/api/submission/workspaceitems?owningCollection=collectionuuid")
+        stubFor(post("/dspace/api/submission/workspaceitems?owningCollection=collectionuuid&embed=item")
             .willReturn(WireMock.ok("{\"_embedded\": {\"workspaceitems\": [{\"id\": 1,"
                 + "\"_embedded\": {\"item\": {\"uuid\": \"uuid\", \"metadata\": {}}}}]}}")));
 
@@ -87,7 +87,7 @@ public abstract class AbstractSubmissionIT extends AbstractDepositSubmissionIT {
         WireMock.verify(expectedCount, getRequestedFor(
             urlEqualTo("/dspace/api/discover/search/objects?query=handle:collectionhandle")));
         WireMock.verify(expectedCount, postRequestedFor(
-            urlEqualTo("/dspace/api/submission/workspaceitems?owningCollection=collectionuuid")));
+            urlEqualTo("/dspace/api/submission/workspaceitems?owningCollection=collectionuuid&embed=item")));
         WireMock.verify(expectedCount, patchRequestedFor(urlEqualTo("/dspace/api/submission/workspaceitems/1")));
         WireMock.verify(expectedCount, postRequestedFor(urlEqualTo("/dspace/api/workflow/workflowitems")));
     }


### PR DESCRIPTION
Change in DSpace REST API for `workspaceitems` requires that we specify we want the `item` returned in the POST response.

https://github.com/eclipse-pass/main/issues/1209