### PR TITLE
Make grant loader localKey domain prefix configurable

### DIFF
--- a/pass-grant-loader/src/main/java/org/eclipse/pass/support/grant/data/AbstractDefaultPassUpdater.java
+++ b/pass-grant-loader/src/main/java/org/eclipse/pass/support/grant/data/AbstractDefaultPassUpdater.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import java.util.Properties;
 
 import lombok.Getter;
+import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.pass.support.client.PassClient;
 import org.eclipse.pass.support.client.PassClientResult;
@@ -71,7 +72,9 @@ public abstract class AbstractDefaultPassUpdater implements PassUpdater {
     @Getter
     private final List<String> ingestRecordErrors = new ArrayList<>();
 
+    @Setter @Getter
     private String domain = "default.domain";
+
     private String latestUpdateString = "";
 
     private record GrantAccumulate(GrantIngestRecord grantIngestRecord, ZonedDateTime awardDate,
@@ -112,10 +115,6 @@ public abstract class AbstractDefaultPassUpdater implements PassUpdater {
             default -> {
             }
         }
-    }
-
-    public void setDomain(String domain) {
-        this.domain = domain;
     }
 
     /**
@@ -575,7 +574,7 @@ public abstract class AbstractDefaultPassUpdater implements PassUpdater {
      */
     private Funder updateFunderInPass(Funder systemFunder) throws IOException, GrantDataException {
         String baseLocalKey = systemFunder.getLocalKey();
-        String fullLocalKey = GrantDataUtils.buildLocalKey(domain, FUNDER_ID_TYPE, baseLocalKey);
+        String fullLocalKey = GrantDataUtils.buildLocalKey(getDomain(), FUNDER_ID_TYPE, baseLocalKey);
         systemFunder.setLocalKey(fullLocalKey);
 
         PassClientSelector<Funder> selector = new PassClientSelector<>(Funder.class);
@@ -654,7 +653,7 @@ public abstract class AbstractDefaultPassUpdater implements PassUpdater {
      */
     private Grant updateGrantInPass(Grant systemGrant) throws IOException, GrantDataException {
         String baseLocalKey = systemGrant.getLocalKey();
-        String fullLocalKey = GrantDataUtils.buildLocalKey(domain, GRANT_ID_TYPE, baseLocalKey);
+        String fullLocalKey = GrantDataUtils.buildLocalKey(getDomain(), GRANT_ID_TYPE, baseLocalKey);
         systemGrant.setLocalKey(fullLocalKey);
 
         LOG.debug("Looking for grant with localKey {}", fullLocalKey);

--- a/pass-grant-loader/src/main/java/org/eclipse/pass/support/grant/data/AbstractDefaultPassUpdater.java
+++ b/pass-grant-loader/src/main/java/org/eclipse/pass/support/grant/data/AbstractDefaultPassUpdater.java
@@ -73,7 +73,7 @@ public abstract class AbstractDefaultPassUpdater implements PassUpdater {
     private final List<String> ingestRecordErrors = new ArrayList<>();
 
     @Setter @Getter
-    private String domain = "default.domain";
+    private String domain;
 
     private String latestUpdateString = "";
 

--- a/pass-grant-loader/src/main/java/org/eclipse/pass/support/grant/data/jhu/JhuPassUpdater.java
+++ b/pass-grant-loader/src/main/java/org/eclipse/pass/support/grant/data/jhu/JhuPassUpdater.java
@@ -30,6 +30,7 @@ import org.eclipse.pass.support.grant.data.GrantIngestRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
@@ -44,12 +45,12 @@ import org.springframework.stereotype.Component;
 public class JhuPassUpdater extends AbstractDefaultPassUpdater {
 
     private static final Logger LOG = LoggerFactory.getLogger(JhuPassUpdater.class);
-    private static final String DOMAIN = "johnshopkins.edu";
+
     private static final String EMPLOYEE_ID_TYPE = "employeeid";
     private static final String JHED_ID_TYPE = "eppn";
 
-    static final String EMPLOYEE_LOCATOR_ID = DOMAIN + ":" + EMPLOYEE_ID_TYPE + ":";
-    static final String JHED_LOCATOR_ID = DOMAIN + ":" + JHED_ID_TYPE + ":";
+    private final String employeeIdLocatorPrefix;
+    private final String eppnLocatorPrefix;
 
     private final DifferenceLogger differenceLogger;
 
@@ -58,13 +59,17 @@ public class JhuPassUpdater extends AbstractDefaultPassUpdater {
      * @param differenceLogger the diff logger
      * @param passClient the pass client
      * @param policyProperties the policy properties
+     * @param localKeyDomainPrefix the domain prefix to use in localKeys
      */
     public JhuPassUpdater(DifferenceLogger differenceLogger,
                           PassClient passClient,
-                          @Qualifier("policyProperties") Properties policyProperties) {
+                          @Qualifier("policyProperties") Properties policyProperties,
+                          @Value("${local.key.domain.prefix}") String localKeyDomainPrefix) {
         super(passClient, policyProperties);
         this.differenceLogger = differenceLogger;
-        setDomain(DOMAIN);
+        setDomain(localKeyDomainPrefix);
+        employeeIdLocatorPrefix = getDomain() + ":" + EMPLOYEE_ID_TYPE + ":";
+        eppnLocatorPrefix =  getDomain() + ":" + JHED_ID_TYPE + ":";
     }
 
     @Override
@@ -104,11 +109,11 @@ public class JhuPassUpdater extends AbstractDefaultPassUpdater {
         String employeeId = grantIngestRecord.getPiEmployeeId();
         //Build the List of locatorIds - put the most reliable ids first
         if (StringUtils.isNotBlank(employeeId)) {
-            user.getLocatorIds().add(EMPLOYEE_LOCATOR_ID + employeeId);
+            user.getLocatorIds().add(employeeIdLocatorPrefix + employeeId);
         }
         if (StringUtils.isNotBlank(grantIngestRecord.getPiInstitutionalId())) {
             String jhedId = grantIngestRecord.getPiInstitutionalId().toLowerCase();
-            user.getLocatorIds().add(JHED_LOCATOR_ID + jhedId);
+            user.getLocatorIds().add(eppnLocatorPrefix + jhedId);
         }
         user.getRoles().add(UserRole.SUBMITTER);
         LOG.debug("Built user with employee ID {}", employeeId);
@@ -166,7 +171,7 @@ public class JhuPassUpdater extends AbstractDefaultPassUpdater {
         if (!Objects.equals(system.getLastName(), stored.getLastName())) {
             return true;
         }
-        String systemUserJhedLocatorId = findLocatorId(system, JhuPassUpdater.JHED_LOCATOR_ID);
+        String systemUserJhedLocatorId = findLocatorId(system, eppnLocatorPrefix);
         if (Objects.nonNull(systemUserJhedLocatorId) && !stored.getLocatorIds().contains(systemUserJhedLocatorId)) {
             return true;
         }
@@ -201,9 +206,9 @@ public class JhuPassUpdater extends AbstractDefaultPassUpdater {
         stored.setFirstName(system.getFirstName());
         stored.setMiddleName(system.getMiddleName());
         stored.setLastName(system.getLastName());
-        String systemUserJhedLocatorId = findLocatorId(system, JhuPassUpdater.JHED_LOCATOR_ID);
+        String systemUserJhedLocatorId = findLocatorId(system, eppnLocatorPrefix);
         if (Objects.nonNull(systemUserJhedLocatorId) && !stored.getLocatorIds().contains(systemUserJhedLocatorId)) {
-            stored.getLocatorIds().removeIf(locatorId -> locatorId.startsWith(JhuPassUpdater.JHED_LOCATOR_ID));
+            stored.getLocatorIds().removeIf(locatorId -> locatorId.startsWith(eppnLocatorPrefix));
             stored.getLocatorIds().add(systemUserJhedLocatorId);
         }
         //populate null fields if we can

--- a/pass-grant-loader/src/main/resources/application.properties
+++ b/pass-grant-loader/src/main/resources/application.properties
@@ -3,6 +3,8 @@ spring.cloud.aws.s3.enabled=false
 
 spring.profiles.active=jhu
 
+local.key.domain.prefix=${LOCAL_KEY_DOMAIN_PREFIX}
+
 pass.policy.prop.path=${POLICY_PROP_PATH:file:///data/grantloader/policy.properties}
 pass.grant.update.ts.path=${GRANT_UPDATE_TS_PATH:file:///data/grantloader/grant_update_timestamps}
 

--- a/pass-grant-loader/src/test/java/org/eclipse/pass/support/grant/AwsParamStoreConfigTest.java
+++ b/pass-grant-loader/src/test/java/org/eclipse/pass/support/grant/AwsParamStoreConfigTest.java
@@ -48,7 +48,8 @@ import org.testcontainers.utility.DockerImageName;
         "pass.client.password=${PASS_CORE_PASSWORD:test-pw}",
         "grant.db.url=${GRANT_DB_URL:test-grant-db-url}",
         "grant.db.username=${GRANT_DB_USER:test-grant-db-user}",
-        "grant.db.password=${GRANT_DB_PASSWORD:test-grant-db-pw}"
+        "grant.db.password=${GRANT_DB_PASSWORD:test-grant-db-pw}",
+        "local.key.domain.prefix=passtest.edu"
     })
 @ContextConfiguration(initializers = ConfigDataApplicationContextInitializer.class)
 @Testcontainers

--- a/pass-grant-loader/src/test/java/org/eclipse/pass/support/grant/PolicyPropertiesS3IT.java
+++ b/pass-grant-loader/src/test/java/org/eclipse/pass/support/grant/PolicyPropertiesS3IT.java
@@ -51,7 +51,8 @@ import org.testcontainers.utility.DockerImageName;
     "pass.client.password=test-pw",
     "grant.db.url=test-grant-db-url",
     "grant.db.username=test-grant-db-user",
-    "grant.db.password=test-grant-db-pw"
+    "grant.db.password=test-grant-db-pw",
+    "local.key.domain.prefix=passtest.edu"
 })
 @Testcontainers
 public class PolicyPropertiesS3IT {

--- a/pass-grant-loader/src/test/java/org/eclipse/pass/support/grant/data/jhu/JhuPassUpdaterIT.java
+++ b/pass-grant-loader/src/test/java/org/eclipse/pass/support/grant/data/jhu/JhuPassUpdaterIT.java
@@ -16,8 +16,6 @@
 package org.eclipse.pass.support.grant.data.jhu;
 
 import static org.eclipse.pass.support.grant.data.DateTimeUtil.createZonedDateTime;
-import static org.eclipse.pass.support.grant.data.jhu.JhuPassUpdater.EMPLOYEE_LOCATOR_ID;
-import static org.eclipse.pass.support.grant.data.jhu.JhuPassUpdater.JHED_LOCATOR_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -48,6 +46,9 @@ import org.springframework.test.annotation.DirtiesContext;
 
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 class JhuPassUpdaterIT extends AbstractIntegrationTest {
+
+    static final String EMPLOYEE_LOCATOR_ID = "johnshopkins.edu:employeeid:";
+    static final String JHED_LOCATOR_ID = "johnshopkins.edu:eppn:";
 
     private final String grantIdPrefix = "johnshopkins.edu:grant:";
 

--- a/pass-grant-loader/src/test/java/org/eclipse/pass/support/grant/data/jhu/JhuPassUpdaterOrderedIT.java
+++ b/pass-grant-loader/src/test/java/org/eclipse/pass/support/grant/data/jhu/JhuPassUpdaterOrderedIT.java
@@ -16,8 +16,8 @@
 package org.eclipse.pass.support.grant.data.jhu;
 
 import static org.eclipse.pass.support.grant.data.DateTimeUtil.createZonedDateTime;
-import static org.eclipse.pass.support.grant.data.jhu.JhuPassUpdater.EMPLOYEE_LOCATOR_ID;
-import static org.eclipse.pass.support.grant.data.jhu.JhuPassUpdater.JHED_LOCATOR_ID;
+import static org.eclipse.pass.support.grant.data.jhu.JhuPassUpdaterIT.EMPLOYEE_LOCATOR_ID;
+import static org.eclipse.pass.support.grant.data.jhu.JhuPassUpdaterIT.JHED_LOCATOR_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/pass-grant-loader/src/test/resources/test-application.properties
+++ b/pass-grant-loader/src/test/resources/test-application.properties
@@ -5,6 +5,8 @@ pass.client.url=http://localhost:8080/
 pass.client.user=backend
 pass.client.password=moo
 
+local.key.domain.prefix=johnshopkins.edu
+
 spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.url=jdbc:h2:mem:db
 spring.datasource.username=sa


### PR DESCRIPTION
This PR makes the domain prefix configurable which is used in the localKey in the Grant Loader model. This is needed if another institution wants to use the Grant Loader default update logic (`jhu` profile).